### PR TITLE
Factory guard update

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -200,7 +200,7 @@ impl SimpleComponent for AppModel {
     }
 
     fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
-        let mut counters_guard = self.counters.guard().unwrap();
+        let mut counters_guard = self.counters.guard();
         match msg {
             AppMsg::AddCounter => {
                 counters_guard.push_back(self.created_widgets);

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -250,34 +250,35 @@ impl SimpleComponent for AppModel {
     }
 
     fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
+        let mut counters_guard = self.counters.guard();
+
         match msg {
             AppMsg::AddCounter => {
-                self.counters.push_back(self.created_widgets);
+                counters_guard.push_back(self.created_widgets);
                 self.created_widgets = self.created_widgets.wrapping_add(1);
             }
             AppMsg::RemoveCounter => {
-                self.counters.pop_back();
+                counters_guard.pop_back();
             }
             AppMsg::SendFront(index) => {
-                self.counters.move_front(index.current_index());
+                counters_guard.move_front(index.current_index());
             }
             AppMsg::MoveDown(index) => {
                 let index = index.current_index();
                 let new_index = index + 1;
                 // Already at the end?
-                if new_index < self.counters.len() {
-                    self.counters.move_to(index, new_index);
+                if new_index < counters_guard.len() {
+                    counters_guard.move_to(index, new_index);
                 }
             }
             AppMsg::MoveUp(index) => {
                 let index = index.current_index();
                 // Already at the start?
                 if index != 0 {
-                    self.counters.move_to(index, index - 1);
+                    counters_guard.move_to(index, index - 1);
                 }
             }
         }
-        self.counters.render_changes();
     }
 }
 

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -242,41 +242,35 @@ impl SimpleComponent for AppModel {
     }
 
     fn update(&mut self, msg: Self::Input, _sender: &ComponentSender<Self>) {
-        self.counters.apply_external_updates();
+        let mut counters_guard = self.counters.guard();
+
         match msg {
             AppMsg::AddCounter => {
-                self.counters.push_back(self.created_widgets);
+                counters_guard.push_back(self.created_widgets);
                 self.created_widgets = self.created_widgets.wrapping_add(1);
             }
             AppMsg::RemoveCounter => {
-                self.counters.pop_back();
+                counters_guard.pop_back();
             }
             AppMsg::SendFront(index) => {
-                self.counters.move_front(index.current_index());
+                counters_guard.move_front(index.current_index());
             }
             AppMsg::MoveDown(index) => {
                 let index = index.current_index();
                 let new_index = index + 1;
                 // Already at the end?
-                if new_index < self.counters.len() {
-                    self.counters.move_to(index, new_index);
+                if new_index < counters_guard.len() {
+                    counters_guard.move_to(index, new_index);
                 }
             }
             AppMsg::MoveUp(index) => {
                 let index = index.current_index();
                 // Already at the start?
                 if index != 0 {
-                    self.counters.move_to(index, index - 1);
+                    counters_guard.move_to(index, index - 1);
                 }
             }
         }
-        if self.counters.len() > 2 {
-            // Testing different stuff...
-            //self.counters.swap(0, 2);
-            // let mut counter = self.counters.get_mut(1);
-            // counter.value = counter.value.wrapping_add(10);
-        }
-        self.counters.render_changes();
     }
 }
 

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -254,17 +254,21 @@ impl Component for AppModel {
             counters: FactoryVecDeque::new(widgets.tabs.clone(), &sender.input),
             start_index: None,
         };
+
+        let mut counters_guard = model.counters.guard();
         for i in 0..3 {
-            model.counters.push_back(i);
+            counters_guard.push_back(i);
         }
-        model.counters.render_changes();
+
+        // Explicitly drop the guard,
+        // so that 'model' is no longer borrowed
+        // and can be moved inside ComponentParts
+        drop(counters_guard);
 
         ComponentParts { model, widgets }
     }
 
     fn update(&mut self, msg: Self::Input, sender: &ComponentSender<Self>) {
-        self.counters.apply_external_updates();
-
         match msg {
             AppMsg::StartGame(index) => {
                 self.start_index = Some(index);
@@ -289,29 +293,27 @@ impl Component for AppModel {
                 **GAME_STATE.get_mut() = GameState::End(index == self.start_index.take().unwrap());
             }
         }
-        self.counters.render_changes();
     }
 
     fn update_cmd(&mut self, msg: Self::CommandOutput, sender: &ComponentSender<Self>) {
         if msg {
             sender.input(AppMsg::StopGame);
         } else {
-            self.counters.apply_external_updates();
+            let mut counters_guard = self.counters.guard();
             match rand::random::<u8>() % 3 {
                 0 => {
-                    self.counters.swap(1, 2);
+                    counters_guard.swap(1, 2);
                 }
                 1 => {
-                    self.counters.swap(0, 1);
+                    counters_guard.swap(0, 1);
                 }
                 _ => {
-                    let widget = self.counters.widget();
+                    let widget = counters_guard.widget();
                     if !widget.select_next_page() {
                         widget.select_previous_page();
                     }
                 }
             }
-            self.counters.render_changes();
         }
     }
 }

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -61,7 +61,6 @@ where
     Widget: 'static,
 {
     fn drop(&mut self) {
-        self.inner.guarded = false;
         self.inner.render_changes();
     }
 }
