### PR TITLE
spawn worker updates instead of awaiting them

### DIFF
--- a/relm4/src/worker.rs
+++ b/relm4/src/worker.rs
@@ -36,7 +36,7 @@ pub trait Worker: Sized + Send {
                 let mut worker = Self::init_inner(params, &mut input_tx, &mut output_tx);
 
                 while let Some(input) = input_rx.recv().await {
-                    worker.update(input, &mut input_tx, &mut output_tx).await;
+                    crate::spawn(worker.update(input, &mut input_tx, &mut output_tx));
                 }
             })
         };


### PR DESCRIPTION
The current behavior will cause all updates to be serialized in the order they are received, instead of interleaving them. The change in behavior can be seen in the non-blocking async example by clicking the button three times.