### PR TITLE
Improvements to extension traits

### DIFF
--- a/relm4/src/extensions/iter_children.rs
+++ b/relm4/src/extensions/iter_children.rs
@@ -1,0 +1,143 @@
+use super::ContainerChild;
+use crate::gtk;
+use gtk::prelude::{Cast, GridExt, IsA, WidgetExt};
+
+/// An iterator over container children.
+#[derive(Debug)]
+struct ChildrenIterator<T: RelmIterChildrenExt> {
+    start: Option<T::Child>,
+    end: Option<T::Child>,
+    done: bool,
+}
+
+impl<T: RelmIterChildrenExt> ChildrenIterator<T> {
+    /// Create a new iterator over children of `widget`.
+    fn new(widget: &T) -> Self {
+        let start = widget.first_child().map(|child| {
+            child
+                .downcast::<T::Child>()
+                .expect("The type of children does not match.")
+        });
+        let end = widget.last_child().map(|child| {
+            child
+                .downcast::<T::Child>()
+                .expect("The type of children does not match.")
+        });
+        let done = start.is_none();
+        ChildrenIterator { start, end, done }
+    }
+}
+
+impl<T: RelmIterChildrenExt> Iterator for ChildrenIterator<T> {
+    type Item = T::Child;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            None
+        } else {
+            // Handle cases where only one child exists and
+            // when all but one widget were consumed
+            if self.start == self.end {
+                self.done = true;
+                self.start.clone()
+            } else if let Some(start) = self.start.take() {
+                // "Increment" the start child
+                self.start = start.next_sibling().map(|child| {
+                    child
+                        .downcast::<T::Child>()
+                        .expect("The type of children does not match.")
+                });
+                // Just to make sure the iterator ends next time
+                // because all widgets were consumed
+                self.done = self.start.is_none();
+                Some(start)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+impl<T: RelmIterChildrenExt> DoubleEndedIterator for ChildrenIterator<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.done {
+            None
+        } else {
+            // Handle cases where only one child exists and
+            // when all but one widget were consumed
+            if self.start == self.end {
+                self.done = true;
+                self.end.clone()
+            } else if let Some(end) = self.end.take() {
+                // "Decrement" the end child
+                self.end = end.prev_sibling().map(|child| {
+                    child
+                        .downcast::<T::Child>()
+                        .expect("The type of children does not match.")
+                });
+                // Just to make sure the iterator ends next time
+                // because all widgets were consumed
+                self.done = self.end.is_none();
+                Some(end)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Widget types which allow iteration over their children.
+pub trait RelmIterChildrenExt: ContainerChild + IsA<gtk::Widget> {
+    /// Returns an iterator over container children.
+    fn iter_children(&self) -> Box<dyn DoubleEndedIterator<Item = Self::Child>> {
+        Box::new(ChildrenIterator::new(self))
+    }
+}
+
+impl RelmIterChildrenExt for gtk::Box {}
+impl RelmIterChildrenExt for gtk::ListBox {}
+impl RelmIterChildrenExt for gtk::FlowBox {}
+impl RelmIterChildrenExt for gtk::Grid {
+    // `gtk::Grid` places children in the order they were added to the grid.
+    //
+    // We have to provide a separate implementation that would sort children
+    // depending on their position.
+    fn iter_children(&self) -> Box<dyn DoubleEndedIterator<Item = Self::Child>> {
+        let mut vec = Vec::new();
+        let mut widget = self.first_child();
+        while let Some(child) = widget {
+            widget = child.next_sibling();
+            let (column, row, _, _) = self.query_child(&child);
+            vec.push((column, row, child));
+        }
+
+        vec.sort_by(|(col_a, row_a, _), (col_b, row_b, _)| {
+            if row_a != row_b {
+                row_a.cmp(row_b)
+            } else {
+                col_a.cmp(col_b)
+            }
+        });
+
+        Box::new(vec.into_iter().map(|(_, _, child)| child))
+    }
+}
+impl RelmIterChildrenExt for gtk::Stack {}
+
+#[cfg(feature = "libadwaita")]
+mod libadwaita {
+    use super::RelmIterChildrenExt;
+    use crate::gtk;
+    use gtk::prelude::{Cast, ListModelExt};
+
+    impl RelmIterChildrenExt for adw::TabView {
+        fn iter_children(&self) -> Box<dyn DoubleEndedIterator<Item = Self::Child>> {
+            let pages = self.pages();
+            Box::new(
+                (0..pages.n_items())
+                    .filter_map(move |index| pages.item(index))
+                    .filter_map(|item| item.downcast::<adw::TabPage>().ok())
+                    .map(|page| page.child()),
+            )
+        }
+    }
+}

--- a/relm4/src/extensions/remove.rs
+++ b/relm4/src/extensions/remove.rs
@@ -1,24 +1,20 @@
-use crate::RelmSetChildExt;
+use crate::{ContainerChild, RelmSetChildExt};
 use gtk::prelude::*;
 
 /// Widget types which can have widgets removed from them.
-pub trait RelmRemoveExt {
-    /// Type of container children.
-    type Child: IsA<gtk::Widget>;
+pub trait RelmRemoveExt: ContainerChild {
     /// Removes the widget from the container
     /// if it is a child of the container.
     fn container_remove(&self, widget: &impl AsRef<Self::Child>);
 }
 
 impl<T: RelmSetChildExt> RelmRemoveExt for T {
-    type Child = gtk::Widget;
     fn container_remove(&self, _widget: &impl AsRef<Self::Child>) {
         self.container_set_child(None::<&gtk::Widget>);
     }
 }
 
 impl RelmRemoveExt for gtk::ListBox {
-    type Child = gtk::ListBoxRow;
     fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
         let row = widget.as_ref();
         row.set_child(None::<&gtk::Widget>);
@@ -27,8 +23,9 @@ impl RelmRemoveExt for gtk::ListBox {
 }
 
 impl RelmRemoveExt for gtk::FlowBox {
-    type Child = gtk::FlowBoxChild;
     fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+        let child = widget.as_ref();
+        child.set_child(None::<&gtk::Widget>);
         self.remove(widget.as_ref());
     }
 }
@@ -37,7 +34,6 @@ macro_rules! remove_impl {
     ($($type:ty),+) => {
         $(
             impl RelmRemoveExt for $type {
-                type Child = gtk::Widget;
                 fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove(widget.as_ref());
                 }
@@ -50,7 +46,6 @@ macro_rules! remove_child_impl {
     ($($type:ty),+) => {
         $(
             impl RelmRemoveExt for $type {
-                type Child = gtk::Widget;
                 fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove_child(widget.as_ref());
                 }
@@ -73,6 +68,12 @@ remove_child_impl!(gtk::InfoBar);
 pub trait RelmRemoveAllExt {
     /// Remove all children from the container.
     fn remove_all(&self);
+}
+
+impl<T: RelmSetChildExt> RelmRemoveAllExt for T {
+    fn remove_all(&self) {
+        self.container_set_child(None::<&gtk::Widget>);
+    }
 }
 
 macro_rules! remove_all_impl {

--- a/relm4/src/extensions/set_child.rs
+++ b/relm4/src/extensions/set_child.rs
@@ -1,7 +1,8 @@
+use super::ContainerChild;
 use gtk::prelude::*;
 
 /// Widget types which allow to set or unset their child.
-pub trait RelmSetChildExt {
+pub trait RelmSetChildExt: ContainerChild {
     /// Set a child for the container or remove it using [`None`].
     fn container_set_child(&self, widget: Option<&impl AsRef<gtk::Widget>>);
 }

--- a/relm4/src/extensions/tests.rs
+++ b/relm4/src/extensions/tests.rs
@@ -30,8 +30,8 @@ fn box_extension_traits() {
     let gtk_box = gtk::Box::default();
     let widgets = TestWidgets::default();
 
-    gtk_box.append(&widgets.0);
     gtk_box.append(&widgets.1);
+    gtk_box.prepend(&widgets.0);
     gtk_box.append(&widgets.2);
 
     widgets.assert_parent();
@@ -53,8 +53,8 @@ fn list_box_extension_traits() {
     let list_box = gtk::ListBox::default();
     let widgets = TestWidgets::default();
 
-    list_box.append(&widgets.0);
     list_box.append(&widgets.1);
+    list_box.prepend(&widgets.0);
     list_box.append(&widgets.2);
 
     widgets.assert_parent();
@@ -96,8 +96,8 @@ fn flow_box_extension_traits() {
     let flow_box = gtk::FlowBox::default();
     let widgets = TestWidgets::default();
 
-    flow_box.insert(&widgets.0, -1);
     flow_box.insert(&widgets.1, -1);
+    flow_box.insert(&widgets.0, 0);
     flow_box.insert(&widgets.2, -1);
 
     widgets.assert_parent();
@@ -120,8 +120,8 @@ fn grid_extension_traits() {
     let widgets = TestWidgets::default();
 
     grid.attach(&widgets.0, 0, 0, 1, 1);
-    grid.attach(&widgets.1, 1, 0, 1, 1);
     grid.attach(&widgets.2, 2, 2, 2, 2);
+    grid.attach(&widgets.1, 1, 0, 1, 1);
 
     widgets.assert_parent();
 


### PR DESCRIPTION
- Add `ContainerChild` trait to define the type of container children. Previously this was inside `RelmRemovableExt`, which was fine but not all widgets that store children can actually remove them, for example `adw::TabView`. A few traits rely on this one to get the correct type of children.
- Add `RelmIterChildrenExt` impl for `adw::TabView`.
- Add `RelmRemoveAllExt` impl for T: `RelmSetChildExt`.
- Fix `RelmIterChildrenExt` impl for `gtk::Grid` (now relies on the widget position inside the grid to decide the right ordering).
- Move `RelmIterChildrenExt` to a separate module.
- Minor changes in tests