### PR TITLE
Implement `Debug` for all public types

### DIFF
--- a/relm4-macros/src/widget_macro/mod.rs
+++ b/relm4-macros/src/widget_macro/mod.rs
@@ -131,6 +131,7 @@ pub(crate) fn generate_tokens(
 
     quote! {
         #[allow(dead_code)]
+        #[derive(Debug)]
         #outer_attrs
         #visibility struct #ty {
             #struct_fields

--- a/relm4/src/channel.rs
+++ b/relm4/src/channel.rs
@@ -1,13 +1,14 @@
 // Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MIT or Apache-2.0
 
+use std::fmt;
+
 pub(crate) fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let (tx, rx) = flume::unbounded();
     (Sender(tx), Receiver(rx))
 }
 
 /// A Relm4 sender sends messages to a component or worker.
-#[derive(Debug)]
 pub struct Sender<T>(pub(crate) flume::Sender<T>);
 
 impl<T> From<flume::Sender<T>> for Sender<T> {
@@ -31,8 +32,13 @@ impl<T> Clone for Sender<T> {
     }
 }
 
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Sender").field(&self.0).finish()
+    }
+}
+
 /// A Relm4 receiver receives messages from a component or worker.
-#[derive(Debug)]
 pub struct Receiver<T>(pub(crate) flume::Receiver<T>);
 
 impl<T> Receiver<T> {
@@ -56,5 +62,11 @@ impl<T> Receiver<T> {
                 break;
             }
         }
+    }
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Receiver").field(&self.0).finish()
     }
 }

--- a/relm4/src/component/connector.rs
+++ b/relm4/src/component/connector.rs
@@ -4,12 +4,12 @@
 
 use super::{Component, ComponentController, Controller, StateWatcher};
 use crate::{Receiver, Sender};
+use std::fmt::{self, Debug};
 use std::rc::Rc;
 
 /// Contains the post-launch input sender and output receivers with the root widget.
 ///
 /// The receiver can be separated from the `Fairing` by choosing a method for handling it.
-#[allow(missing_debug_implementations)]
 pub struct Connector<C: Component> {
     /// The models and widgets maintained by the component.
     pub(super) state: Rc<StateWatcher<C>>,
@@ -101,5 +101,20 @@ impl<C: Component> ComponentController<C> for Connector<C> {
 
     fn widget(&self) -> &C::Root {
         &self.widget
+    }
+}
+
+impl<C: Component> Debug for Connector<C>
+where
+    C: Debug,
+    C::Widgets: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Connector")
+            .field("state", &self.state)
+            .field("widget", &self.widget)
+            .field("sender", &self.sender)
+            .field("receiver", &self.receiver)
+            .finish()
     }
 }

--- a/relm4/src/component/controller.rs
+++ b/relm4/src/component/controller.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 
 use crate::*;
+use std::fmt::{self, Debug};
 use std::rc::Rc;
 
 /// Shared behavior of component controller types.
@@ -23,7 +24,6 @@ pub trait ComponentController<C: Component> {
 }
 
 /// Controls the component from afar.
-#[allow(missing_debug_implementations)]
 pub struct Controller<C: Component> {
     /// The models and widgets maintained by the component.
     pub(super) state: Rc<StateWatcher<C>>,
@@ -46,5 +46,19 @@ impl<C: Component> ComponentController<C> for Controller<C> {
 
     fn widget(&self) -> &C::Root {
         &self.widget
+    }
+}
+
+impl<C: Component> Debug for Controller<C>
+where
+    C: Debug,
+    C::Widgets: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Controller")
+            .field("state", &self.state)
+            .field("widget", &self.widget)
+            .field("sender", &self.sender)
+            .finish()
     }
 }

--- a/relm4/src/component/state_watcher.rs
+++ b/relm4/src/component/state_watcher.rs
@@ -1,10 +1,11 @@
 use super::{Component, ComponentParts};
+
 use std::cell::{Ref, RefCell, RefMut};
+use std::fmt::{self, Debug};
 
 /// Keeps track of a components model and view.
 ///
 /// Borrowing the model and view will notify the component to check for updates.
-#[allow(missing_debug_implementations)]
 pub struct StateWatcher<C: Component> {
     /// The models and widgets maintained by the component.
     pub(super) state: RefCell<ComponentParts<C>>,
@@ -21,5 +22,18 @@ impl<C: Component> StateWatcher<C> {
     pub fn get_mut(&self) -> RefMut<'_, ComponentParts<C>> {
         let _ = self.notifier.send(());
         self.state.borrow_mut()
+    }
+}
+
+impl<C: Component> Debug for StateWatcher<C>
+where
+    C: Debug,
+    C::Widgets: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StateWatcher")
+            .field("state", &self.state)
+            .field("notifier", &self.notifier)
+            .finish()
     }
 }

