### PR TITLE
derive Debug for Widgets struct

### DIFF
--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -122,6 +122,7 @@ pub(crate) fn generate_tokens(
     quote! {
         #[allow(dead_code)]
         #outer_attrs
+        #[derive(Debug)]
         #vis struct #widgets_type {
             #struct_fields
             #additional_fields

--- a/relm4-macros/tests/simple.rs
+++ b/relm4-macros/tests/simple.rs
@@ -72,3 +72,10 @@ impl SimpleComponent for AppModel {
         }
     }
 }
+
+fn assert_impls_debug<T: std::fmt::Debug>() {}
+
+#[test]
+fn assert_widgets_impl_debug() {
+    assert_impls_debug::<AppWidgets>();
+}


### PR DESCRIPTION
Looks like #169 was partially reverted by the merge of the new macro code. Re-added the derive and added a test.