### PR TITLE
Use Component trait for Worker

### DIFF
--- a/examples/non_blocking_async.rs
+++ b/examples/non_blocking_async.rs
@@ -1,23 +1,10 @@
-use std::convert::identity;
 use std::time::Duration;
 
 use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt};
-use relm4::{
-    gtk, Component, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus, Worker,
-    WorkerController,
-};
-
-struct AsyncHandler;
-
-#[derive(Debug)]
-enum AsyncHandlerMsg {
-    DelayedIncrement,
-    DelayedDecrement,
-}
+use relm4::{gtk, Component, ComponentParts, ComponentSender, RelmApp, WidgetPlus};
 
 struct AppModel {
     counter: u8,
-    worker: WorkerController<AsyncHandler>,
 }
 
 #[derive(Debug)]
@@ -26,31 +13,11 @@ enum AppMsg {
     Decrement,
 }
 
-impl Worker for AsyncHandler {
-    type InitParams = ();
-    type Input = AsyncHandlerMsg;
-    type Output = AppMsg;
-
-    fn init(_params: Self::InitParams, _sender: &relm4::ComponentSender<Self>) -> Self {
-        Self
-    }
-
-    fn update(&mut self, msg: AsyncHandlerMsg, sender: &ComponentSender<Self>) {
-        let output = sender.output.clone();
-
-        std::thread::sleep(Duration::from_secs(1));
-
-        match msg {
-            AsyncHandlerMsg::DelayedIncrement => output.send(AppMsg::Increment),
-            AsyncHandlerMsg::DelayedDecrement => output.send(AppMsg::Decrement),
-        }
-    }
-}
-
 #[relm4::component]
