### PR TITLE
Port file dialogs to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "relm4-macros",
     "examples",
     "examples/libadwaita",
+    "examples/relm4-components"
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dev-dependencies]
 relm4 = { path = "../relm4", features = ["macros"] }
-#relm4-components = { path = "../relm4-components" }
 tokio = { version = "1.15", features = ["rt", "macros", "time", "rt-multi-thread"] }
 futures = "0.3.19"
 tracker = "0.1"

--- a/examples/relm4-components/Cargo.toml
+++ b/examples/relm4-components/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "relm4-components-examples"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+relm4 = { path = "../../relm4", features = ["macros"] }
+relm4-components = { path = "../../relm4-components" }
+
+[[example]]
+name = "file_dialogs"
+path = "file_dialogs.rs"

--- a/examples/relm4-components/file_dialogs.rs
+++ b/examples/relm4-components/file_dialogs.rs
@@ -95,7 +95,9 @@ impl SimpleComponent for App {
             .launch(OpenDialogSettings::default())
             .forward(sender.input_sender(), |response| match response {
                 OpenDialogResponse::Accept(path) => Input::OpenResponse(path),
-                _ => Input::ShowMessage(String::from("File opening was cancelled")),
+                OpenDialogResponse::Cancel => {
+                    Input::ShowMessage(String::from("File opening was cancelled"))
+                }
             });
 
         let save_dialog = SaveDialog::builder()

--- a/examples/relm4-components/file_dialogs.rs
+++ b/examples/relm4-components/file_dialogs.rs
@@ -1,14 +1,10 @@
-use gtk::prelude::{
-    ButtonExt, DialogExt, GtkWindowExt, OrientableExt, TextBufferExt, TextViewExt, WidgetExt,
-};
+use gtk::prelude::*;
 use relm4::{
     gtk, Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmApp,
     SimpleComponent, WidgetPlus,
 };
-use relm4_components::{
-    open_dialog::{OpenDialog, OpenDialogMsg, OpenDialogResponse, OpenDialogSettings},
-    save_dialog::{SaveDialog, SaveDialogMsg, SaveDialogResponse, SaveDialogSettings},
-};
+use relm4_components::{open_dialog::*, save_dialog::*};
+
 use std::path::PathBuf;
 
 struct App {
@@ -99,9 +95,7 @@ impl SimpleComponent for App {
             .launch(OpenDialogSettings::default())
             .forward(sender.input_sender(), |response| match response {
                 OpenDialogResponse::Accept(path) => Input::OpenResponse(path),
-                OpenDialogResponse::Cancel => {
-                    Input::ShowMessage(String::from("File opening was cancelled"))
-                }
+                _ => Input::ShowMessage(String::from("File opening was cancelled")),
             });
 
         let save_dialog = SaveDialog::builder()

--- a/examples/relm4-components/file_dialogs.rs
+++ b/examples/relm4-components/file_dialogs.rs
@@ -1,0 +1,181 @@
+use gtk::prelude::{
+    ButtonExt, DialogExt, GtkWindowExt, OrientableExt, TextBufferExt, TextViewExt, WidgetExt,
+};
+use relm4::{
+    gtk, Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmApp,
+    SimpleComponent, WidgetPlus,
+};
+use relm4_components::{
+    open_dialog::{OpenDialog, OpenDialogMsg, OpenDialogResponse, OpenDialogSettings},
+    save_dialog::{SaveDialog, SaveDialogMsg, SaveDialogResponse, SaveDialogSettings},
+};
+use std::path::PathBuf;
+
+struct App {
+    open_dialog: Controller<OpenDialog>,
+    save_dialog: Controller<SaveDialog>,
+    buffer: gtk::TextBuffer,
+    file_name: Option<String>,
+    message: Option<String>,
+}
+
+enum Input {
+    OpenRequest,
+    OpenResponse(PathBuf),
+    SaveRequest,
+    SaveResponse(PathBuf),
+    ShowMessage(String),
+    ResetMessage,
+}
+
+#[relm4::component]
+impl SimpleComponent for App {
+    type Widgets = AppWidgets;
+
+    type InitParams = ();
+
+    type Input = Input;
+    type Output = ();
+
+    view! {
+        root = gtk::ApplicationWindow {
+            set_title: watch!(Some(model.file_name.as_deref().unwrap_or_default())),
+            set_default_width: 600,
+            set_default_height: 400,
+
+            set_titlebar = Some(&gtk::HeaderBar) {
+                pack_start = &gtk::Button {
+                    set_label: "Open",
+                    connect_clicked(sender) => move |_| {
+                        sender.input(Input::OpenRequest);
+                    },
+                },
+                pack_end = &gtk::Button {
+                    set_label: "Save",
+                    set_sensitive: watch!(model.file_name.is_some()),
+                    connect_clicked(sender) => move |_| {
+                        sender.input(Input::SaveRequest);
+                    },
+                }
+            },
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_margin_all: 5,
+
+                gtk::ScrolledWindow {
+                    set_min_content_height: 380,
+
+                    set_child = Some(&gtk::TextView) {
+                        set_visible: watch!(model.file_name.is_some()),
+                        set_buffer: Some(&model.buffer),
+                    },
+                },
+            }
+        }
+    }
+
+    fn post_view() {
+        if let Some(text) = &model.message {
+            let dialog = gtk::MessageDialog::builder()
+                .text(text)
+                .transient_for(&widgets.root)
+                .modal(true)
+                .buttons(gtk::ButtonsType::Ok)
+                .build();
+            dialog.connect_response(|dialog, _| dialog.destroy());
+            dialog.show();
+            sender.input(Input::ResetMessage);
+        }
+    }
+
+    fn init(
+        _: Self::InitParams,
+        root: &Self::Root,
+        sender: &ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let open_dialog = OpenDialog::builder()
+            .transient_for(root)
+            .launch(OpenDialogSettings::default())
+            .forward(sender.input_sender(), |response| match response {
+                OpenDialogResponse::Accept(path) => Input::OpenResponse(path),
+                OpenDialogResponse::Cancel => {
+                    Input::ShowMessage(String::from("File opening was cancelled"))
+                }
+            });
+
+        let save_dialog = SaveDialog::builder()
+            .transient_for(root)
+            .launch(SaveDialogSettings::default())
+            .forward(sender.input_sender(), |response| match response {
+                SaveDialogResponse::Accept(path) => Input::SaveResponse(path),
+                SaveDialogResponse::Cancel => {
+                    Input::ShowMessage(String::from("File saving was cancelled"))
+                }
+            });
+
+        let model = App {
+            open_dialog,
+            save_dialog,
+            buffer: gtk::TextBuffer::new(None),
+            file_name: None,
+            message: None,
+        };
+
+        let widgets = view_output!();
+
+        sender.input(Input::ShowMessage(String::from(
+            "This is a simple text editor. Start by clicking \"Open\" on the header bar.",
+        )));
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, message: Self::Input, sender: &ComponentSender<Self>) {
+        match message {
+            Input::OpenRequest => self.open_dialog.emit(OpenDialogMsg::Open),
+            Input::OpenResponse(path) => match std::fs::read_to_string(&path) {
+                Ok(contents) => {
+                    self.buffer.set_text(&contents);
+                    self.file_name = Some(
+                        path.file_name()
+                            .expect("The path has no file name")
+                            .to_str()
+                            .expect("Cannot convert file name to string")
+                            .to_string(),
+                    );
+                }
+                Err(e) => sender.input(Input::ShowMessage(e.to_string())),
+            },
+            Input::SaveRequest => self
+                .save_dialog
+                .emit(SaveDialogMsg::SaveAs(self.file_name.clone().unwrap())),
+            Input::SaveResponse(path) => match std::fs::write(
+                &path,
+                self.buffer
+                    .text(&self.buffer.start_iter(), &self.buffer.end_iter(), false),
+            ) {
+                Ok(_) => {
+                    sender.input(Input::ShowMessage(format!(
+                        "File saved successfully at {:?}",
+                        path
+                    )));
+                    self.buffer.set_text("");
+                    self.file_name = None;
+                }
+                Err(e) => sender.input(Input::ShowMessage(e.to_string())),
+            },
+            Input::ShowMessage(message) => {
+                self.message = Some(message);
+            }
+            Input::ResetMessage => {
+                self.message = None;
+            }
+        }
+    }
+}
+
+fn main() {
+    let app: RelmApp<App> = RelmApp::new("relm4.example.file_dialogs");
+    app.run(());
+}

--- a/examples/relm4-components/file_dialogs.rs
+++ b/examples/relm4-components/file_dialogs.rs
@@ -91,7 +91,7 @@ impl SimpleComponent for App {
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let open_dialog = OpenDialog::builder()
-            .transient_for(root)
+            .update_root(|dialog| dialog.set_transient_for(Some(root)))
             .launch(OpenDialogSettings::default())
             .forward(sender.input_sender(), |response| match response {
                 OpenDialogResponse::Accept(path) => Input::OpenResponse(path),
@@ -99,7 +99,7 @@ impl SimpleComponent for App {
             });
 
         let save_dialog = SaveDialog::builder()
-            .transient_for(root)
+            .update_root(|dialog| dialog.set_transient_for(Some(root)))
             .launch(SaveDialogSettings::default())
             .forward(sender.input_sender(), |response| match response {
                 SaveDialogResponse::Accept(path) => Input::SaveResponse(path),

--- a/examples/relm4-components/file_dialogs.rs
+++ b/examples/relm4-components/file_dialogs.rs
@@ -91,7 +91,7 @@ impl SimpleComponent for App {
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let open_dialog = OpenDialog::builder()
-            .update_root(|dialog| dialog.set_transient_for(Some(root)))
+            .transient_for_native(root)
             .launch(OpenDialogSettings::default())
             .forward(sender.input_sender(), |response| match response {
                 OpenDialogResponse::Accept(path) => Input::OpenResponse(path),
@@ -99,7 +99,7 @@ impl SimpleComponent for App {
             });
 
         let save_dialog = SaveDialog::builder()
-            .update_root(|dialog| dialog.set_transient_for(Some(root)))
+            .transient_for_native(root)
             .launch(SaveDialogSettings::default())
             .forward(sender.input_sender(), |response| match response {
                 SaveDialogResponse::Accept(path) => Input::SaveResponse(path),

--- a/relm4-components/src/lib.rs
+++ b/relm4-components/src/lib.rs
@@ -9,9 +9,6 @@
 )]
 
 pub mod alert;
-pub mod open_button;
+// pub mod open_button;
 pub mod open_dialog;
 pub mod save_dialog;
-mod traits;
-
-pub use traits::*;

--- a/relm4-components/src/open_dialog.rs
+++ b/relm4-components/src/open_dialog.rs
@@ -1,9 +1,7 @@
 //! Reusable and easily configurable open dialog component.
 //!
 //! **[Example implementation](https://github.com/AaronErhardt/relm4/blob/next/examples/file_dialogs.rs)**
-use gtk::prelude::{
-    Cast, DialogExt, FileChooserExt, FileExt, GtkWindowExt, ListModelExt, WidgetExt,
-};
+use gtk::prelude::{Cast, FileChooserExt, FileExt, ListModelExt, NativeDialogExt};
 use relm4::{gtk, ComponentParts, ComponentSender, SimpleComponent};
 
 use std::path::PathBuf;
@@ -81,7 +79,7 @@ impl SimpleComponent for OpenDialog {
     type Output = OpenDialogResponse;
 
     view! {
-        gtk::FileChooserDialog {
+        gtk::FileChooserNative {
             set_action: if settings.folder_mode {
                 gtk::FileChooserAction::SelectFolder
             } else {
@@ -91,8 +89,8 @@ impl SimpleComponent for OpenDialog {
             set_select_multiple: settings.select_multiple,
             set_create_folders: settings.create_folders,
             set_modal: settings.is_modal,
-            add_button(gtk::ResponseType::Accept): &settings.accept_label,
-            add_button(gtk::ResponseType::Cancel): &settings.cancel_label,
+            set_accept_label: Some(&settings.accept_label),
+            set_cancel_label: Some(&settings.cancel_label),
             add_filter: iterate!(&settings.filters),
 
             set_visible: watch!(model.visible),

--- a/relm4-components/src/open_dialog.rs
+++ b/relm4-components/src/open_dialog.rs
@@ -61,10 +61,7 @@ impl Select for MultiSelection {
 #[derive(Clone, Debug)]
 /// Configuration for the open dialog component
 pub struct OpenDialogSettings {
-    /// Select folders instead of files.
-    ///
-    /// You should be aware the user might be able to select folders
-    /// even if this setting is set to `false`. This is a technical limitation of gtk.
+    /// Select folders instead of files
     pub folder_mode: bool,
     /// Label for cancel button
     pub cancel_label: String,

--- a/relm4-components/src/save_dialog.rs
+++ b/relm4-components/src/save_dialog.rs
@@ -1,7 +1,7 @@
 //! Reusable and easily configurable save dialog component.
 //!
 //! **[Example implementation](https://github.com/AaronErhardt/relm4/blob/next/examples/file_dialogs.rs)**
-use gtk::prelude::{DialogExt, FileChooserExt, FileExt, GtkWindowExt, WidgetExt};
+use gtk::prelude::{FileChooserExt, FileExt, NativeDialogExt};
 use relm4::{gtk, ComponentParts, ComponentSender, SimpleComponent};
 
 use std::path::PathBuf;
@@ -71,13 +71,13 @@ impl SimpleComponent for SaveDialog {
     type Output = SaveDialogResponse;
 
     view! {
-        gtk::FileChooserDialog {
+        gtk::FileChooserNative {
             set_action: gtk::FileChooserAction::Save,
 
             set_create_folders: settings.create_folders,
             set_modal: settings.is_modal,
-            add_button(gtk::ResponseType::Accept): &settings.accept_label,
-            add_button(gtk::ResponseType::Cancel): &settings.cancel_label,
+            set_accept_label: Some(&settings.accept_label),
+            set_cancel_label: Some(&settings.cancel_label),
             add_filter: iterate!(&settings.filters),
 
             set_current_name: watch!(&model.current_name),

--- a/relm4-components/src/save_dialog.rs
+++ b/relm4-components/src/save_dialog.rs
@@ -78,12 +78,15 @@ impl SimpleComponent for SaveDialog {
             set_modal: settings.is_modal,
             set_accept_label: Some(&settings.accept_label),
             set_cancel_label: Some(&settings.cancel_label),
-            add_filter: iterate!(&settings.filters),
+            #[iterate]
+            add_filter: &settings.filters,
 
-            set_current_name: watch!(&model.current_name),
-            set_visible: watch!(model.visible),
+            #[watch]
+            set_current_name: &model.current_name,
+            #[watch]
+            set_visible: model.visible,
 
-            connect_response(sender) => move |dialog, res_ty| {
+            connect_response[sender] => move |dialog, res_ty| {
                 match res_ty {
                     gtk::ResponseType::Accept => {
                         if let Some(file) = dialog.file() {
@@ -105,7 +108,7 @@ impl SimpleComponent for SaveDialog {
     fn init(
         settings: Self::InitParams,
         root: &Self::Root,
-        sender: &ComponentSender<Self>,
+        sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let model = SaveDialog {
             current_name: String::new(),
@@ -117,7 +120,7 @@ impl SimpleComponent for SaveDialog {
         ComponentParts { model, widgets }
     }
 
-    fn update(&mut self, message: Self::Input, _sender: &ComponentSender<Self>) {
+    fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
         match message {
             SaveDialogMsg::Save => {
                 self.current_name = String::new();

--- a/relm4-components/src/traits.rs
+++ b/relm4-components/src/traits.rs
@@ -1,9 +1,0 @@
-use relm4::gtk;
-
-/// Get the parent window that allows setting the parent window of a dialog with
-/// [`gtk::prelude::GtkWindowExt::set_transient_for`].
-pub trait ParentWindow {
-    /// Returns the parent window that a dialog should use or [`None`] if
-    /// no parent window should be set
-    fn parent_window(&self) -> Option<gtk::Window>;
-}

--- a/relm4/src/component/builder.rs
+++ b/relm4/src/component/builder.rs
@@ -7,7 +7,7 @@ use crate::shutdown;
 use crate::RelmContainerExt;
 use async_oneshot::oneshot;
 use futures::FutureExt;
-use gtk::prelude::GtkWindowExt;
+use gtk::prelude::{GtkWindowExt, NativeDialogExt};
 use std::any;
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -63,7 +63,25 @@ where
     C::Root: AsRef<gtk::Window>,
 {
     /// Set the component's root widget transient for a given window.
+    ///
+    /// If the root widget is a native dialog, such as [`gtk::FileChooserNative`],
+    /// you should use [`transient_for_native`][ComponentBuilder::transient_for_native] instead.
     pub fn transient_for(self, window: impl AsRef<gtk::Window>) -> Self {
+        self.root.as_ref().set_transient_for(Some(window.as_ref()));
+
+        self
+    }
+}
+
+impl<C: Component> ComponentBuilder<C>
+where
+    C::Root: AsRef<gtk::NativeDialog>,
+{
+    /// Set the component's root widget transient for a given window.
+    ///
+    /// Applicable to native dialogs only, such as [`gtk::FileChooserNative`].
+    /// If the root widget is a non-native dialog, you should use [`transient_for`][ComponentBuilder::transient_for] instead.
+    pub fn transient_for_native(self, window: impl AsRef<gtk::Window>) -> Self {
         self.root.as_ref().set_transient_for(Some(window.as_ref()));
 
         self


### PR DESCRIPTION
Related to #101.

# Changes

- Port `OpenDialog` and `SaveDialog` to the next version or relm4.
- ~~Dialogs use a non-native file chooser.~~
    -  See #143 
- Added a new example, featuring a simple text editor.
- Added Default settings for both dialogs.
- Button labels now use `String` instead of `&'static str`, which allows creating them dynamically at runtime.  
- Support for selecting folders.
- Support for multi selection.