@@ -83,7 +82,6 @@ where
     model_state: VecDeque<ModelStateValue>,
     rendered_state: VecDeque<RenderedState>,
     uid_counter: u16,
-    guarded: bool,
 }
 
 impl<Widget, C, ParentMsg> Drop for FactoryVecDeque<Widget, C, ParentMsg>
@@ -142,17 +140,11 @@ where
             rendered_state: VecDeque::new(),
             // 0 is always an invalid uid
             uid_counter: 1,
-            guarded: false,
         }
     }
 
-    pub fn guard<'a>(&'a mut self) -> Option<FactoryVecDequeGuard<'a, Widget, C, ParentMsg>> {
-        if !self.guarded {
-            self.guarded = true;
-            Some(FactoryVecDequeGuard { inner: self })
-        } else {
-            None
-        }
+    pub fn guard(&mut self) -> FactoryVecDequeGuard<'_, Widget, C, ParentMsg> {
+        FactoryVecDequeGuard { inner: self }
     }
 
     /// Updates the widgets according to the changes made to the factory.

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -5,12 +5,14 @@ use crate::factory::{
     FactoryView, Position,
 };
 
+use gtk::prelude::{Cast, IsA};
+
 use super::{ModelStateValue, RenderedState};
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
-use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::ops::{Deref, Index, IndexMut};
 
 #[derive(Debug)]
 pub struct FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
