### PR TITLE
macros: Make view_output a function

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -64,7 +64,7 @@ impl SimpleComponent for AppModel {
         let model = AppModel { counter };
 
         // Insert the macro code generation here
-        let widgets = view_output!();
+        let widgets = view_output();
 
         ComponentParts { model, widgets }
     }


### PR DESCRIPTION
This is only to fix an incorrect rust-analyzer warning when using `view_output!()`. 