### PR TITLE
Update examples

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -15,6 +15,7 @@ enum CounterMsg {
     Decrement,
 }
 
+#[derive(Debug)]
 enum CounterOutput {
     SendFront(DynamicIndex),
     MoveUp(DynamicIndex),

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -15,6 +15,7 @@ enum CounterMsg {
     Decrement,
 }
 
+#[derive(Debug)]
 enum CounterOutput {
     SendFront(DynamicIndex),
     MoveUp(DynamicIndex),

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -16,6 +16,7 @@ enum CounterMsg {
     Decrement,
 }
 
+#[derive(Debug)]
 enum CounterOutput {
     SendFront(DynamicIndex),
     MoveUp(DynamicIndex),

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -33,6 +33,7 @@ enum CounterMsg {
     Update,
 }
 
+#[derive(Debug)]
 enum CounterOutput {
     StartGame(DynamicIndex),
     SelectedGuess(DynamicIndex),

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -9,6 +9,7 @@ struct AppModel {
     counter: u8,
 }
 
+#[derive(Debug)]
 enum AppMsg {
     Increment,
     Decrement,

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -35,14 +35,17 @@ pub struct Widgets {
     progress: gtk::ProgressBar,
 }
 
+#[derive(Debug)]
 pub enum Input {
     Compute,
 }
 
+#[derive(Debug)]
 pub enum Output {
     Clicked(u32),
 }
 
+#[derive(Debug)]
 pub enum CmdOut {
     /// Progress update from a command.
     Progress(f32),

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -79,6 +79,7 @@ pub struct Widgets {
     pub button_sg: gtk::SizeGroup,
 }
 
+#[derive(Debug)]
 pub enum Input {
     AddSetting {
         description: String,
@@ -89,11 +90,13 @@ pub enum Input {
     Reload,
 }
 
+#[derive(Debug)]
 pub enum Output {
     Clicked(u32),
     Reload,
 }
 
+#[derive(Debug)]
 pub enum CmdOut {
     Reload,
 }

--- a/relm4-macros/tests/ui/compile-fail/pre-view-return.rs
+++ b/relm4-macros/tests/ui/compile-fail/pre-view-return.rs
@@ -1,0 +1,31 @@
+#![deny(unreachable_code)]
+
+use relm4::{gtk, SimpleComponent, ComponentParts, ComponentSender};
+
+struct TestComponent;
+
+#[relm4_macros::component]
+impl SimpleComponent for TestComponent {
+    type InitParams = ();
+    type Input = ();
+    type Output = ();
+    type Widgets = TestWidgets;
+
+    view! {
+        gtk::Window {}
+    }
+
+    fn pre_view() {
+        return;
+    }
+
+    fn init(_init_param: (), _root: &Self::Root, _sender: &ComponentSender<Self>) -> ComponentParts<Self> {
+        let model = Self;
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+}
+
+fn main() {}

--- a/relm4-macros/tests/ui/compile-fail/pre-view-return.stderr
+++ b/relm4-macros/tests/ui/compile-fail/pre-view-return.stderr
@@ -1,0 +1,15 @@
+error: unreachable statement
+  --> tests/ui/compile-fail/pre-view-return.rs:7:1
+   |
+7  | #[relm4_macros::component]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+...
+19 |         return;
+   |         ------ any code following this expression is unreachable
+   |
+note: the lint level is defined here
+  --> tests/ui/compile-fail/pre-view-return.rs:1:9
+   |
+1  | #![deny(unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `relm4_macros::component` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
+ Update examples (add missing `Debug` impls)
+ Add test case that should allow us to comfortably close #136, knowing there will always be a warning on early returns.