### PR TITLE
only use `doc(cfg)` if `dox` cfg is present

### DIFF
--- a/relm4/src/factory/widgets/mod.rs
+++ b/relm4/src/factory/widgets/mod.rs
@@ -1,11 +1,11 @@
 mod gtk;
 
 #[cfg(feature = "libadwaita")]
-#[cfg_attr(doc, doc(cfg(feature = "libadwaita")))]
+#[cfg_attr(dox, doc(cfg(feature = "libadwaita")))]
 mod libadwaita;
 
 #[cfg(feature = "libpanel")]
-#[cfg_attr(doc, doc(cfg(feature = "libpanel")))]
+#[cfg_attr(dox, doc(cfg(feature = "libpanel")))]
 mod libpanel;
 
 #[cfg(test)]

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -12,6 +12,7 @@
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/AaronErhardt/relm4/main/assets/Relm_logo.svg"
 )]
+#![cfg_attr(dox, feature(doc_cfg))]
 
 pub mod actions;
 mod app;


### PR DESCRIPTION
Fixes #171, which allows building the documentation with a stable compiler.

This will require changing the documentation build process to pass `--cfg dox` as a rustdoc argument.