@@ -22,6 +24,291 @@ where
     Widget: 'static,
 {
     inner: &'a mut FactoryVecDeque<Widget, C, ParentMsg>,
+}
+
+impl<'a, Widget, C, ParentMsg> Drop for FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
+where
+    Widget: FactoryView,
+    C: FactoryComponent<Widget, ParentMsg> + Position<Widget::Position>,
+    C::Root: AsRef<Widget::Children>,
+    ParentMsg: 'static,
+    Widget: 'static,
+{
+    fn drop(&mut self) {
+        self.inner.render_changes();
+    }
+}
+
+impl<'a, Widget, C, ParentMsg> FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
+where
+    Widget: FactoryView,
+    C: FactoryComponent<Widget, ParentMsg> + Position<Widget::Position>,
+    C::Root: AsRef<Widget::Children>,
+    ParentMsg: 'static,
+    Widget: 'static,
+{
+    fn new(inner: &'a mut FactoryVecDeque<Widget, C, ParentMsg>) -> Self {
+        let mut guard = FactoryVecDequeGuard { inner };
+
+        #[cfg(feature = "libadwaita")]
+        guard.apply_external_updates();
+
+        guard
+    }
+
+    /// Apply external updates that happened between the last render.
+    ///
+    /// [`FactoryVecDeque`] should not be edited between calling [`Self::render_changes`]
+    /// and this method, as it might cause undefined behaviour. This shouldn't be possible
+    /// because [`FactoryVecDequeGuard`] calls this method on creation.
+    #[cfg(feature = "libadwaita")]
+    fn apply_external_updates(&mut self) {
+        if let Some(tab_view) = self.inner.widget().dynamic_cast_ref::<adw::TabView>() {
+            let length = tab_view.n_pages();
+            let mut hashes: Vec<u64> = Vec::with_capacity(length as usize);
+
+            for i in 0..length {
+                let page = tab_view.nth_page(i);
+                let mut hasher = DefaultHasher::default();
+                page.hash(&mut hasher);
+                hashes.push(hasher.finish());
+            }
+
+            for (index, hash) in hashes.iter().enumerate() {
+                if *hash
+                    != self
+                        .inner
+                        .rendered_state
+                        .get(index)
+                        .map(|state| state.widget_hash)
+                        .unwrap_or_default()
+                {
+                    let old_position = self
+                        .inner
+                        .rendered_state
+                        .iter()
+                        .position(|state| state.widget_hash == *hash)
+                        .expect("A new widget was added");
+
+                    let elem = self.inner.rendered_state.remove(old_position).unwrap();
+                    self.inner.rendered_state.insert(index, elem);
+
+                    self.move_to(old_position, index);
+                }
+            }
+        }
+    }
+
+    /// Tries to get a mutable reference to
+    /// the model of one element.
+    ///
+    /// Returns `None` is `index` is invalid.
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut C> {
+        // Mark as modified
+        if let Some(state) = self.inner.model_state.get_mut(index) {
+            state.changed = true;
+        }
+        self.inner
+            .components
+            .get_mut(index)
+            .map(ComponentStorage::get_mut)
+    }
+
+    /// Provides a mutable reference to the model of the back element.
+    ///
+    /// Returns None if the deque is empty.
+    pub fn back_mut(&mut self) -> Option<&mut C> {
+        self.get_mut(self.len().wrapping_sub(1))
+    }
+
+    /// Provides a mutable reference to the model of the front element.
+    ///
+    /// Returns None if the deque is empty.
+    pub fn front_mut(&mut self) -> Option<&mut C> {
+        self.get_mut(0)
+    }
+
+    /// Removes the last element from the [`FactoryVecDeque`] and returns it,
+    /// or [`None`] if it is empty.
+    pub fn pop_back(&mut self) -> Option<C> {
+        if self.is_empty() {
+            None
+        } else {
+            self.remove(self.len() - 1)
+        }
+    }
+
+    /// Removes the first element from the [`FactoryVecDeque`] and returns it,
+    /// or [`None`] if it is empty.
+    pub fn pop_front(&mut self) -> Option<C> {
+        self.remove(0)
+    }
+
+    /// Removes and returns the element at index from the [`FactoryVecDeque`].
+    /// Returns [`None`] if index is out of bounds.
+    ///
+    /// Element at index 0 is the front of the queue.
+    pub fn remove(&mut self, index: usize) -> Option<C> {
+        self.inner.model_state.remove(index);
+        let component = self.inner.components.remove(index);
+
+        // Decrement the indexes of the following elements.
+        for states in self.inner.model_state.iter_mut().skip(index) {
+            states.index.decrement();
+        }
+
+        if let Some(comp) = &component {
+            if let Some(widget) = &comp.returned_widget() {
+                self.widget.factory_remove(widget);
+            }
+        }
+
+        component.map(ComponentStorage::extract)
+    }
+
+    /// Appends an element at the end of the [`FactoryVecDeque`].
+    pub fn push_back(&mut self, init_params: C::InitParams) {
+        let index = self.len();
+        self.insert(index, init_params);
+    }
+
+    /// Prepends an element to the [`FactoryVecDeque`].
+    pub fn push_front(&mut self, init_params: C::InitParams) {
+        self.insert(0, init_params);
+    }
+
+    /// Inserts an element at index within the [`FactoryVecDeque`],
+    /// shifting all elements with indices greater than or equal
+    /// to index towards the back.
+    ///
+    /// Element at index 0 is the front of the queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index is greater than [`FactoryVecDeque`]’s length.
+    pub fn insert(&mut self, index: usize, init_params: C::InitParams) {
+        let dyn_index = DynamicIndex::new(index);
+
+        // Increment the indexes of the following elements.
+        for states in self.inner.model_state.iter_mut().skip(index) {
+            states.index.increment();
+        }
+
+        let builder = FactoryBuilder::new(&dyn_index, init_params);
+
+        self.inner
+            .components
+            .insert(index, ComponentStorage::Builder(builder));
+        self.inner.model_state.insert(
+            index,
+            ModelStateValue {
+                index: dyn_index,
+                uid: self.uid_counter,
+                changed: false,
+            },
+        );
+        self.inner.uid_counter += 1;
+    }
+
+    /// Swaps elements at indices `first` and `second`.
+    ///
+    /// `first` and `second` may be equal.
+    ///
+    /// Element at index 0 is the front of the queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either index is out of bounds.
+    pub fn swap(&mut self, first: usize, second: usize) {
+        // Don't update anything if both are equal
+        if first != second {
+            self.inner.model_state.swap(first, second);
+            self.inner.components.swap(first, second);
+
+            // Update indexes.
+            self.model_state[first].index.set_value(first);
+            self.model_state[second].index.set_value(second);
+        }
+    }
+
+    /// Moves an element at index `current_position` to `target`,
+    /// shifting all elements between these positions.
+    ///
+    /// `current_position` and `target` may be equal.
+    ///
+    /// Element at index 0 is the front of the queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either index is out of bounds.
+    pub fn move_to(&mut self, current_position: usize, target: usize) {
+        // Don't update anything if both are equal
+        if current_position != target {
+            let elem = self.inner.model_state.remove(current_position).unwrap();
+            // Set new index
+            elem.index.set_value(target);
+            self.inner.model_state.insert(target, elem);
+
+            let comp = self.inner.components.remove(current_position).unwrap();
+            self.inner.components.insert(target, comp);
+
+            // Update indexes.
+            if current_position > target {
+                // Move down -> shift elements in between up.
+                for state in self
+                    .inner
+                    .model_state
+                    .iter_mut()
+                    .skip(target + 1)
+                    .take(current_position - target)
+                {
+                    state.index.increment();
+                }
+            } else {
+                // Move up -> shift elements in between down.
+                for state in self
+                    .inner
+                    .model_state
+                    .iter_mut()
+                    .skip(current_position)
+                    .take(target - current_position)
+                {
+                    state.index.decrement();
+                }
+            }
+        }
+    }
+
+    /// Moves an element at index `current_position` to the front,
+    /// shifting all elements between these positions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index is out of bounds.
+    pub fn move_front(&mut self, current_position: usize) {
+        self.move_to(current_position, 0)
+    }
+
+    /// Moves an element at index `current_position` to the back,
+    /// shifting all elements between these positions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index is out of bounds.
+    pub fn move_back(&mut self, current_position: usize) {
+        self.move_to(current_position, self.len() - 1)
+    }
+
+    /// Remove all components from the [`FactoryVecDeque`].
+    pub fn clear(&mut self) {
+        self.inner.model_state.clear();
+
+        for component in self.inner.components.drain(..) {
+            if let Some(widget) = component.returned_widget() {
+                self.inner.widget.factory_remove(widget);
+            }
+        }
+    }
 }
 
 impl<'a, Widget, C, ParentMsg> Deref for FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