-impl SimpleComponent for AppModel {
+impl Component for AppModel {
+    type CommandOutput = AppMsg;
     type InitParams = ();
-    type Input = AppMsg;
+    type Input = ();
     type Output = ();
     type Widgets = AppWidgets;
 
@@ -67,15 +34,28 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Increment",
-                    connect_clicked[sender = model.worker.sender().clone()] => move |_| {
-                        sender.send(AsyncHandlerMsg::DelayedIncrement);
+                    // Messages are fully async, no blocking!
+                    connect_clicked[sender] => move |_| {
+                        sender.command(|out, shutdown| {
+                            shutdown.register(async move {
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                out.send(AppMsg::Increment);
+                            }).drop_on_shutdown()
+                        })
                     },
                 },
+
                 gtk::Button::with_label("Decrement") {
-                    connect_clicked[sender = model.worker.sender().clone()] => move |_| {
-                        sender.send(AsyncHandlerMsg::DelayedDecrement);
+                    connect_clicked[sender] => move |_| {
+                        sender.command(|out, shutdown| {
+                            shutdown.register(async move {
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                out.send(AppMsg::Decrement);
+                            }).drop_on_shutdown()
+                        });
                     },
                 },
+
                 gtk::Label {
                     set_margin_all: 5,
                     #[watch]
@@ -86,19 +66,14 @@ impl SimpleComponent for AppModel {
     }
 
     fn init(_: (), root: &Self::Root, sender: &ComponentSender<Self>) -> ComponentParts<Self> {
-        let model = AppModel {
-            counter: 0,
-            worker: AsyncHandler::builder()
-                .detach_worker(())
-                .forward(&sender.input, identity),
-        };
+        let model = AppModel { counter: 0 };
 
         let widgets = view_output!();
 
         ComponentParts { model, widgets }
     }
 
-    fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
+    fn update_cmd(&mut self, msg: Self::CommandOutput, _sender: &ComponentSender<Self>) {
         match msg {
             AppMsg::Increment => {
                 self.counter = self.counter.wrapping_add(1);

--- a/examples/non_blocking_async.rs
+++ b/examples/non_blocking_async.rs
@@ -67,12 +67,12 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Increment",
-                    connect_clicked[sender = model.worker.sender.clone()] => move |_| {
+                    connect_clicked[sender = model.worker.sender().clone()] => move |_| {
                         sender.send(AsyncHandlerMsg::DelayedIncrement);
                     },
                 },
                 gtk::Button::with_label("Decrement") {
-                    connect_clicked[sender = model.worker.sender.clone()] => move |_| {
+                    connect_clicked[sender = model.worker.sender().clone()] => move |_| {
                         sender.send(AsyncHandlerMsg::DelayedDecrement);
                     },
                 },

--- a/examples/worker.rs
+++ b/examples/worker.rs
@@ -1,0 +1,120 @@
+use std::convert::identity;
+use std::time::Duration;
+
+use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt};
+use relm4::{
+    gtk, Component, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus, Worker,
+    WorkerController,
+};
+
+struct AsyncHandler;
+
+#[derive(Debug)]
+enum AsyncHandlerMsg {
+    DelayedIncrement,
+    DelayedDecrement,
+}
+
+struct AppModel {
+    counter: u8,
+    worker: WorkerController<AsyncHandler>,
+}
+
+#[derive(Debug)]
+enum AppMsg {
+    Increment,
+    Decrement,
+}
+
+impl Worker for AsyncHandler {
+    type InitParams = ();
+    type Input = AsyncHandlerMsg;
+    type Output = AppMsg;
+
+    fn init(_params: Self::InitParams, _sender: &relm4::ComponentSender<Self>) -> Self {
+        Self
+    }
+
+    // This is blocking on purpose.
+    // Only one message can be processed at the time.
+    // If you don't want to block during processing, look for commands.
+    // You'll find a good reference in the "non_blocking_async" example.
+    fn update(&mut self, msg: AsyncHandlerMsg, sender: &ComponentSender<Self>) {
+        let output = sender.output.clone();
+
+        std::thread::sleep(Duration::from_secs(1));
+
+        match msg {
+            AsyncHandlerMsg::DelayedIncrement => output.send(AppMsg::Increment),
+            AsyncHandlerMsg::DelayedDecrement => output.send(AppMsg::Decrement),
+        }
+    }
+}
+
+#[relm4::component]
+impl SimpleComponent for AppModel {
+    type InitParams = ();
+    type Input = AppMsg;
+    type Output = ();
+    type Widgets = AppWidgets;
+
+    view! {
+        gtk::Window {
+            set_title: Some("Worker Counter"),
+            set_default_width: 300,
+            set_default_height: 100,
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_margin_all: 5,
+                set_spacing: 5,
+
+                gtk::Button {
+                    set_label: "Increment",
+                    connect_clicked[sender = model.worker.sender().clone()] => move |_| {
+                        sender.send(AsyncHandlerMsg::DelayedIncrement);
+                    },
+                },
+                gtk::Button::with_label("Decrement") {
+                    connect_clicked[sender = model.worker.sender().clone()] => move |_| {
+                        sender.send(AsyncHandlerMsg::DelayedDecrement);
+                    },
+                },
+                gtk::Label {
+                    set_margin_all: 5,
+                    #[watch]
+                    set_label: &format!("Counter: {}", model.counter),
+                },
+            },
+        }
+    }
+
+    fn init(_: (), root: &Self::Root, sender: &ComponentSender<Self>) -> ComponentParts<Self> {
+        let model = AppModel {
+            counter: 0,
+            worker: AsyncHandler::builder()
+                .detach_worker(())
+                .forward(&sender.input, identity),
+        };
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
+        match msg {
+            AppMsg::Increment => {
+                self.counter = self.counter.wrapping_add(1);
+            }
+            AppMsg::Decrement => {
+                self.counter = self.counter.wrapping_sub(1);
+            }
+        }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.test.worker");
+    app.run::<AppModel>(());
+}

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -16,8 +16,7 @@ pub struct RelmApp {
     pub app: Application,
 }
 
-impl RelmApp
-{
+impl RelmApp {
     /// Create a Relm4 application.
     pub fn new(app_id: &str) -> Self {
         let app = Application::builder().application_id(app_id).build();
@@ -43,10 +42,10 @@ impl RelmApp
     /// does not handle command-line arguments. To pass arguments to GTK, use
     /// [`RelmApp::run_with_args`].
     pub fn run<C>(self, payload: C::InitParams)
-        where
-            C: Component,
-            C::Root: IsA<gtk::Window> + WidgetExt,
-     {
+    where
+        C: Component,
+        C::Root: IsA<gtk::Window> + WidgetExt,
+    {
         self.run_with_args::<C, &str>(payload, &[]);
     }
 

--- a/relm4/src/worker.rs
+++ b/relm4/src/worker.rs
@@ -2,96 +2,218 @@
 // Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MIT or Apache-2.0
 
-use crate::{Receiver, Sender};
-use std::future::Future;
-use std::pin::Pin;
+use async_oneshot::oneshot;
+use futures::FutureExt;
+use gtk::glib;
+use tracing::info_span;
 
-/// A future returned by a component's command method.
-pub type WorkerFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+use crate::component::{ComponentSenderInner, EmptyRoot};
+use crate::{
+    shutdown, Component, ComponentBuilder, ComponentParts, OnDestroy, Receiver, Sender,
+    SimpleComponent,
+};
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::{any, thread};
+
+impl<T> SimpleComponent for T
+where
+    T: Worker + 'static,
+{
+    type Root = EmptyRoot;
+    type Widgets = ();
+
+    type InitParams = <Self as Worker>::InitParams;
+    type Input = <Self as Worker>::Input;
+    type Output = <Self as Worker>::Output;
+
+    fn init_root() -> Self::Root {
+        EmptyRoot::default()
+    }
+
+    fn init(
+        params: Self::InitParams,
+        _root: &Self::Root,
+        sender: &crate::ComponentSender<Self>,
+    ) -> crate::ComponentParts<Self> {
+        let model = Self::init(params, sender);
+        ComponentParts { model, widgets: () }
+    }
+
+    fn update(&mut self, message: Self::Input, sender: &crate::ComponentSender<Self>) {
+        Self::update(self, message, sender);
+    }
+}
 
 /// Receives inputs and outputs in the background.
-pub trait Worker: Sized + Send {
+pub trait Worker: Sized + Send + 'static {
     /// The initial parameters that will be used to build the worker state.
-    type InputParams: 'static + Send;
+    type InitParams: 'static + Send;
     /// The type of inputs that this worker shall receive.
-    type Input: 'static + Send;
+    type Input: 'static + Send + Debug;
     /// The typue of outputs that this worker shall send.
-    type Output: 'static + Send;
+    type Output: 'static + Send + Debug;
 
     /// Defines the initial state of the worker.
-    fn init_inner(
-        params: Self::InputParams,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
-    ) -> Self;
+    fn init(params: Self::InitParams, sender: &crate::ComponentSender<Self>) -> Self;
 
-    /// Spawns the worker task in the background.
-    fn init(params: Self::InputParams) -> WorkerHandle<Self> {
-        let (input_tx, input_rx) = crate::channel::<Self::Input>();
-        let (mut output_tx, output_rx) = crate::channel::<Self::Output>();
+    /// Defines how inputs will bep processed
+    fn update(&mut self, message: Self::Input, sender: &crate::ComponentSender<Self>);
+}
 
-        let worker = {
-            let mut input_tx = input_tx.clone();
-            crate::spawn(async move {
-                let mut worker = Self::init_inner(params, &mut input_tx, &mut output_tx);
+impl<C> ComponentBuilder<C>
+where
+    C: Component<Root = EmptyRoot, Widgets = ()> + Send,
+    C::Input: Send,
+    C::Output: Send,
+    C::CommandOutput: Send,
+{
+    /// Starts the component, passing ownership to a future attached to a GLib context.
+    pub fn detach_worker(self, payload: C::InitParams) -> WorkerHandle<C> {
+        let ComponentBuilder { root, .. } = self;
 
-                while let Some(input) = input_rx.recv().await {
-                    crate::spawn(worker.update(input, &mut input_tx, &mut output_tx));
+        // Used for all events to be processed by this component's internal service.
+        let (input_tx, input_rx) = crate::channel::<C::Input>();
+
+        // Used by this component to send events to be handled externally by the caller.
+        let (output_tx, output_rx) = crate::channel::<C::Output>();
+
+        // Sends messages from commands executed from the background.
+        let (cmd_tx, cmd_rx) = crate::channel::<C::CommandOutput>();
+
+        // Notifies the component's child commands that it is now deceased.
+        let (death_notifier, death_recipient) = shutdown::channel();
+
+        // Encapsulates the senders used by component methods.
+        let component_sender = Arc::new(ComponentSenderInner {
+            command: cmd_tx,
+            input: input_tx.clone(),
+            output: output_tx.clone(),
+            shutdown: death_recipient,
+        });
+
+        // The source ID of the component's service will be sent through this once the root
+        // widget has been iced, which will give the component one last chance to say goodbye.
+        let (mut burn_notifier, burn_recipient) = oneshot::<()>();
+
+        let mut state = C::init(payload, &root, &component_sender);
+
+        thread::spawn(move || {
+            let context =
+                glib::MainContext::thread_default().unwrap_or_else(glib::MainContext::new);
+
+            // Spawns the component's service. It will receive both `Self::Input` and
+            // `Self::CommandOutput` messages. It will spawn commands as requested by
+            // updates, and send `Self::Output` messages externally.
+            context.block_on(async move {
+                let mut burn_notice = burn_recipient.fuse();
+                loop {
+                    let cmd = cmd_rx.recv().fuse();
+                    let input = input_rx.recv().fuse();
+
+                    futures::pin_mut!(cmd);
+                    futures::pin_mut!(input);
+
+                    futures::select!(
+                        // Performs the model update, checking if the update requested a command.
+                        // Runs that command asynchronously in the background using tokio.
+                        message = input => {
+                            if let Some(message) = message {
+                                let &mut ComponentParts {
+                                    ref mut model,
+                                    ref mut widgets,
+                                } = &mut state;
+
+                                let span = info_span!(
+                                    "update_with_view",
+                                    input=?message,
+                                    component=any::type_name::<C>(),
+                                    id=model.id(),
+                                );
+                                let _enter = span.enter();
+
+                                model.update_with_view(widgets, message, &component_sender);
+                            }
+                        }
+
+                        // Handles responses from a command.
+                        message = cmd => {
+                            if let Some(message) = message {
+                                let &mut ComponentParts {
+                                    ref mut model,
+                                    ref mut widgets,
+                                } = &mut state;
+
+                                let span = info_span!(
+                                    "update_cmd_with_view",
+                                    cmd_output=?message,
+                                    component=any::type_name::<C>(),
+                                    id=model.id(),
+                                );
+                                let _enter = span.enter();
+
+                                model.update_cmd_with_view(widgets, message, &component_sender);
+                            }
+                        },
+
+                        // Triggered when the component is destroyed
+                        _ = burn_notice => {
+                            let ComponentParts {
+                                ref mut model,
+                                ref mut widgets,
+                            } = &mut state;
+
+                            model.shutdown(widgets, output_tx);
+
+                            death_notifier.shutdown();
+
+                            return
+                        }
+                    );
                 }
-            })
-        };
+            });
+        });
 
+        // When the root widget is destroyed, the spawned service will be removed.
+        root.on_destroy(move || {
+            let _ = burn_notifier.send(());
+        });
+
+        // Give back a type for controlling the component service.
         WorkerHandle {
             sender: input_tx,
             receiver: output_rx,
-            worker,
+            _root: root,
         }
-    }
-
-    /// Defines how inputs will bep processed
-    #[allow(unused)]
-    fn update(
-        &mut self,
-        message: Self::Input,
-        input: &mut Sender<Self::Input>,
-        output: &mut Sender<Self::Output>,
-    ) -> WorkerFuture {
-        Box::pin(async move {})
     }
 }
 
 #[derive(Debug)]
-#[must_use = "Dropping without aborting or handling the receiver causes the worker to live forever."]
 /// Handle to a worker task in the background
-pub struct WorkerHandle<W: Worker> {
+pub struct WorkerHandle<W: Component> {
     /// Sends inputs to the worker.
     pub sender: Sender<W::Input>,
 
     /// Where the worker will send its outputs to.
     pub receiver: Receiver<W::Output>,
 
-    worker: crate::JoinHandle<()>,
+    _root: EmptyRoot,
 }
 
-impl<W: Worker> WorkerHandle<W>
+impl<W: Component> WorkerHandle<W>
 where
     W::Input: 'static,
     W::Output: 'static,
 {
-    /// Drops the handle and shuts down the service.
-    pub fn abort(self) {
-        self.worker.abort();
-    }
-
     /// Given a mutable closure, captures the receiver for handling.
     pub fn connect_receiver<F: FnMut(&mut Sender<W::Input>, W::Output) + 'static>(
         self,
         mut func: F,
     ) -> WorkerController<W> {
         let WorkerHandle {
-            worker,
             sender,
             receiver,
+            _root,
         } = self;
 
         let mut sender_ = sender.clone();
@@ -101,37 +223,33 @@ where
             }
         });
 
-        WorkerController { worker, sender }
+        WorkerController { sender, _root }
     }
 
     /// Forwards output events to the designated sender.
     pub fn forward<X: 'static, F: (Fn(W::Output) -> X) + 'static>(
         self,
-        sender_: &Sender<X>,
+        sender: &Sender<X>,
         transform: F,
     ) -> WorkerController<W> {
         let WorkerHandle {
-            sender,
+            sender: own_sender,
             receiver,
-            worker,
+            _root,
         } = self;
 
-        crate::spawn_local(receiver.forward(sender_.clone(), transform));
-        WorkerController { sender, worker }
+        crate::spawn_local(receiver.forward(sender.clone(), transform));
+        WorkerController {
+            sender: own_sender,
+            _root,
+        }
     }
 }
 
 /// Sends inputs to a worker. On drop, shuts down the worker.
 #[derive(Debug)]
-pub struct WorkerController<W: Worker> {
+pub struct WorkerController<W: Component> {
     /// Sends inputs to the worker.
     pub sender: Sender<W::Input>,
-
-    worker: crate::JoinHandle<()>,
-}
-
-impl<W: Worker> Drop for WorkerController<W> {
-    fn drop(&mut self) {
-        self.worker.abort();
-    }
+    _root: EmptyRoot,
 }

--- a/relm4/src/worker.rs
+++ b/relm4/src/worker.rs
@@ -246,16 +246,9 @@ where
 
     /// Ignore outputs from the component and take the handle.
     pub fn detach(self) -> WorkerController<W> {
-        let Self {
-            sender,
-            _root,
-            ..
-        } = self;
+        let Self { sender, _root, .. } = self;
 
-        WorkerController {
-            sender,
-            _root,
-        }
+        WorkerController { sender, _root }
     }
 }
 


### PR DESCRIPTION
Changes: 

+ Make workers a subset of `SimpleComponent`
+ For components without widgets and `Send` impls for messages (e. g. `Worker` trait impls), allow running them on their own thread
+ Make workers sync again as async stuff (previously AsyncWorker) is already done much better by using commands

TODO:
- [ ] Collect feedback
- [x] Rename "non_blocking_async" to "worker" and add a new "non_blocking_async" example based on commands
- [x] Clean up the code