### PR TITLE
Workaround for syn's public API

### DIFF
--- a/relm4-macros/src/widgets/parse_util.rs
+++ b/relm4-macros/src/widgets/parse_util.rs
@@ -1,11 +1,10 @@
 use std::sync::atomic::{AtomicU16, Ordering};
 
 use proc_macro2::Span as Span2;
-use syn::group::{parse_braces, parse_brackets, parse_parens};
 use syn::parse::ParseBuffer;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{Error, Ident, Path, PathArguments, PathSegment};
+use syn::{braced, bracketed, parenthesized, Error, Ident, Path, PathArguments, PathSegment};
 
 use super::{ParseError, PropertyName};
 use crate::widgets::{parse_util, AssignPropertyAttr, WidgetAttr, WidgetFunc};
@@ -109,25 +108,49 @@ pub(crate) fn idents_to_snake_case<'a, I: Iterator<Item = &'a Ident>>(
     Ident::new(&name, span)
 }
 
+/// Weird hack to work around syn's awkward macros
+/// that always return [`syn::Error`] and are worse
+/// in every aspect compared to regular Rust code.
+///
+/// Sadly, the regular Rust API won't be made public,
+/// see https://github.com/dtolnay/syn/issues/1190.
 pub(super) fn parens<'a>(input: &'a ParseBuffer) -> Result<ParseBuffer<'a>, ParseError> {
-    match parse_parens(input) {
-        Ok(parens) => Ok(parens.content),
-        Err(error) => Err(error.into()),
-    }
+    let content = (move || {
+        let content;
+        parenthesized!(content in input);
+        Ok(content)
+    })();
+    Ok(content?)
 }
 
+/// Weird hack to work around syn's awkward macros
+/// that always return [`syn::Error`] and are worse
+/// in every aspect compared to regular Rust code.
+///
+/// Sadly, the regular Rust API won't be made public,
+/// see https://github.com/dtolnay/syn/issues/1190.
 pub(super) fn braces<'a>(input: &'a ParseBuffer) -> Result<ParseBuffer<'a>, ParseError> {
-    match parse_braces(input) {
-        Ok(parens) => Ok(parens.content),
-        Err(error) => Err(error.into()),
-    }
+    let content = (move || {
+        let content;
+        braced!(content in input);
+        Ok(content)
+    })();
+    Ok(content?)
 }
 
+/// Weird hack to work around syn's awkward macros
+/// that always return [`syn::Error`] and are worse
+/// in every aspect compared to regular Rust code.
+///
+/// Sadly, the regular Rust API won't be made public,
+/// see https://github.com/dtolnay/syn/issues/1190.
 pub(super) fn brackets<'a>(input: &'a ParseBuffer) -> Result<ParseBuffer<'a>, ParseError> {
-    match parse_brackets(input) {
-        Ok(parens) => Ok(parens.content),
-        Err(error) => Err(error.into()),
-    }
+    let content = (move || {
+        let content;
+        bracketed!(content in input);
+        Ok(content)
+    })();
+    Ok(content?)
 }
 
 pub(super) fn strings_to_path(strings: &[&str]) -> Path {


### PR DESCRIPTION
A workaround for syn because some functions are not considered as public API (see: https://github.com/dtolnay/syn/issues/1190).