@@ -39,29 +326,28 @@ where
     }
 }
 
-impl<'a, Widget, C, ParentMsg> DerefMut for FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
+impl<'a, Widget, C, ParentMsg> Index<usize> for FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
 where
     Widget: FactoryView,
     C: FactoryComponent<Widget, ParentMsg> + Position<Widget::Position>,
     C::Root: AsRef<Widget::Children>,
-    ParentMsg: 'static,
-    Widget: 'static,
 {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+    type Output = C;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.inner.index(index)
     }
 }
 
-impl<'a, Widget, C, ParentMsg> Drop for FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
+impl<'a, Widget, C, ParentMsg> IndexMut<usize> for FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
 where
     Widget: FactoryView,
     C: FactoryComponent<Widget, ParentMsg> + Position<Widget::Position>,
     C::Root: AsRef<Widget::Children>,
-    ParentMsg: 'static,
-    Widget: 'static,
 {
-    fn drop(&mut self) {
-        self.inner.render_changes();
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.get_mut(index)
+            .expect("Called `get_mut` on an invalid index")
     }
 }
 
@@ -112,18 +398,6 @@ where
     }
 }
 
-impl<Widget, C, ParentMsg> IndexMut<usize> for FactoryVecDeque<Widget, C, ParentMsg>
-where
-    Widget: FactoryView,
-    C: FactoryComponent<Widget, ParentMsg> + Position<Widget::Position>,
-    C::Root: AsRef<Widget::Children>,
-{
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        self.get_mut(index)
-            .expect("Called `get_mut` on an invalid index")
-    }
-}
-
 impl<Widget, C, ParentMsg> FactoryVecDeque<Widget, C, ParentMsg>
 where
     Widget: FactoryView,