--- a/relm4/src/factory/builder.rs
+++ b/relm4/src/factory/builder.rs
@@ -3,12 +3,12 @@ use super::{handle::FactoryHandle, DynamicIndex, FactoryComponent, FactoryView};
 use crate::{shutdown, OnDestroy, Receiver, Sender};
 
 use std::cell::RefCell;
+use std::fmt;
 use std::rc::Rc;
 
 use async_oneshot::oneshot;
 use futures::FutureExt;
 
-#[allow(missing_debug_implementations)]
 pub(super) struct FactoryBuilder<Widget, C, ParentMsg>
 where
     Widget: FactoryView,
@@ -190,5 +190,23 @@ where
             notifier: Sender(notifier),
             runtime_id,
         }
+    }
+}
+
+impl<Widget, C, ParentMsg> fmt::Debug for FactoryBuilder<Widget, C, ParentMsg>
+where
+    Widget: FactoryView,
+    C: FactoryComponent<Widget, ParentMsg>,
+    ParentMsg: 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FactoryBuilder")
+            .field("data", &self.data)
+            .field("root_widget", &self.root_widget)
+            .field("input_tx", &self.input_tx)
+            .field("input_rx", &self.input_rx)
+            .field("output_tx", &self.output_tx)
+            .field("output_rx", &self.output_rx)
+            .finish()
     }
 }

--- a/relm4/src/factory/component_storage.rs
+++ b/relm4/src/factory/component_storage.rs
@@ -2,9 +2,10 @@ use crate::factory::{DynamicIndex, FactoryBuilder, FactoryComponent, FactoryHand
 use crate::Sender;
 
 use std::cell::{Ref, RefMut};
+use std::fmt::Debug;
 use std::rc::Rc;
 
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub(super) enum ComponentStorage<Widget, C, ParentMsg>
 where
     Widget: FactoryView,

--- a/relm4/src/factory/handle.rs
+++ b/relm4/src/factory/handle.rs
@@ -1,13 +1,13 @@
 use super::FactoryComponent;
 
 use std::cell::RefCell;
+use std::fmt;
 use std::rc::Rc;
 
 use super::FactoryView;
 use crate::Sender;
 use gtk::glib;
 
-#[derive(Debug)]
 pub(super) struct FactoryHandle<Widget, C: FactoryComponent<Widget, ParentMsg>, ParentMsg>
 where
     Widget: FactoryView,
@@ -19,4 +19,20 @@ where
     pub(super) input: Sender<C::Input>,
     pub(super) notifier: Sender<()>,
     pub(super) runtime_id: Rc<RefCell<Option<glib::SourceId>>>,
+}
+
+impl<Widget, C, ParentMsg> fmt::Debug for FactoryHandle<Widget, C, ParentMsg>
+where
+    Widget: FactoryView,
+    C: FactoryComponent<Widget, ParentMsg>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FactoryHandle")
+            .field("data", &self.data)
+            .field("root_widget", &self.root_widget)
+            .field("input", &self.input)
+            .field("notifier", &self.notifier)
+            .field("runtime_id", &self.runtime_id)
+            .finish()
+    }
 }

--- a/relm4/src/factory/mod.rs
+++ b/relm4/src/factory/mod.rs
@@ -22,9 +22,9 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
 
-#[allow(missing_debug_implementations)]
 /// A container similar to [`VecDeque`] that can be used to store
 /// data associated with components that implement [`FactoryComponent`].
+#[derive(Debug)]
 pub struct FactoryVecDeque<Widget, C, ParentMsg>
 where
     Widget: FactoryView,
@@ -41,11 +41,14 @@ where
     uid_counter: u16,
 }
 
+#[allow(dead_code)] // As of 1.60 dead code analysis erroneously reports the Debug impl as dead
+#[derive(Debug)]
 struct RenderedState {
     uid: u16,
     widget_hash: u64,
 }
 
+#[derive(Debug)]
 struct ModelStateValue {
     index: DynamicIndex,
     uid: u16,


### PR DESCRIPTION
The overall goal of this PR is to make it possible to derive `Debug` for `Component` impls that have a `Controller` in them. This is accomplished by implementing `Debug` for all types in the library, including the complex types that were explicitly left unimplemented. This also involved relaxing the `Debug` bounds on `Sender` and `Receiver`, which weren't actually required.

Additionally, `Debug` is derived for the `Widgets` struct produced by the macro to make the new bounds easier to satisfy.