### PR TITLE
feat!: Configurable component stopping

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -223,6 +223,9 @@ impl SimpleComponent for AppModel {
         root: &Self::Root,
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        // Stop the event loop when the root widget is destroyed.
+        sender.stop_with_widget(root);
+
         // Insert the macro codegen here
         let widgets = view_output!();
 

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -237,6 +237,9 @@ impl SimpleComponent for AppModel {
         root: &Self::Root,
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        // Stop the event loop when the root widget is destroyed.
+        sender.stop_with_widget(root);
+
         // Insert the macro codegen here
         let widgets = view_output!();
 

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -229,6 +229,9 @@ impl SimpleComponent for AppModel {
         root: &Self::Root,
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        // Stop the event loop when the root widget is destroyed.
+        sender.stop_with_widget(root);
+
         // Insert the macro codegen here
         let widgets = view_output!();
 

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -67,6 +67,9 @@ impl Component for App {
         root: &Self::Root,
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        // Stop the event loop when the root widget is destroyed.
+        sender.stop_with_widget(root);
+
         relm4::view! {
             container = gtk::Box {
                 set_halign: gtk::Align::Center,

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -21,7 +21,7 @@ fn main() {
         .application_id("org.relm4.SettingsListExample")
         .launch(|_app, window| {
             // Intiialize a component's root widget
-            let component = App::builder()
+            App::builder()
                 // Attach the root widget to the given window.
                 .attach_to(&window)
                 // Start the component service with an initial parameter
@@ -63,8 +63,6 @@ fn main() {
                         });
                     }
                 });
-
-            println!("parent is {:?}", component.widget().toplevel_window());
         });
 }
 
@@ -119,6 +117,9 @@ impl Component for App {
         root: &Self::Root,
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        // Stop the event loop when the root widget is destroyed.
+        sender.stop_with_widget(root);
+
         // Request the caller to reload its options.
         sender.output(Output::Reload);
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -60,6 +60,9 @@ impl SimpleComponent for AppModel {
         root: &Self::Root,
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        // Stop the event loop when the root widget is destroyed.
+        sender.stop_with_widget(root);
+
         let model = AppModel { counter };
 
         // Insert the macro codegen here

--- a/examples/simple_manual.rs
+++ b/examples/simple_manual.rs
@@ -43,6 +43,9 @@ impl SimpleComponent for AppModel {
         window: &Self::Root,
         sender: &ComponentSender<Self>,
     ) -> ComponentParts<Self> {
+        // Stop the event loop when the root widget is destroyed.
+        sender.stop_with_widget(window);
+
         let model = AppModel { counter };
 
         let vbox = gtk::Box::builder()

--- a/relm4/src/component/burner.rs
+++ b/relm4/src/component/burner.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 System76 <info@system76.com>
+// SPDX-License-Identifier: MIT or Apache-2.0
+
+#[derive(Debug)]
+pub(crate) struct CompBurner {
+    /// The `SourceId` of the event loop this is attached to.
+    pub(crate) runtime_id: std::cell::RefCell<Option<gtk::glib::SourceId>>,
+
+    /// The `SourceId` is sent here on drop to stop the event loop.
+    pub(crate) burn_notifier: async_oneshot::Sender<gtk::glib::SourceId>,
+}
+
+impl Drop for CompBurner {
+    fn drop(&mut self) {
+        if let Some(id) = self.runtime_id.borrow_mut().take() {
+            let _ = self.burn_notifier.send(id);
+        }
+    }
+}

--- a/relm4/src/component/controller.rs
+++ b/relm4/src/component/controller.rs
@@ -12,6 +12,14 @@ pub trait ComponentController<C: Component> {
         let _ = self.sender().send(event);
     }
 
+    /// Provides access to the component's killswitch.
+    fn killswitch(&self) -> &flume::Sender<()>;
+
+    /// Remotely stops the component.
+    fn stop(&self) {
+        let _ = self.killswitch().send(());
+    }
+
     /// Provides access to the component's sender.
     fn sender(&self) -> &Sender<C::Input>;
 
@@ -33,9 +41,16 @@ pub struct Controller<C: Component> {
 
     /// Used for emitting events to the component.
     pub(super) sender: Sender<C::Input>,
+
+    /// Allows the caller to stop the event loop remotely.
+    pub(super) killswitch: flume::Sender<()>,
 }
 
 impl<C: Component> ComponentController<C> for Controller<C> {
+    fn killswitch(&self) -> &flume::Sender<()> {
+        &self.killswitch
+    }
+
     fn sender(&self) -> &Sender<C::Input> {
         &self.sender
     }

--- a/relm4/src/component/mod.rs
+++ b/relm4/src/component/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 
 mod builder;
+mod burner;
 mod connector;
 mod controller;
 mod sender;
@@ -11,6 +12,8 @@ mod traits;
 
 #[allow(unreachable_pub)]
 pub use self::builder::ComponentBuilder;
+#[allow(unreachable_pub)]
+pub(crate) use self::burner::CompBurner;
 #[allow(unreachable_pub)]
 pub use self::connector::Connector;
 #[allow(unreachable_pub)]
@@ -37,22 +40,4 @@ pub struct ComponentParts<C: Component> {
     pub model: C,
     /// The widgets created for the view.
     pub widgets: C::Widgets,
-}
-
-/// Type which supports signaling when it has been destroyed.
-pub trait OnDestroy {
-    /// Runs the given function when destroyed.
-    fn on_destroy<F: FnOnce() + 'static>(&self, func: F);
-}
-
-impl<T: AsRef<gtk::Widget>> OnDestroy for T {
-    fn on_destroy<F: FnOnce() + 'static>(&self, func: F) {
-        use gtk::prelude::WidgetExt;
-        let func = std::cell::RefCell::new(Some(func));
-        self.as_ref().connect_destroy(move |_| {
-            if let Some(func) = func.take() {
-                func();
-            }
-        });
-    }
 }

--- a/relm4/src/component/traits.rs
+++ b/relm4/src/component/traits.rs
@@ -20,7 +20,7 @@ pub trait Component: Sized + 'static {
     type InitParams;
 
     /// The widget that was constructed by the component.
-    type Root: std::fmt::Debug + OnDestroy;
+    type Root: std::fmt::Debug;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;
@@ -91,7 +91,7 @@ pub trait SimpleComponent: Sized + 'static {
     type InitParams;
 
     /// The widget that was constructed by the component.
-    type Root: std::fmt::Debug + OnDestroy;
+    type Root: std::fmt::Debug;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;

--- a/relm4/src/factory/component_storage.rs
+++ b/relm4/src/factory/component_storage.rs
@@ -59,7 +59,7 @@ where
         match self {
             Self::Builder(builder) => Rc::try_unwrap(builder.data).unwrap().into_inner(),
             Self::Final(handle) => {
-                if let Some(id) = handle.runtime_id.borrow_mut().take() {
+                if let Some(id) = handle.burner.runtime_id.borrow_mut().take() {
                     id.remove();
                 }
                 Rc::try_unwrap(handle.data).unwrap().into_inner()

--- a/relm4/src/factory/handle.rs
+++ b/relm4/src/factory/handle.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 
 use super::FactoryView;
 use crate::Sender;
-use gtk::glib;
 
 #[derive(Debug)]
 pub(super) struct FactoryHandle<Widget, C: FactoryComponent<Widget, ParentMsg>, ParentMsg>
@@ -18,5 +17,7 @@ where
     pub(super) returned_widget: Widget::ReturnedWidget,
     pub(super) input: Sender<C::Input>,
     pub(super) notifier: Sender<()>,
-    pub(super) runtime_id: Rc<RefCell<Option<glib::SourceId>>>,
+
+    /// Kills the event loop of this component on drop.
+    pub(super) burner: crate::component::CompBurner,
 }

--- a/relm4/src/factory/traits.rs
+++ b/relm4/src/factory/traits.rs
@@ -1,7 +1,7 @@
 //! Traits for for managing and updating factories.
 
 use super::DynamicIndex;
-use crate::{CommandFuture, OnDestroy, Sender, ShutdownReceiver};
+use crate::{CommandFuture, Sender, ShutdownReceiver};
 
 use std::fmt::Debug;
 
@@ -99,7 +99,7 @@ pub trait FactoryComponent<ParentWidget: FactoryView, ParentMsg>: Sized + Debug 
     type InitParams;
 
     /// The widget that was constructed by the component.
-    type Root: std::fmt::Debug + OnDestroy + Clone;
+    type Root: std::fmt::Debug + Clone;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;


### PR DESCRIPTION
- Pro: Removes the `OnDestroy` trait and `Root: OnDestroy` restriction.
- Pro: Can kill the component externally from the controller
- Pro: Can kill the component through any means necessary
- Con: Requires that the kill signal be attached by the component author.
    - Comes with `sender.stop_with_widget()` and `sender.stop_with_native_dialog()` to ease that burden.