@@ -144,7 +418,7 @@ where
     }
 
     pub fn guard(&mut self) -> FactoryVecDequeGuard<'_, Widget, C, ParentMsg> {
-        FactoryVecDequeGuard { inner: self }
+        FactoryVecDequeGuard::new(self)
     }
 
     /// Updates the widgets according to the changes made to the factory.
@@ -155,7 +429,7 @@ where
     /// but won't cause any UI updates.
     ///
     /// Also, only modified elements will be updated.
-    pub fn render_changes(&mut self) {
+    fn render_changes(&mut self) {
         let mut first_position_change_idx = None;
 
         let components = &mut self.components;
@@ -273,20 +547,6 @@ where
         self.components.get(index).map(ComponentStorage::get)
     }
 
-    /// Tries to get a mutable reference to
-    /// the model of one element.
-    ///
-    /// Returns `None` is `index` is invalid.
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut C> {
-        // Mark as modified
-        if let Some(state) = self.model_state.get_mut(index) {
-            state.changed = true;
-        }
-        self.components
-            .get_mut(index)
-            .map(ComponentStorage::get_mut)
-    }
-
     /// Provides a reference to the model of the back element.
     ///
     /// Returns None if the deque is empty.
@@ -301,245 +561,8 @@ where
         self.get(0)
     }
 
