### PR TITLE
emit tracing logs on received inputs

### DIFF
--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -42,6 +42,7 @@ fn gtk_import() -> std::rc::Rc<syn::Path> {
 ///     counter: u8,
 /// }
 ///
+/// #[derive(Debug)]
 /// enum AppMsg {
 ///     Increment,
 ///     Decrement,

--- a/relm4-macros/tests/simple.rs
+++ b/relm4-macros/tests/simple.rs
@@ -6,6 +6,7 @@ struct AppModel {
     counter: u8,
 }
 
+#[derive(Debug)]
 enum AppMsg {
     Increment,
     Decrement,

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.15", features = ["rt", "rt-multi-thread"] }
 
 #relm4-macros = { version = "0.4.1", optional = true }
 relm4-macros = { path = "../relm4-macros", optional = true }
+tracing = { version = "0.1.35", features = ["log"] }
 
 [dev-dependencies]
 relm4-macros = { path = "../relm4-macros" }

--- a/relm4/src/component/builder.rs
+++ b/relm4/src/component/builder.rs
@@ -8,10 +8,12 @@ use crate::RelmContainerExt;
 use async_oneshot::oneshot;
 use futures::FutureExt;
 use gtk::prelude::GtkWindowExt;
+use std::any;
 use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
+use tracing::info_span;
 
 /// A component that is ready for docking and launch.
 #[derive(Debug)]
@@ -132,6 +134,13 @@ impl<C: Component> ComponentBuilder<C> {
                                 ref mut widgets,
                             } = &mut *watcher_.state.borrow_mut();
 
+                            info_span!(
+                                "update_with_view",
+                                input=?message,
+                                component=any::type_name::<C>(),
+                                id=model.id(),
+                            );
+
                             model.update_with_view(widgets, message, &component_sender);
                         }
                     }
@@ -143,6 +152,13 @@ impl<C: Component> ComponentBuilder<C> {
                                 ref mut model,
                                 ref mut widgets,
                             } = &mut *watcher_.state.borrow_mut();
+
+                            info_span!(
+                                "update_cmd_with_view",
+                                cmd_output=?message,
+                                component=any::type_name::<C>(),
+                                id=model.id(),
+                            );
 
                             model.update_cmd_with_view(widgets, message, &component_sender);
                         }

--- a/relm4/src/component/traits.rs
+++ b/relm4/src/component/traits.rs
@@ -2,25 +2,27 @@
 // Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MIT or Apache-2.0
 
+use std::fmt::Debug;
+
 use super::*;
 use crate::{ComponentSender, Sender};
 
 /// Elm-style variant of a Component with view updates separated from input updates
 pub trait Component: Sized + 'static {
     /// Messages which are received from commands executing in the background.
-    type CommandOutput: 'static + Send;
+    type CommandOutput: Debug + Send + 'static;
 
     /// The message type that the component accepts as inputs.
-    type Input: 'static;
+    type Input: Debug + 'static;
 
     /// The message type that the component provides as outputs.
-    type Output: 'static;
+    type Output: Debug + 'static;
 
     /// The initial parameter(s) for launch.
     type InitParams;
 
     /// The widget that was constructed by the component.
-    type Root: std::fmt::Debug + OnDestroy;
+    type Root: Debug + OnDestroy;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;
@@ -77,15 +79,23 @@ pub trait Component: Sized + 'static {
     /// Last method called before a component is shut down.
     #[allow(unused)]
     fn shutdown(&mut self, widgets: &mut Self::Widgets, output: Sender<Self::Output>) {}
+
+    /// An identifier for the component used for debug logging.
+    ///
+    /// The default implementation of this method uses the address of the component, but
+    /// implementations are free to provide more meaningful identifiers.
+    fn id(&self) -> String {
+        format!("{:p}", &self)
+    }
 }
 
 /// Elm-style variant of a Component with view updates separated from input updates
 pub trait SimpleComponent: Sized + 'static {
     /// The message type that the component accepts as inputs.
-    type Input: 'static;
+    type Input: Debug + 'static;
 
     /// The message type that the component provides as outputs.
-    type Output: 'static;
+    type Output: Debug + 'static;
 
     /// The initial parameter(s) for launch.
     type InitParams;

--- a/relm4/src/factory/traits.rs
+++ b/relm4/src/factory/traits.rs
@@ -84,22 +84,22 @@ impl<C> Position<()> for C {
 /// of factories.
 pub trait FactoryComponent<ParentWidget: FactoryView, ParentMsg>: Sized + Debug + 'static {
     /// Internal commands to perform
-    type Command: 'static + Send;
+    type Command: Debug + Send + 'static;
 
     /// Messages which are received from commands executing in the background.
-    type CommandOutput: 'static + Send;
+    type CommandOutput: Debug + Send + 'static;
 
     /// The message type that the component accepts as inputs.
-    type Input: 'static;
+    type Input: Debug + 'static;
 
     /// The message type that the component provides as outputs.
-    type Output: 'static;
+    type Output: Debug + 'static;
 
     /// The initial parameter(s) for launch.
     type InitParams;
 
     /// The widget that was constructed by the component.
-    type Root: std::fmt::Debug + OnDestroy + Clone;
+    type Root: Debug + OnDestroy + Clone;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;
@@ -202,4 +202,12 @@ pub trait FactoryComponent<ParentWidget: FactoryView, ParentMsg>: Sized + Debug 
     /// Last method called before a component is shut down.
     #[allow(unused)]
     fn shutdown(&mut self, widgets: &mut Self::Widgets, output: Sender<Self::Output>) {}
+
+    /// An identifier for the component used for debug logging.
+    ///
+    /// The default implementation of this method uses the address of the component, but
+    /// implementations are free to provide more meaningful identifiers.
+    fn id(&self) -> String {
+        format!("{:p}", &self)
+    }
 }


### PR DESCRIPTION
Fixes #198.

Only logs `update_with_view` and `update_view_with_cmd`, expecting more events to be added in the future. Most importantly, this adds `Debug` bounds to `Input` and `Output` so that the breaking changes are in early.