### PR TITLE
macros: Remove relm4_path

### DIFF
--- a/relm4-macros/Cargo.toml
+++ b/relm4-macros/Cargo.toml
@@ -15,6 +15,14 @@ documentation = "https://relm4.org/docs/stable/relm4/"
 [lib]
 proc-macro = true
 
+[features]
+default = ["relm4"]
+
+# Without the default "relm4" feature, all imports of gtk will
+# be `use gtk;` instread of `use relm4::gtk;` thus making it 
+# easier to use this crate without Relm4.
+relm4 = []
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/relm4-macros/src/attrs.rs
+++ b/relm4-macros/src/attrs.rs
@@ -1,9 +1,7 @@
 use proc_macro2::Span;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{Error, Ident, Path, Result, Token, Visibility};
-
-use crate::util::default_relm4_path;
+use syn::{Error, Ident, Result, Token, Visibility};
 
 enum AttributeType {
     None,
@@ -14,19 +12,11 @@ enum AttributeType {
 pub struct Attrs {
     /// Keeps information about visibility of the widget
     pub visibility: Option<Visibility>,
-
-    /// Path to relm4
-    ///
-    /// Defaults to `::relm4`
-    pub relm4_path: Path,
 }
 
 impl Attrs {
     fn new() -> Self {
-        Attrs {
-            visibility: None,
-            relm4_path: default_relm4_path(),
-        }
+        Attrs { visibility: None }
     }
 }
 
@@ -47,10 +37,8 @@ impl Parse for Attrs {
         // #[widget(relm4 = ::my::path, relm4 = ::my::other::path ) ]
         // ```
         // is illegal.
-        let mut relm4_path_set = false;
-
         let mixed_use_error_message =
-            "You can't mix named and unnamed arguments while using `relm4_macros::widget`. \n\
+            "You can't mix named and unnamed arguments. \n\
             \n\
             You can use one of\n\
             \n\
@@ -93,22 +81,8 @@ impl Parse for Attrs {
 
                     attrs.visibility = Some(pub_vis);
                     attrs_type = AttributeType::Named;
-                } else if ident == "relm4" {
-                    let path: Path = input.parse()?;
-
-                    if let AttributeType::Unnamed { span } = attrs_type {
-                        return Err(Error::new(span, mixed_use_error_message));
-                    }
-                    if relm4_path_set {
-                        return Err(Error::new(path.span(), "You can't assign relm4 path twice"));
-                    }
-
-                    attrs.relm4_path = path;
-                    relm4_path_set = true;
-                    attrs_type = AttributeType::Named;
                 } else {
-                    return Err(input
-                        .error("Unknown argument. Valid arguments are: `visibility` or `relm4`"));
+                    return Err(input.error("Unknown argument. Expected `visibility`"));
                 }
             }
 

--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
-use syn::{Error, Path, PathArguments, Visibility};
+use syn::{Error, PathArguments, Visibility};
 
 use crate::macros::Macros;
 use crate::ItemImpl;
@@ -13,11 +13,7 @@ mod types;
 
 use inject_view_code::inject_view_code;
 
-pub(crate) fn generate_tokens(
-    vis: Option<Visibility>,
-    relm4_path: Path,
-    data: ItemImpl,
-) -> TokenStream2 {
+pub(crate) fn generate_tokens(vis: Option<Visibility>, data: ItemImpl) -> TokenStream2 {
     let last_segment = data
         .trait_
         .segments
@@ -53,7 +49,7 @@ pub(crate) fn generate_tokens(
     };
 
     // Generate menu tokens
-    let menus_stream = menus.map(|m| m.menus_stream(&relm4_path));
+    let menus_stream = menus.map(|m| m.menus_stream());
 
     let funcs::Funcs {
         init,
@@ -78,7 +74,7 @@ pub(crate) fn generate_tokens(
         return_fields,
         destructure_fields,
         update_view,
-    } = view_widgets.generate_streams(&vis, &relm4_path, &model_name, Some(&root_name), false);
+    } = view_widgets.generate_streams(&vis, &model_name, Some(&root_name), false);
 
     let root_widget_type = view_widgets.root_type();
 

--- a/relm4-macros/src/component/token_streams.rs
+++ b/relm4-macros/src/component/token_streams.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote_spanned;
-use syn::{Error, Ident, Path, Visibility};
+use syn::{Error, Ident, Visibility};
 
 use crate::widgets::{TopLevelWidget, ViewWidgets, Widget};
 
@@ -32,7 +32,6 @@ impl ViewWidgets {
     pub fn generate_streams(
         &self,
         vis: &Option<Visibility>,
-        relm4_path: &Path,
         model_name: &Ident,
         root_name: Option<&Ident>,
         standalone_view: bool,
@@ -43,7 +42,6 @@ impl ViewWidgets {
             top_level_widget.generate_streams(
                 &mut streams,
                 vis,
-                relm4_path,
                 model_name,
                 root_name,
                 standalone_view,
@@ -73,7 +71,6 @@ impl TopLevelWidget {
         &self,
         streams: &mut TokenStreams,
         vis: &Option<Visibility>,
-        relm4_path: &Path,
         model_name: &Ident,
         root_name: Option<&Ident>,
         standalone_view: bool,
@@ -81,7 +78,6 @@ impl TopLevelWidget {
         self.inner.init_token_generation(
             streams,
             vis,
-            relm4_path,
             model_name,
             root_name,
             !standalone_view && self.root_attr.is_some(),
@@ -94,7 +90,6 @@ impl Widget {
         &self,
         streams: &mut TokenStreams,
         vis: &Option<Visibility>,
-        relm4_path: &Path,
         model_name: &Ident,
         root_name: Option<&Ident>,
         generate_init_root_stream: bool,
@@ -105,20 +100,20 @@ impl Widget {
         // Initialize the root
         if generate_init_root_stream {
             // For the `component` macro
-            self.init_root_init_streams(&mut streams.init_root, &mut streams.init, relm4_path);
+            self.init_root_init_streams(&mut streams.init_root, &mut streams.init);
         } else {
             // For the `view!` macro
-            self.init_stream(&mut streams.init, relm4_path);
+            self.init_stream(&mut streams.init);
         }
 
         self.error_stream(&mut streams.error);
-        self.start_assign_stream(&mut streams.assign, relm4_path);
-        self.init_conditional_init_stream(&mut streams.assign, model_name, relm4_path);
-        self.struct_fields_stream(&mut streams.struct_fields, vis, relm4_path);
+        self.start_assign_stream(&mut streams.assign);
+        self.init_conditional_init_stream(&mut streams.assign, model_name);
+        self.struct_fields_stream(&mut streams.struct_fields, vis);
         self.return_stream(&mut streams.return_fields);
         self.destructure_stream(&mut streams.destructure_fields);
-        self.init_update_view_stream(&mut streams.update_view, model_name, relm4_path);
-        self.connect_signals_stream(&mut streams.connect, relm4_path);
+        self.init_update_view_stream(&mut streams.update_view, model_name);
+        self.connect_signals_stream(&mut streams.connect);
 
         // Rename the `root` to the actual widget name
         if generate_init_root_stream {

--- a/relm4-macros/src/factory/inject_view_code.rs
+++ b/relm4-macros/src/factory/inject_view_code.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
-use syn::{ImplItemMethod, Path};
+use syn::ImplItemMethod;
 
 use crate::component;
 
@@ -9,7 +9,6 @@ pub(super) fn inject_view_code(
     view_code: TokenStream2,
     widgets_return_code: TokenStream2,
     container_widget: TokenStream2,
-    relm4_path: &Path,
 ) -> TokenStream2 {
     if let Some(func) = func {
         match component::inject_view_code::inject_view_code(func, view_code, widgets_return_code) {
@@ -20,9 +19,9 @@ pub(super) fn inject_view_code(
         quote! {
             fn init_widgets(
                 &mut self,
-                index: &#relm4_path::factory::DynamicIndex,
+                index: &relm4::factory::DynamicIndex,
                 root: &Self::Root,
-                returned_widget: &<#container_widget as #relm4_path::factory::FactoryView>::ReturnedWidget,
+                returned_widget: &<#container_widget as relm4::factory::FactoryView>::ReturnedWidget,
                 input: &Sender<Self::Input>,
                 output: &Sender<Self::Output>,
             ) -> Self::Widgets {

--- a/relm4-macros/src/factory/mod.rs
+++ b/relm4-macros/src/factory/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span as Span2, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
-use syn::{Ident, Path, PathArguments, Visibility};
+use syn::{Ident, PathArguments, Visibility};
 
 use crate::component::token_streams;
 use crate::macros::Macros;
@@ -12,11 +12,7 @@ mod types;
 
 use inject_view_code::inject_view_code;
 
-pub(crate) fn generate_tokens(
-    vis: Option<Visibility>,
-    relm4_path: Path,
-    data: ItemImpl,
-) -> TokenStream2 {
+pub(crate) fn generate_tokens(vis: Option<Visibility>, data: ItemImpl) -> TokenStream2 {
     let last_segment = data
         .trait_
         .segments
@@ -54,7 +50,7 @@ pub(crate) fn generate_tokens(
     };
 
     // Generate menu tokens
-    let menus_stream = menus.map(|m| m.menus_stream(&relm4_path));
+    let menus_stream = menus.map(|m| m.menus_stream());
 
     let funcs::Funcs {
         init_widgets,
@@ -80,7 +76,6 @@ pub(crate) fn generate_tokens(
         update_view,
     } = view_widgets.generate_streams(
         &vis,
-        &relm4_path,
         &Ident::new("self", Span2::call_site()),
         Some(&root_name),
         false,
@@ -126,7 +121,6 @@ pub(crate) fn generate_tokens(
         view_code,
         widgets_return_code,
         container_widget,
-        &relm4_path,
     );
 
     quote! {

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -22,6 +22,10 @@ use attrs::Attrs;
 use item_impl::ItemImpl;
 use menu::Menus;
 
+fn gtk_import() -> std::rc::Rc<syn::Path> {
+    util::GTK_IMPORT.with(|p| p.clone())
+}
+
 /// Macro that implements [`relm4::Component`](https://relm4.org/docs/next/relm4/trait.Component.html) and generates the corresponding struct.
 ///
 /// # Attributes
@@ -154,24 +158,18 @@ use menu::Menus;
 /// ```
 #[proc_macro_attribute]
 pub fn component(attributes: TokenStream, input: TokenStream) -> TokenStream {
-    let Attrs {
-        visibility,
-        relm4_path,
-    } = parse_macro_input!(attributes as Attrs);
+    let Attrs { visibility } = parse_macro_input!(attributes as Attrs);
     let data = parse_macro_input!(input as ItemImpl);
 
-    component::generate_tokens(visibility, relm4_path, data).into()
+    component::generate_tokens(visibility, data).into()
 }
 
 #[proc_macro_attribute]
 pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
-    let Attrs {
-        visibility,
-        relm4_path,
-    } = parse_macro_input!(attributes as Attrs);
+    let Attrs { visibility } = parse_macro_input!(attributes as Attrs);
     let data = parse_macro_input!(input as ItemImpl);
 
-    factory::generate_tokens(visibility, relm4_path, data).into()
+    factory::generate_tokens(visibility, data).into()
 }
 
 // Macro that implements [`relm4::factory::FactoryPrototype`](https://aaronerhardt.github.io/docs/relm4/relm4/factory/trait.FactoryPrototype.html)
@@ -182,11 +180,10 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
 // pub fn factory_prototype(attributes: TokenStream, input: TokenStream) -> TokenStream {
 // let Attrs {
 //     visibility,
-//     relm4_path,
 // } = parse_macro_input!(attributes as Attrs);
 // let data = parse_macro_input!(input as ItemImpl);
 
-// factory_prototype_macro::generate_tokens(visibility, relm4_path, data).into()
+// factory::generate_tokens(visibility, data).into()
 //    quote! {}.into()
 // }
 
@@ -286,9 +283,7 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn menu(input: TokenStream) -> TokenStream {
     let menus = parse_macro_input!(input as Menus);
-    let default_relm4_path = util::default_relm4_path();
-
-    menus.menus_stream(&default_relm4_path).into()
+    menus.menus_stream().into()
 }
 
 /// The [`view!`] macro allows you to construct your UI easily and cleanly.

--- a/relm4-macros/src/menu/gen.rs
+++ b/relm4-macros/src/menu/gen.rs
@@ -1,15 +1,15 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
-use syn::{Ident, Path};
+use syn::Ident;
 
 use super::{Menu, MenuEntry, MenuItem, MenuSection, Menus};
 
 impl Menus {
-    pub fn menus_stream(&self, relm4_path: &Path) -> TokenStream2 {
+    pub fn menus_stream(&self) -> TokenStream2 {
         let mut menu_stream = TokenStream2::new();
 
         for item in &self.items {
-            menu_stream.extend(item.menu_stream(relm4_path));
+            menu_stream.extend(item.menu_stream());
         }
 
         menu_stream
@@ -17,15 +17,16 @@ impl Menus {
 }
 
 impl Menu {
-    fn menu_stream(&self, relm4_path: &Path) -> TokenStream2 {
+    fn menu_stream(&self) -> TokenStream2 {
         let name = &self.name;
+        let gtk_import = crate::gtk_import();
         let mut menu_stream = quote_spanned! {
             name.span() =>
-                let #name = #relm4_path::gtk::gio::Menu::new();
+                let #name = #gtk_import ::gio::Menu::new();
         };
 
         for item in &self.items {
-            menu_stream.extend(item.item_stream(name, relm4_path));
+            menu_stream.extend(item.item_stream(name));
         }
 
         menu_stream
@@ -33,16 +34,12 @@ impl Menu {
 }
 
 impl MenuItem {
-    fn item_stream(&self, parent_ident: &Ident, relm4_path: &Path) -> TokenStream2 {
+    fn item_stream(&self, parent_ident: &Ident) -> TokenStream2 {
         let mut item_stream = TokenStream2::new();
 
         match self {
-            MenuItem::Entry(entry) => {
-                item_stream.extend(entry.entry_stream(parent_ident, relm4_path))
-            }
-            MenuItem::Section(section) => {
-                item_stream.extend(section.section_stream(parent_ident, relm4_path))
-            }
+            MenuItem::Entry(entry) => item_stream.extend(entry.entry_stream(parent_ident)),
+            MenuItem::Section(section) => item_stream.extend(section.section_stream(parent_ident)),
         }
 
         item_stream
@@ -50,19 +47,19 @@ impl MenuItem {
 }
 
 impl MenuEntry {
-    fn entry_stream(&self, parent_ident: &Ident, relm4_path: &Path) -> TokenStream2 {
+    fn entry_stream(&self, parent_ident: &Ident) -> TokenStream2 {
         let string = &self.string;
         let ty = &self.action_ty;
         if let Some(value) = &self.value {
             quote_spanned! {
                 string.span() =>
-                    let new_entry = #relm4_path::actions::RelmAction::<#ty>::to_menu_item_with_target_value(#string, &#value);
+                    let new_entry = relm4::actions::RelmAction::<#ty>::to_menu_item_with_target_value(#string, &#value);
                     #parent_ident.append_item(&new_entry);
             }
         } else {
             quote_spanned! {
                 string.span() =>
-                    let new_entry = #relm4_path::actions::RelmAction::<#ty>::to_menu_item(#string);
+                    let new_entry = relm4::actions::RelmAction::<#ty>::to_menu_item(#string);
                     #parent_ident.append_item(&new_entry);
             }
         }
@@ -70,15 +67,16 @@ impl MenuEntry {
 }
 
 impl MenuSection {
-    fn section_stream(&self, parent_ident: &Ident, relm4_path: &Path) -> TokenStream2 {
+    fn section_stream(&self, parent_ident: &Ident) -> TokenStream2 {
         let name = &self.name;
+        let gtk_import = crate::gtk_import();
         let mut section_stream = quote! {
-            let #name = #relm4_path::gtk::gio::Menu::new();
+            let #name = #gtk_import::gio::Menu::new();
             #parent_ident.append_section(None, &#name);
         };
 
         for item in &self.items {
-            section_stream.extend(item.item_stream(name, relm4_path));
+            section_stream.extend(item.item_stream(name));
         }
 
         section_stream

--- a/relm4-macros/src/view.rs
+++ b/relm4-macros/src/view.rs
@@ -3,12 +3,11 @@ use proc_macro2::Span as Span2;
 use quote::quote;
 use syn::{parse_macro_input, Ident};
 
+use crate::component;
 use crate::widgets::ViewWidgets;
-use crate::{component, util};
 
 pub(super) fn generate_tokens(input: TokenStream) -> TokenStream {
     let view_widgets: ViewWidgets = parse_macro_input!(input);
-    let relm4_path = util::default_relm4_path();
     let model_name = Ident::new("_", Span2::call_site());
 
     let component::token_streams::TokenStreams {
@@ -17,7 +16,7 @@ pub(super) fn generate_tokens(input: TokenStream) -> TokenStream {
         assign,
         connect,
         ..
-    } = view_widgets.generate_streams(&None, &relm4_path, &model_name, None, true);
+    } = view_widgets.generate_streams(&None, &model_name, None, true);
 
     let output = quote! {
         #init

--- a/relm4-macros/src/widgets/gen/assign/assign_property.rs
+++ b/relm4-macros/src/widgets/gen/assign/assign_property.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
-use syn::{Expr, Ident, Path};
+use syn::{Expr, Ident};
 
 use crate::widgets::{AssignProperty, AssignPropertyAttr, PropertyName};
 
@@ -12,7 +12,6 @@ impl AssignProperty {
         p_name: &PropertyName,
         w_name: &Ident,
         is_conditional: bool,
-        relm4_path: &Path,
     ) {
         // If the code gen path is behind a conditional widgets, handle `watch` and `track` later.
         // Normally, those would be initialized right away, but they might need access to
@@ -24,7 +23,7 @@ impl AssignProperty {
                 AssignPropertyAttr::Track(_) | AssignPropertyAttr::Watch
             )
         {
-            self.assign_stream(stream, p_name, w_name, relm4_path);
+            self.assign_stream(stream, p_name, w_name);
         }
     }
 
@@ -33,9 +32,8 @@ impl AssignProperty {
         stream: &mut TokenStream2,
         p_name: &PropertyName,
         w_name: &Ident,
-        relm4_path: &Path,
     ) {
-        let assign_fn = p_name.assign_fn_stream(w_name, relm4_path);
+        let assign_fn = p_name.assign_fn_stream(w_name);
         let self_assign_args = p_name.assign_args_stream(w_name);
         let span = p_name.span();
 
@@ -57,21 +55,22 @@ impl AssignProperty {
         } else {
             let mut block_stream = TokenStream2::default();
             let mut unblock_stream = TokenStream2::default();
+            let gtk_import = crate::gtk_import();
             for signal_handler in &self.block_signals {
                 block_stream.extend(quote_spanned! {
                     signal_handler.span() =>
                         {
-                            use #relm4_path ::WidgetRef;
+                            use relm4::WidgetRef;
                             #[allow(clippy::needless_borrow)]
-                            #relm4_path ::gtk::prelude::ObjectExt::block_signal(#w_name.widget_ref(), &#signal_handler);
+                            #gtk_import::prelude::ObjectExt::block_signal(#w_name.widget_ref(), &#signal_handler);
                         }
                 });
                 unblock_stream.extend(quote_spanned! {
                     signal_handler.span() =>
                         {
-                            use #relm4_path ::WidgetRef;
+                            use relm4::WidgetRef;
                             #[allow(clippy::needless_borrow)]
-                            #relm4_path ::gtk::prelude::ObjectExt::unblock_signal(#w_name.widget_ref(), &#signal_handler);
+                            #gtk_import::prelude::ObjectExt::unblock_signal(#w_name.widget_ref(), &#signal_handler);
                         }
                 });
             }

--- a/relm4-macros/src/widgets/gen/assign/conditional_widget.rs
+++ b/relm4-macros/src/widgets/gen/assign/conditional_widget.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
-use syn::{Ident, Path};
+use syn::Ident;
 
 use crate::widgets::{ConditionalBranches, ConditionalWidget, PropertyName};
 
@@ -11,9 +11,8 @@ impl ConditionalWidget {
         stream: &mut TokenStream2,
         p_name: &PropertyName,
         w_name: &Ident,
-        relm4_path: &Path,
     ) {
-        let assign_fn = p_name.assign_fn_stream(w_name, relm4_path);
+        let assign_fn = p_name.assign_fn_stream(w_name);
         let self_assign_args = p_name.assign_args_stream(w_name);
         let span = p_name.span();
 
@@ -38,16 +37,13 @@ impl ConditionalWidget {
             ConditionalBranches::If(if_branches) => {
                 for branch in if_branches {
                     let p_name = PropertyName::Ident(Ident::new("add_named", p_name.span()));
-                    branch
-                        .widget
-                        .assign_stream(stream, &p_name, w_name, true, relm4_path);
+                    branch.widget.assign_stream(stream, &p_name, w_name, true);
                 }
             }
             ConditionalBranches::Match((_, _, match_arms)) => {
                 for arm in match_arms {
                     let p_name = PropertyName::Ident(Ident::new("add_named", p_name.span()));
-                    arm.widget
-                        .assign_stream(stream, &p_name, w_name, true, relm4_path);
+                    arm.widget.assign_stream(stream, &p_name, w_name, true);
                 }
             }
         }

--- a/relm4-macros/src/widgets/gen/assign/mod.rs
+++ b/relm4-macros/src/widgets/gen/assign/mod.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{Ident, Path};
+use syn::Ident;
 
 use crate::widgets::{Property, PropertyType};
 
@@ -9,26 +9,16 @@ mod properties;
 mod widgets;
 
 impl Property {
-    fn assign_stream(
-        &self,
-        stream: &mut TokenStream2,
-        w_name: &Ident,
-        is_conditional: bool,
-        relm4_path: &Path,
-    ) {
+    fn assign_stream(&self, stream: &mut TokenStream2, w_name: &Ident, is_conditional: bool) {
         match &self.ty {
-            PropertyType::Assign(assign) => assign.conditional_assign_stream(
-                stream,
-                &self.name,
-                w_name,
-                is_conditional,
-                relm4_path,
-            ),
+            PropertyType::Assign(assign) => {
+                assign.conditional_assign_stream(stream, &self.name, w_name, is_conditional)
+            }
             PropertyType::Widget(widget) => {
-                widget.assign_stream(stream, &self.name, w_name, is_conditional, relm4_path)
+                widget.assign_stream(stream, &self.name, w_name, is_conditional)
             }
             PropertyType::ConditionalWidget(cond_widget) => {
-                cond_widget.assign_stream(stream, &self.name, w_name, relm4_path)
+                cond_widget.assign_stream(stream, &self.name, w_name)
             }
             PropertyType::ParseError(_) | PropertyType::SignalHandler(_) => (),
         }

--- a/relm4-macros/src/widgets/gen/assign/properties.rs
+++ b/relm4-macros/src/widgets/gen/assign/properties.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{Ident, Path};
+use syn::Ident;
 
 use crate::widgets::Properties;
 
@@ -9,10 +9,9 @@ impl Properties {
         stream: &mut TokenStream2,
         w_name: &Ident,
         is_conditional: bool,
-        relm4_path: &Path,
     ) {
         for prop in &self.properties {
-            prop.assign_stream(stream, w_name, is_conditional, relm4_path);
+            prop.assign_stream(stream, w_name, is_conditional);
         }
     }
 }

--- a/relm4-macros/src/widgets/gen/assign/widgets.rs
+++ b/relm4-macros/src/widgets/gen/assign/widgets.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
-use syn::{Ident, Path};
+use syn::Ident;
 
 use crate::widgets::{PropertyName, ReturnedWidget, Widget};
 
@@ -22,10 +22,9 @@ impl ReturnedWidget {
 }
 
 impl Widget {
-    pub fn start_assign_stream(&self, stream: &mut TokenStream2, relm4_path: &Path) {
+    pub fn start_assign_stream(&self, stream: &mut TokenStream2) {
         let w_name = &self.name;
-        self.properties
-            .assign_stream(stream, w_name, false, relm4_path);
+        self.properties.assign_stream(stream, w_name, false);
     }
 
     pub(super) fn assign_stream(
@@ -34,9 +33,8 @@ impl Widget {
         p_name: &PropertyName,
         w_name: &Ident,
         is_conditional: bool,
-        relm4_path: &Path,
     ) {
-        let assign_fn = p_name.assign_fn_stream(w_name, relm4_path);
+        let assign_fn = p_name.assign_fn_stream(w_name);
         let self_assign_args = p_name.assign_args_stream(w_name);
         let assign = self.widget_assignment();
         let span = p_name.span();
@@ -62,13 +60,13 @@ impl Widget {
         // Recursively generate code for properties
         let w_name = &self.name;
         self.properties
-            .assign_stream(stream, w_name, is_conditional, relm4_path);
+            .assign_stream(stream, w_name, is_conditional);
 
         if let Some(returned_widget) = &self.returned_widget {
             let w_name = &returned_widget.name;
             returned_widget
                 .properties
-                .assign_stream(stream, w_name, is_conditional, relm4_path);
+                .assign_stream(stream, w_name, is_conditional);
         }
     }
 }

--- a/relm4-macros/src/widgets/gen/init.rs
+++ b/relm4-macros/src/widgets/gen/init.rs
@@ -1,19 +1,18 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote_spanned, ToTokens};
-use syn::Path;
 
 use crate::widgets::{
     ConditionalBranches, ConditionalWidget, Properties, Property, PropertyType, Widget, WidgetAttr,
 };
 
 impl Property {
-    fn init_stream(&self, stream: &mut TokenStream2, relm4_path: &Path) {
+    fn init_stream(&self, stream: &mut TokenStream2) {
         match &self.ty {
             PropertyType::Widget(widget) => {
-                widget.init_stream(stream, relm4_path);
+                widget.init_stream(stream);
             }
             PropertyType::ConditionalWidget(cond_widget) => {
-                cond_widget.init_stream(stream, relm4_path);
+                cond_widget.init_stream(stream);
             }
             _ => (),
         }
@@ -21,30 +20,29 @@ impl Property {
 }
 
 impl Properties {
-    fn init_stream(&self, stream: &mut TokenStream2, relm4_path: &Path) {
+    fn init_stream(&self, stream: &mut TokenStream2) {
         for prop in &self.properties {
-            prop.init_stream(stream, relm4_path);
+            prop.init_stream(stream);
         }
     }
 }
 
 impl Widget {
-    pub fn init_stream(&self, stream: &mut TokenStream2, relm4_path: &Path) {
+    pub fn init_stream(&self, stream: &mut TokenStream2) {
         self.self_init_stream(stream);
-        self.other_init_stream(stream, relm4_path);
+        self.other_init_stream(stream);
     }
 
     pub fn init_root_init_streams(
         &self,
         init_root_stream: &mut TokenStream2,
         init_stream: &mut TokenStream2,
-        relm4_path: &Path,
     ) {
         // Init and name as return value
         self.self_init_stream(init_root_stream);
         self.name.to_tokens(init_root_stream);
 
-        self.other_init_stream(init_stream, relm4_path);
+        self.other_init_stream(init_stream);
     }
 
     fn self_init_stream(&self, stream: &mut TokenStream2) {
@@ -66,36 +64,37 @@ impl Widget {
         }
     }
 
-    fn other_init_stream(&self, stream: &mut TokenStream2, relm4_path: &Path) {
-        self.properties.init_stream(stream, relm4_path);
+    fn other_init_stream(&self, stream: &mut TokenStream2) {
+        self.properties.init_stream(stream);
     }
 }
 
 impl ConditionalWidget {
-    fn init_stream(&self, stream: &mut TokenStream2, relm4_path: &Path) {
+    fn init_stream(&self, stream: &mut TokenStream2) {
         let name = &self.name;
+        let gtk_import = crate::gtk_import();
 
         stream.extend(quote_spanned! {
             name.span() =>
-                let #name = #relm4_path::gtk::Stack::default();
+                let #name = #gtk_import::Stack::default();
         });
 
         if let Some(transition) = &self.transition {
             stream.extend(quote_spanned! {
                 transition.span() =>
-                    #name.set_transition_type(#relm4_path::gtk::StackTransitionType:: #transition);
+                    #name.set_transition_type(#gtk_import::StackTransitionType:: #transition);
             });
         }
 
         match &self.branches {
             ConditionalBranches::If(if_branches) => {
                 for branch in if_branches {
-                    branch.widget.init_stream(stream, relm4_path);
+                    branch.widget.init_stream(stream);
                 }
             }
             ConditionalBranches::Match((_, _, match_arms)) => {
                 for arm in match_arms {
-                    arm.widget.init_stream(stream, relm4_path);
+                    arm.widget.init_stream(stream);
                 }
             }
         }

--- a/relm4-macros/src/widgets/gen/struct_fields.rs
+++ b/relm4-macros/src/widgets/gen/struct_fields.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
-use syn::{Path, Visibility};
+use syn::Visibility;
 
 use super::{ReturnedWidget, Widget};
 use crate::widgets::{
@@ -8,19 +8,14 @@ use crate::widgets::{
 };
 
 impl Property {
-    fn struct_fields_stream(
-        &self,
-        stream: &mut TokenStream2,
-        vis: &Option<Visibility>,
-        relm4_path: &Path,
-    ) {
+    fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
         match &self.ty {
-            PropertyType::Widget(widget) => widget.struct_fields_stream(stream, vis, relm4_path),
+            PropertyType::Widget(widget) => widget.struct_fields_stream(stream, vis),
             PropertyType::SignalHandler(signal_handler) => {
-                signal_handler.struct_fields_stream(stream, vis, relm4_path)
+                signal_handler.struct_fields_stream(stream, vis)
             }
             PropertyType::ConditionalWidget(cond_widget) => {
-                cond_widget.struct_fields_stream(stream, vis, relm4_path)
+                cond_widget.struct_fields_stream(stream, vis)
             }
             PropertyType::Assign(_) | PropertyType::ParseError(_) => (),
         }
@@ -28,25 +23,15 @@ impl Property {
 }
 
 impl Properties {
-    fn struct_fields_stream(
-        &self,
-        stream: &mut TokenStream2,
-        vis: &Option<Visibility>,
-        relm4_path: &Path,
-    ) {
+    fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
         for prop in &self.properties {
-            prop.struct_fields_stream(stream, vis, relm4_path);
+            prop.struct_fields_stream(stream, vis);
         }
     }
 }
 
 impl Widget {
-    pub fn struct_fields_stream(
-        &self,
-        stream: &mut TokenStream2,
-        vis: &Option<Visibility>,
-        relm4_path: &Path,
-    ) {
+    pub fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
         let name = &self.name;
         let ty = self.func_type_token_stream();
 
@@ -62,46 +47,41 @@ impl Widget {
             }
         });
 
-        self.properties
-            .struct_fields_stream(stream, vis, relm4_path);
+        self.properties.struct_fields_stream(stream, vis);
         if let Some(returned_widget) = &self.returned_widget {
-            returned_widget.struct_fields_stream(stream, vis, relm4_path);
+            returned_widget.struct_fields_stream(stream, vis);
         }
     }
 }
 
 impl ConditionalWidget {
-    fn struct_fields_stream(
-        &self,
-        stream: &mut TokenStream2,
-        vis: &Option<Visibility>,
-        relm4_path: &Path,
-    ) {
+    fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
         let name = &self.name;
+        let gtk_import = crate::gtk_import();
 
         stream.extend(if let Some(docs) = &self.doc_attr {
             quote_spanned! {
                 name.span() =>
                    #[doc = #docs]
-                   #vis #name: #relm4_path::gtk::Stack,
+                   #vis #name: #gtk_import::Stack,
             }
         } else {
             quote_spanned! {
                 name.span() =>
                     #[allow(missing_docs)]
-                    #vis #name: #relm4_path::gtk::Stack,
+                    #vis #name: #gtk_import::Stack,
             }
         });
 
         match &self.branches {
             ConditionalBranches::If(if_branches) => {
                 for branch in if_branches {
-                    branch.widget.struct_fields_stream(stream, vis, relm4_path);
+                    branch.widget.struct_fields_stream(stream, vis);
                 }
             }
             ConditionalBranches::Match((_, _, match_arms)) => {
                 for arm in match_arms {
-                    arm.widget.struct_fields_stream(stream, vis, relm4_path);
+                    arm.widget.struct_fields_stream(stream, vis);
                 }
             }
         }
@@ -109,12 +89,7 @@ impl ConditionalWidget {
 }
 
 impl ReturnedWidget {
-    fn struct_fields_stream(
-        &self,
-        stream: &mut TokenStream2,
-        vis: &Option<Visibility>,
-        relm4_path: &Path,
-    ) {
+    fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
         if let Some(ty) = &self.ty {
             let name = &self.name;
             stream.extend(quote! {
@@ -122,23 +97,18 @@ impl ReturnedWidget {
                 #vis #name: #ty,
             });
         }
-        self.properties
-            .struct_fields_stream(stream, vis, relm4_path);
+        self.properties.struct_fields_stream(stream, vis);
     }
 }
 
 impl SignalHandler {
-    fn struct_fields_stream(
-        &self,
-        stream: &mut TokenStream2,
-        vis: &Option<Visibility>,
-        relm4_path: &Path,
-    ) {
+    fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
         if let Some(signal_handler_id) = &self.handler_id {
+            let gtk_import = crate::gtk_import();
             stream.extend(quote_spanned! {
                 signal_handler_id.span() =>
                     #[allow(missing_docs)]
-                    #vis #signal_handler_id: #relm4_path::gtk::glib::signal::SignalHandlerId,
+                    #vis #signal_handler_id: #gtk_import::glib::signal::SignalHandlerId,
             });
         }
     }

--- a/relm4-macros/src/widgets/gen/update_view.rs
+++ b/relm4-macros/src/widgets/gen/update_view.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
-use syn::{Ident, Path};
+use syn::Ident;
 
 use crate::widgets::{
     AssignProperty, AssignPropertyAttr, ConditionalBranches, ConditionalWidget, MatchArm,
@@ -15,7 +15,6 @@ impl Property {
         w_name: &Ident,
         model_name: &Ident,
         conditional_branch: bool,
-        relm4_path: &Path,
     ) {
         match &self.ty {
             PropertyType::Assign(assign) => assign.update_view_stream(
@@ -24,13 +23,12 @@ impl Property {
                 w_name,
                 model_name,
                 conditional_branch,
-                relm4_path,
             ),
             PropertyType::Widget(widget) => {
-                widget.update_view_stream(stream, model_name, conditional_branch, relm4_path)
+                widget.update_view_stream(stream, model_name, conditional_branch)
             }
             PropertyType::ConditionalWidget(cond_widget) => {
-                cond_widget.update_view_stream(stream, model_name, relm4_path)
+                cond_widget.update_view_stream(stream, model_name)
             }
             PropertyType::SignalHandler(_) | PropertyType::ParseError(_) => (),
         }
@@ -44,22 +42,16 @@ impl Properties {
         w_name: &Ident,
         model_name: &Ident,
         conditional_branch: bool,
-        relm4_path: &Path,
     ) {
         for prop in &self.properties {
-            prop.update_view_stream(stream, w_name, model_name, conditional_branch, relm4_path);
+            prop.update_view_stream(stream, w_name, model_name, conditional_branch);
         }
     }
 }
 
 impl Widget {
-    pub fn init_update_view_stream(
-        &self,
-        stream: &mut TokenStream2,
-        model_name: &Ident,
-        relm4_path: &Path,
-    ) {
-        self.update_view_stream(stream, model_name, false, relm4_path);
+    pub fn init_update_view_stream(&self, stream: &mut TokenStream2, model_name: &Ident) {
+        self.update_view_stream(stream, model_name, false);
     }
 
     fn update_view_stream(
@@ -67,36 +59,27 @@ impl Widget {
         stream: &mut TokenStream2,
         model_name: &Ident,
         conditional_branch: bool,
-        relm4_path: &Path,
     ) {
         let w_name = &self.name;
-        self.properties.update_view_stream(
-            stream,
-            w_name,
-            model_name,
-            conditional_branch,
-            relm4_path,
-        );
+        self.properties
+            .update_view_stream(stream, w_name, model_name, conditional_branch);
         if let Some(returned_widget) = &self.returned_widget {
-            returned_widget.update_view_stream(stream, model_name, conditional_branch, relm4_path);
+            returned_widget.update_view_stream(stream, model_name, conditional_branch);
         }
     }
 }
 
 impl ConditionalWidget {
-    fn update_view_stream(&self, stream: &mut TokenStream2, model_name: &Ident, relm4_path: &Path) {
+    fn update_view_stream(&self, stream: &mut TokenStream2, model_name: &Ident) {
         let brach_stream = match &self.branches {
             ConditionalBranches::If(if_branches) => {
                 let mut stream = TokenStream2::new();
 
                 for (index, branch) in if_branches.iter().enumerate() {
                     let mut inner_update_stream = TokenStream2::new();
-                    branch.widget.update_view_stream(
-                        &mut inner_update_stream,
-                        model_name,
-                        true,
-                        relm4_path,
-                    );
+                    branch
+                        .widget
+                        .update_view_stream(&mut inner_update_stream, model_name, true);
                     branch.update_stream(&mut stream, inner_update_stream, index);
                 }
                 stream
@@ -105,12 +88,9 @@ impl ConditionalWidget {
                 let mut inner_tokens = TokenStream2::new();
                 for (index, match_arm) in match_arms.iter().enumerate() {
                     let mut inner_update_stream = TokenStream2::new();
-                    match_arm.widget.update_view_stream(
-                        &mut inner_update_stream,
-                        model_name,
-                        true,
-                        relm4_path,
-                    );
+                    match_arm
+                        .widget
+                        .update_view_stream(&mut inner_update_stream, model_name, true);
                     let MatchArm {
                         pattern,
                         guard,
@@ -155,16 +135,10 @@ impl ReturnedWidget {
         stream: &mut TokenStream2,
         model_name: &Ident,
         conditional_branch: bool,
-        relm4_path: &Path,
     ) {
         let w_name = &self.name;
-        self.properties.update_view_stream(
-            stream,
-            w_name,
-            model_name,
-            conditional_branch,
-            relm4_path,
-        );
+        self.properties
+            .update_view_stream(stream, w_name, model_name, conditional_branch);
     }
 }
 
@@ -176,16 +150,15 @@ impl AssignProperty {
         w_name: &Ident,
         model_name: &Ident,
         conditional_branch: bool,
-        relm4_path: &Path,
     ) {
         match &self.attr {
             AssignPropertyAttr::None => (),
             AssignPropertyAttr::Watch => {
-                self.assign_stream(stream, p_name, w_name, relm4_path);
+                self.assign_stream(stream, p_name, w_name);
             }
             AssignPropertyAttr::Track((track_stream, paste_model)) => {
                 let mut assign_stream = TokenStream2::new();
-                self.assign_stream(&mut assign_stream, p_name, w_name, relm4_path);
+                self.assign_stream(&mut assign_stream, p_name, w_name);
                 let model = paste_model.then(|| model_name);
                 let page_switch = conditional_branch.then(|| {
                     quote_spanned! {

--- a/relm4-macros/src/widgets/gen/util/property_name.rs
+++ b/relm4-macros/src/widgets/gen/util/property_name.rs
@@ -1,18 +1,18 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned, ToTokens};
-use syn::{Ident, Path};
+use syn::Ident;
 
 use crate::widgets::gen::PropertyName;
 
 impl PropertyName {
-    pub fn assign_fn_stream(&self, w_name: &Ident, relm4_path: &Path) -> TokenStream2 {
+    pub fn assign_fn_stream(&self, w_name: &Ident) -> TokenStream2 {
         match self {
             PropertyName::Ident(ident) => {
                 quote! { #w_name.#ident }
             }
             PropertyName::Path(path) => path.to_token_stream(),
             PropertyName::RelmContainerExtAssign => {
-                quote_spanned! { w_name.span() => #relm4_path ::RelmContainerExt::container_add }
+                quote_spanned! { w_name.span() => relm4::RelmContainerExt::container_add }
             }
         }
     }

--- a/relm4-macros/src/widgets/parse/top_level_widget.rs
+++ b/relm4-macros/src/widgets/parse/top_level_widget.rs
@@ -1,5 +1,6 @@
 use syn::parse::ParseStream;
 
+use crate::util;
 use crate::widgets::{
     parse_util, Attr, Attrs, Properties, Property, PropertyName, PropertyType, TopLevelWidget,
     Widget, WidgetAttr, WidgetFunc,
@@ -37,7 +38,7 @@ impl TopLevelWidget {
                 mutable: None,
                 name: parse_util::string_to_snake_case("incorrect_top_level_widget"),
                 func: WidgetFunc {
-                    path: parse_util::strings_to_path(&["gtk", "Box"]),
+                    path: util::strings_to_path(&["gtk", "Box"]),
                     args: None,
                     method_chain: None,
                     ty: None,

--- a/relm4-macros/src/widgets/parse_util.rs
+++ b/relm4-macros/src/widgets/parse_util.rs
@@ -2,9 +2,8 @@ use std::sync::atomic::{AtomicU16, Ordering};
 
 use proc_macro2::Span as Span2;
 use syn::parse::ParseBuffer;
-use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{braced, bracketed, parenthesized, Error, Ident, Path, PathArguments, PathSegment};
+use syn::{braced, bracketed, parenthesized, Error, Ident, Path};
 
 use super::{ParseError, PropertyName};
 use crate::widgets::{parse_util, AssignPropertyAttr, WidgetAttr, WidgetFunc};
@@ -151,18 +150,4 @@ pub(super) fn brackets<'a>(input: &'a ParseBuffer) -> Result<ParseBuffer<'a>, Pa
         Ok(content)
     })();
     Ok(content?)
-}
-
-pub(super) fn strings_to_path(strings: &[&str]) -> Path {
-    let path_segments: Vec<PathSegment> = strings
-        .iter()
-        .map(|string| PathSegment {
-            ident: Ident::new(string, Span2::call_site()),
-            arguments: PathArguments::None,
-        })
-        .collect();
-    Path {
-        leading_colon: None,
-        segments: Punctuated::from_iter(path_segments),
-    }
 }


### PR DESCRIPTION
"relm4_path" was added as feature to specify the path of the Relm4 crate used by relm4-macros. To keep macro hygiene, all paths started with `::relm4` to avoid that someone would have an item in scope that had the name "relm4" but wasn't the actual crate. That required passing the path to a lot of code generation functions and in general wasn't worth the effort. There's simply no plausible situation in which you had "relm4" in the scope and it's not the crate.

The only situation would be a re-export, which made this so complicated in the first place. If you had a crate that re-exported Relm4, the macro wouldn't work because it uses `use ::relm4::item`. Now, with `use relm4::item` the generated code works in every scope that has the Relm4 crate included.