-    /// Provides a mutable reference to the model of the back element.
-    ///
-    /// Returns None if the deque is empty.
-    pub fn back_mut(&mut self) -> Option<&mut C> {
-        self.get_mut(self.len().wrapping_sub(1))
-    }
-
-    /// Provides a mutable reference to the model of the front element.
-    ///
-    /// Returns None if the deque is empty.
-    pub fn front_mut(&mut self) -> Option<&mut C> {
-        self.get_mut(0)
-    }
-
-    /// Removes the last element from the [`FactoryVecDeque`] and returns it,
-    /// or [`None`] if it is empty.
-    pub fn pop_back(&mut self) -> Option<C> {
-        if self.is_empty() {
-            None
-        } else {
-            self.remove(self.len() - 1)
-        }
-    }
-
-    /// Removes the first element from the [`FactoryVecDeque`] and returns it,
-    /// or [`None`] if it is empty.
-    pub fn pop_front(&mut self) -> Option<C> {
-        self.remove(0)
-    }
-
-    /// Removes and returns the element at index from the [`FactoryVecDeque`].
-    /// Returns [`None`] if index is out of bounds.
-    ///
-    /// Element at index 0 is the front of the queue.
-    pub fn remove(&mut self, index: usize) -> Option<C> {
-        self.model_state.remove(index);
-        let component = self.components.remove(index);
-
-        // Decrement the indexes of the following elements.
-        for states in self.model_state.iter_mut().skip(index) {
-            states.index.decrement();
-        }
-
-        if let Some(comp) = &component {
-            if let Some(widget) = &comp.returned_widget() {
-                self.widget.factory_remove(widget);
-            }
-        }
-
-        component.map(ComponentStorage::extract)
-    }
-
     /// Returns the widget all components are attached to.
     pub fn widget(&self) -> &Widget {
         &self.widget
-    }
-
-    /// Appends an element at the end of the [`FactoryVecDeque`].
-    pub fn push_back(&mut self, init_params: C::InitParams) {
-        let index = self.len();
-        self.insert(index, init_params);
-    }
-
-    /// Prepends an element to the [`FactoryVecDeque`].
-    pub fn push_front(&mut self, init_params: C::InitParams) {
-        self.insert(0, init_params);
-    }
-
-    /// Inserts an element at index within the [`FactoryVecDeque`],
-    /// shifting all elements with indices greater than or equal
-    /// to index towards the back.
-    ///
-    /// Element at index 0 is the front of the queue.
-    ///
-    /// # Panics
-    ///
-    /// Panics if index is greater than [`FactoryVecDeque`]’s length.
-    pub fn insert(&mut self, index: usize, init_params: C::InitParams) {
-        let dyn_index = DynamicIndex::new(index);
-
-        // Increment the indexes of the following elements.
-        for states in self.model_state.iter_mut().skip(index) {
-            states.index.increment();
-        }
-
-        let builder = FactoryBuilder::new(&dyn_index, init_params);
-
-        self.components
-            .insert(index, ComponentStorage::Builder(builder));
-        self.model_state.insert(
-            index,
-            ModelStateValue {
-                index: dyn_index,
-                uid: self.uid_counter,
-                changed: false,
-            },
-        );
-        self.uid_counter += 1;
-    }
-
-    /// Swaps elements at indices `first` and `second`.
-    ///
-    /// `first` and `second` may be equal.
-    ///
-    /// Element at index 0 is the front of the queue.
-    ///
-    /// # Panics
-    ///
-    /// Panics if either index is out of bounds.
-    pub fn swap(&mut self, first: usize, second: usize) {
-        // Don't update anything if both are equal
-        if first != second {
-            self.model_state.swap(first, second);
-            self.components.swap(first, second);
-
-            // Update indexes.
-            self.model_state[first].index.set_value(first);
-            self.model_state[second].index.set_value(second);
-        }
-    }
-
-    /// Moves an element at index `current_position` to `target`,
-    /// shifting all elements between these positions.
-    ///
-    /// `current_position` and `target` may be equal.
-    ///
-    /// Element at index 0 is the front of the queue.
-    ///
-    /// # Panics
-    ///
-    /// Panics if either index is out of bounds.
-    pub fn move_to(&mut self, current_position: usize, target: usize) {
-        // Don't update anything if both are equal
-        if current_position != target {
-            let elem = self.model_state.remove(current_position).unwrap();
-            // Set new index
-            elem.index.set_value(target);
-            self.model_state.insert(target, elem);
-
-            let comp = self.components.remove(current_position).unwrap();
-            self.components.insert(target, comp);
-
-            // Update indexes.
-            if current_position > target {
-                // Move down -> shift elements in between up.
-                for state in self
-                    .model_state
-                    .iter_mut()
-                    .skip(target + 1)
-                    .take(current_position - target)
-                {
-                    state.index.increment();
-                }
-            } else {
-                // Move up -> shift elements in between down.
-                for state in self
-                    .model_state
-                    .iter_mut()
-                    .skip(current_position)
-                    .take(target - current_position)
-                {
-                    state.index.decrement();
-                }
-            }
-        }
-    }
-
-    /// Moves an element at index `current_position` to the front,
-    /// shifting all elements between these positions.
-    ///
-    /// # Panics
-    ///
-    /// Panics if index is out of bounds.
-    pub fn move_front(&mut self, current_position: usize) {
-        self.move_to(current_position, 0)
-    }
-
-    /// Moves an element at index `current_position` to the back,
-    /// shifting all elements between these positions.
-    ///
-    /// # Panics
-    ///
-    /// Panics if index is out of bounds.
-    pub fn move_back(&mut self, current_position: usize) {
-        self.move_to(current_position, self.len() - 1)
-    }
-
-    /// Remove all components from the [`FactoryVecDeque`].
-    pub fn clear(&mut self) {
-        self.model_state.clear();
-
-        for component in self.components.drain(..) {
-            if let Some(widget) = component.returned_widget() {
-                self.widget.factory_remove(widget);
-            }
-        }
-    }
-}
-
-#[cfg(feature = "libadwaita")]
-impl<C, ParentMsg> FactoryVecDeque<adw::TabView, C, ParentMsg>
-where
-    C: FactoryComponent<adw::TabView, ParentMsg> + Position<()>,
-    C::Root: AsRef<gtk::Widget>,
-{
-    /// Apply external updates that happened between the last render.
-    ///
-    /// **YOU MUST NOT EDIT THE [`FactoryVecDeque`] BETWEEN CALLING
-    /// [`Self::render_changes`] AND THIS METHOD. THIS MIGHT CAUSE UNDEFINED BEHAVIOR.
-    pub fn apply_external_updates(&mut self) {
-        let length = self.widget().n_pages();
-        let mut hashes: Vec<u64> = Vec::with_capacity(length as usize);
-
-        for i in 0..length {
-            let page = self.widget.nth_page(i);
-            let mut hasher = DefaultHasher::default();
-            page.hash(&mut hasher);
-            hashes.push(hasher.finish());
-        }
-
-        for (index, hash) in hashes.iter().enumerate() {
-            if *hash
-                != self
-                    .rendered_state
-                    .get(index)
-                    .map(|state| state.widget_hash)
-                    .unwrap_or_default()
-            {
-                let old_position = self
-                    .rendered_state
-                    .iter()
-                    .position(|state| state.widget_hash == *hash)
-                    .expect("A new widget was added");
-
-                let elem = self.rendered_state.remove(old_position).unwrap();
-                self.rendered_state.insert(index, elem);
-
-                self.move_to(old_position, index);
-            }
-        }
     }
 }

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -5,7 +5,7 @@ use crate::factory::{
     FactoryView, Position,
 };
 
-use gtk::prelude::{Cast, IsA};
+use gtk::prelude::Cast;
 
 use super::{ModelStateValue, RenderedState};
 

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -14,6 +14,9 @@ use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, Index, IndexMut};
 
+/// Provides methods to edit the underlying [`FactoryVecDeque`].
+///
+/// The changes will be rendered on the widgets after the guard goes out of scope.
 #[derive(Debug)]
 pub struct FactoryVecDequeGuard<'a, Widget, C, ParentMsg>
 where
@@ -353,6 +356,8 @@ where
 
 /// A container similar to [`VecDeque`] that can be used to store
 /// data associated with components that implement [`FactoryComponent`].
+///
+/// To access mutable methods of the factory, create a guard using [`Self::guard`].
 #[derive(Debug)]
 pub struct FactoryVecDeque<Widget, C, ParentMsg>
 where
@@ -417,6 +422,9 @@ where
         }
     }
 
+    /// Provides a [`FactoryVecDequeGuard`] that can be used to edit the factory.
+    ///
+    /// The changes will be rendered on the widgets after the guard goes out of scope.
     pub fn guard(&mut self) -> FactoryVecDequeGuard<'_, Widget, C, ParentMsg> {
         FactoryVecDequeGuard::new(self)
     }
@@ -539,11 +547,6 @@ where
     ///
     /// Returns `None` is `index` is invalid.
     pub fn get(&self, index: usize) -> Option<&C> {
-        // Safety: This is safe because ownership is tracked by each
-        // component individually, an therefore violating ownership
-        // rules is impossible.
-        // The safe version struggles with lifetime, maybe this can
-        // be fixed soon.
         self.components.get(index).map(ComponentStorage::get)
     }
 

--- a/relm4/src/factory/data_guard.rs
+++ b/relm4/src/factory/data_guard.rs
@@ -131,7 +131,7 @@ mod test {
         let main_ctx = MainContext::default();
 
         let (data, rt) = DataGuard::new(data, |mut rt_data| async move {
-            while let Ok(_) = rx.recv_async().await {
+            while (rx.recv_async().await).is_ok() {
                 rt_data.add();
             }
         });
@@ -169,7 +169,7 @@ mod test {
         let main_ctx = MainContext::default();
 
         let (data, rt) = DataGuard::new(data, |mut rt_data| async move {
-            while let Ok(_) = rx.recv_async().await {
+            while (rx.recv_async().await).is_ok() {
                 rt_data.add();
             }
         });

--- a/relm4/src/factory/data_guard.rs
+++ b/relm4/src/factory/data_guard.rs
@@ -123,7 +123,7 @@ mod test {
         let _data = Box::new(DontDropBelow4(0_u8));
     }
 
-    #[test]
+    #[gtk::test]
     fn test_data_guard_drop() {
         let data = Box::new(DontDropBelow4(0_u8));
         let (tx, rx) = flume::unbounded();
@@ -161,7 +161,7 @@ mod test {
         main_ctx.iteration(false);
     }
 
-    #[test]
+    #[gtk::test]
     fn test_data_guard_rt_kill() {
         let data = Box::new(DontDropBelow4(0_u8));
         let (tx, rx) = flume::unbounded();

--- a/relm4/src/factory/data_guard.rs
+++ b/relm4/src/factory/data_guard.rs
@@ -35,7 +35,7 @@ impl<Data: std::fmt::Debug> DataGuard<Data> {
         //    was dropped. The second reference can then safely behave like a normal `Box<C>`.
         //
         // Unsoundness only occurs when data that was moved into the runtime is moved out on
-        // purpose. This would allow the first reference to outlive the first one, becoming
+        // purpose. This would allow the first reference to outlive the second one, becoming
         // a dangling pointer.
         let (data, model_data) = unsafe {
             let raw = Box::into_raw(data);

--- a/relm4/src/factory/traits.rs
+++ b/relm4/src/factory/traits.rs
@@ -1,12 +1,14 @@
 //! Traits for for managing and updating factories.
 
+use gtk::prelude::IsA;
+
 use super::DynamicIndex;
 use crate::{component::CommandFuture, OnDestroy, Sender, ShutdownReceiver};
 
 use std::fmt::Debug;
 
 /// A trait implemented for GTK4 widgets that allows a factory to create and remove widgets.
-pub trait FactoryView {
+pub trait FactoryView: IsA<gtk::Widget> {
     /// The widget returned when inserting a widget.
     ///
     /// This doesn't matter on containers like [`gtk::Box`].


### PR DESCRIPTION
- Mutable methods are now accessible only through `FactoryVecDequeGuard`. All changes to the factory are rendered when the guard is dropped.
- Simplify `guard` method. Now returns a guard directly instead of wrapping it inside an `Option`. There was no need to check if the guard was already created because that is handled compile-time by rust borrowing rules.
- `apply_external_changes` is now also called automatically when `FactoryVecDequeGuard` is created, so there should be no way for it to cause undefined behaviour. I also fixed a bug in which it the method won't recognize in some tabs if `adw::TabView` were closed.
- Adjust examples
- Add basic documentation

I believe this approach is a lot better than the current one. My only concern is that I had to explicitly drop the guard in `tab_game` example, which was a little unintuitive, I wonder how could we fix that.