### PR TITLE
Do not use generics in `FactoryComponent`

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -1,6 +1,6 @@
 use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt};
 use relm4::factory::{DynamicIndex, FactoryComponent, FactoryComponentSender, FactoryVecDeque};
-use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, Sender, SimpleComponent, WidgetPlus};
+use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
 
 #[derive(Debug)]
 struct Counter {
@@ -21,7 +21,9 @@ enum CounterOutput {
 }
 
 #[relm4::factory]
-impl FactoryComponent<gtk::Box, AppMsg> for Counter {
+impl FactoryComponent for Counter {
+    type ParentWidget = gtk::Box;
+    type ParentMsg = AppMsg;
     type CommandOutput = ();
     type InitParams = u8;
     type Input = CounterMsg;
@@ -92,16 +94,12 @@ impl FactoryComponent<gtk::Box, AppMsg> for Counter {
     fn init_model(
         value: Self::InitParams,
         _index: &DynamicIndex,
-        _sender: &FactoryComponentSender<gtk::Box, AppMsg, Self>,
+        _sender: &FactoryComponentSender<Self>,
     ) -> Self {
         Self { value }
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        _sender: &FactoryComponentSender<gtk::Box, AppMsg, Self>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &FactoryComponentSender<Self>) {
         match msg {
             CounterMsg::Increment => {
                 self.value = self.value.wrapping_add(1);
@@ -119,7 +117,7 @@ impl FactoryComponent<gtk::Box, AppMsg> for Counter {
 
 struct AppModel {
     created_widgets: u8,
-    counters: FactoryVecDeque<gtk::Box, Counter, AppMsg>,
+    counters: FactoryVecDeque<Counter>,
 }
 
 #[derive(Debug)]

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -3,7 +3,7 @@ use relm4::factory::positions::GridPosition;
 use relm4::factory::{
     DynamicIndex, FactoryComponent, FactoryComponentSender, FactoryVecDeque, Position,
 };
-use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, Sender, SimpleComponent, WidgetPlus};
+use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
 
 #[derive(Debug)]
 struct Counter {
@@ -40,7 +40,9 @@ impl Position<GridPosition> for Counter {
     }
 }
 
-impl FactoryComponent<gtk::Grid, AppMsg> for Counter {
+impl FactoryComponent for Counter {
+    type ParentWidget = gtk::Grid;
+    type ParentMsg = AppMsg;
     type CommandOutput = ();
     type InitParams = u8;
     type Input = CounterMsg;
@@ -69,7 +71,7 @@ impl FactoryComponent<gtk::Grid, AppMsg> for Counter {
     fn init_model(
         value: Self::InitParams,
         _index: &DynamicIndex,
-        _sender: &FactoryComponentSender<gtk::Grid, AppMsg, Self>,
+        _sender: &FactoryComponentSender<Self>,
     ) -> Self {
         Self { value }
     }
@@ -79,7 +81,7 @@ impl FactoryComponent<gtk::Grid, AppMsg> for Counter {
         index: &DynamicIndex,
         root: &Self::Root,
         _returned_widget: &gtk::Widget,
-        sender: &FactoryComponentSender<gtk::Grid, AppMsg, Self>,
+        sender: &FactoryComponentSender<Self>,
     ) -> Self::Widgets {
         relm4::view! {
             label = gtk::Label {
@@ -143,11 +145,7 @@ impl FactoryComponent<gtk::Grid, AppMsg> for Counter {
         CounterWidgets { label }
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        _sender: &FactoryComponentSender<gtk::Grid, AppMsg, Self>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &FactoryComponentSender<Self>) {
         match msg {
             CounterMsg::Increment => {
                 self.value = self.value.wrapping_add(1);
@@ -158,18 +156,14 @@ impl FactoryComponent<gtk::Grid, AppMsg> for Counter {
         }
     }
 
-    fn update_view(
-        &self,
-        widgets: &mut Self::Widgets,
-        _sender: &FactoryComponentSender<gtk::Grid, AppMsg, Self>,
-    ) {
+    fn update_view(&self, widgets: &mut Self::Widgets, _sender: &FactoryComponentSender<Self>) {
         widgets.label.set_label(&self.value.to_string());
     }
 }
 
 struct AppModel {
     created_widgets: u8,
-    counters: FactoryVecDeque<gtk::Grid, Counter, AppMsg>,
+    counters: FactoryVecDeque<Counter>,
 }
 
 #[derive(Debug)]

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -27,7 +27,10 @@ struct CounterWidgets {
     label: gtk::Label,
 }
 
-impl FactoryComponent<adw::TabView, AppMsg> for Counter {
+impl FactoryComponent for Counter {
+    type ParentWidget = adw::TabView;
+    type ParentMsg = AppMsg;
+
     type Widgets = CounterWidgets;
 
     type InitParams = u8;
@@ -59,7 +62,7 @@ impl FactoryComponent<adw::TabView, AppMsg> for Counter {
     fn init_model(
         value: Self::InitParams,
         _index: &DynamicIndex,
-        _sender: &FactoryComponentSender<adw::TabView, AppMsg, Self>,
+        _sender: &FactoryComponentSender<Self>,
     ) -> Self {
         Self { value }
     }
@@ -69,7 +72,7 @@ impl FactoryComponent<adw::TabView, AppMsg> for Counter {
         index: &DynamicIndex,
         root: &Self::Root,
         returned_widget: &adw::TabPage,
-        sender: &FactoryComponentSender<adw::TabView, AppMsg, Self>,
+        sender: &FactoryComponentSender<Self>,
     ) -> Self::Widgets {
         relm4::view! {
             label = gtk::Label {
@@ -135,11 +138,7 @@ impl FactoryComponent<adw::TabView, AppMsg> for Counter {
         CounterWidgets { label }
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        _sender: &FactoryComponentSender<adw::TabView, AppMsg, Self>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &FactoryComponentSender<Self>) {
         match msg {
             CounterMsg::Increment => {
                 self.value = self.value.wrapping_add(1);
@@ -150,18 +149,14 @@ impl FactoryComponent<adw::TabView, AppMsg> for Counter {
         }
     }
 
-    fn update_view(
-        &self,
-        widgets: &mut Self::Widgets,
-        _sender: &FactoryComponentSender<adw::TabView, AppMsg, Self>,
-    ) {
+    fn update_view(&self, widgets: &mut Self::Widgets, _sender: &FactoryComponentSender<Self>) {
         widgets.label.set_label(&self.value.to_string());
     }
 }
 
 struct AppModel {
     created_widgets: u8,
-    counters: FactoryVecDeque<adw::TabView, Counter, AppMsg>,
+    counters: FactoryVecDeque<Counter>,
 }
 
 #[derive(Debug)]

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -4,7 +4,7 @@ use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt, WidgetExt};
 use relm4::{
     adw,
     factory::{DynamicIndex, FactoryComponent, FactoryComponentSender, FactoryVecDeque},
-    gtk, Component, ComponentParts, ComponentSender, RelmApp, Sender, SharedState, WidgetPlus,
+    gtk, Component, ComponentParts, ComponentSender, RelmApp, SharedState, WidgetPlus,
 };
 
 enum GameState {
@@ -40,7 +40,10 @@ enum CounterOutput {
 }
 
 #[relm4::factory]
-impl FactoryComponent<adw::TabView, AppMsg> for GamePage {
+impl FactoryComponent for GamePage {
+    type ParentWidget = adw::TabView;
+    type ParentMsg = AppMsg;
+
     type Widgets = CounterWidgets;
 
     type InitParams = u8;
@@ -155,7 +158,7 @@ impl FactoryComponent<adw::TabView, AppMsg> for GamePage {
     fn init_model(
         value: Self::InitParams,
         _index: &DynamicIndex,
-        sender: &FactoryComponentSender<adw::TabView, AppMsg, Self>,
+        sender: &FactoryComponentSender<Self>,
     ) -> Self {
         GAME_STATE.subscribe(&sender.input, |_| CounterMsg::Update);
         Self { id: value }
@@ -166,7 +169,7 @@ impl FactoryComponent<adw::TabView, AppMsg> for GamePage {
         index: &DynamicIndex,
         root: &Self::Root,
         returned_widget: &adw::TabPage,
-        sender: &FactoryComponentSender<adw::TabView, AppMsg, Self>,
+        sender: &FactoryComponentSender<Self>,
     ) -> Self::Widgets {
         let state = GAME_STATE.get();
         let widgets = view_output!();
@@ -177,11 +180,7 @@ impl FactoryComponent<adw::TabView, AppMsg> for GamePage {
         let state = GAME_STATE.get();
     }
 
-    fn update(
-        &mut self,
-        msg: Self::Input,
-        sender: &FactoryComponentSender<adw::TabView, AppMsg, Self>,
-    ) {
+    fn update(&mut self, msg: Self::Input, _sender: &FactoryComponentSender<Self>) {
         match msg {
             CounterMsg::Update => (),
         }
@@ -189,7 +188,7 @@ impl FactoryComponent<adw::TabView, AppMsg> for GamePage {
 }
 
 struct AppModel {
-    counters: FactoryVecDeque<adw::TabView, GamePage, AppMsg>,
+    counters: FactoryVecDeque<GamePage>,
     start_index: Option<DynamicIndex>,
 }
 

--- a/relm4-macros/src/factory/inject_view_code.rs
+++ b/relm4-macros/src/factory/inject_view_code.rs
@@ -8,11 +8,7 @@ pub(super) fn inject_view_code(
     func: Option<ImplItemMethod>,
     view_code: TokenStream2,
     widgets_return_code: TokenStream2,
-    container_widget: &GenericArgument,
-    parent_msg: &GenericArgument,
 ) -> TokenStream2 {
-    let container_widget_tokens = container_widget.to_token_stream();
-
     if let Some(func) = func {
         match component::inject_view_code::inject_view_code(func, view_code, widgets_return_code) {
             Ok(func) => func.to_token_stream(),
@@ -24,8 +20,8 @@ pub(super) fn inject_view_code(
                 &mut self,
                 index: &relm4::factory::DynamicIndex,
                 root: &Self::Root,
-                returned_widget: &<#container_widget_tokens as relm4::factory::FactoryView>::ReturnedWidget,
-                sender: &relm4::factory::FactoryComponentSender<#container_widget, #parent_msg, Self>,
+                returned_widget: &<Self::ParentWidget as relm4::factory::FactoryView>::ReturnedWidget,
+                sender: &relm4::factory::FactoryComponentSender<Self>,
             ) -> Self::Widgets {
                 #view_code
                 #widgets_return_code

--- a/relm4-macros/src/factory/mod.rs
+++ b/relm4-macros/src/factory/mod.rs
@@ -134,28 +134,7 @@ pub(crate) fn generate_tokens(
         }
     };
 
-    let last_segment = trait_.segments.last().unwrap();
-
-    let (container_widget, parent_msg) = {
-        let mut args = match &last_segment.arguments {
-            syn::PathArguments::AngleBracketed(args) => Some(args.args.clone()),
-            _ => None,
-        }
-        .unwrap_or_default()
-        .into_iter();
-        (
-            args.next().unwrap_or_else(|| syn::parse_quote!(())),
-            args.next().unwrap_or_else(|| syn::parse_quote!(())),
-        )
-    };
-
-    let init_injected = inject_view_code(
-        init_widgets,
-        view_code,
-        widgets_return_code,
-        &container_widget,
-        &parent_msg,
-    );
+    let init_injected = inject_view_code(init_widgets, view_code, widgets_return_code);
 
     quote! {
         #[allow(dead_code)]
@@ -182,7 +161,7 @@ pub(crate) fn generate_tokens(
             fn update_view(
                 &self,
                 widgets: &mut Self::Widgets,
-                sender: &relm4::factory::FactoryComponentSender<#container_widget, #parent_msg, Self>,
+                sender: &relm4::factory::FactoryComponentSender<Self>,
             ) {
                 #[allow(unused_variables)]
                 let Self::Widgets {

--- a/relm4/src/factory/handle.rs
+++ b/relm4/src/factory/handle.rs
@@ -11,30 +11,15 @@ use crate::Sender;
 /// It might be unsafe to extract `data` or `runtime`.
 /// Inside this type, it is guaranteed that extracting `data` will drop `runtime` before to
 /// comply with all required safety guarantees.
-pub(super) struct FactoryHandle<Widget, C: FactoryComponent<Widget, ParentMsg>, ParentMsg>
-where
-    Widget: FactoryView,
-    C: FactoryComponent<Widget, ParentMsg>,
-{
+pub(super) struct FactoryHandle<C: FactoryComponent> {
     pub(super) data: DataGuard<C>,
     pub(super) root_widget: C::Root,
-    pub(super) returned_widget: Widget::ReturnedWidget,
+    pub(super) returned_widget: <C::ParentWidget as FactoryView>::ReturnedWidget,
     pub(super) input: Sender<C::Input>,
     pub(super) notifier: Sender<()>,
 }
 
-impl<Widget, C, ParentMsg> FactoryHandle<Widget, C, ParentMsg>
-where
-    Widget: FactoryView,
-    C: FactoryComponent<Widget, ParentMsg>,
-{
-}
-
-impl<Widget, C, ParentMsg> fmt::Debug for FactoryHandle<Widget, C, ParentMsg>
-where
-    Widget: FactoryView,
-    C: FactoryComponent<Widget, ParentMsg>,
-{
+impl<C: FactoryComponent> fmt::Debug for FactoryHandle<C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FactoryHandle")
             .field("data", &self.data)

--- a/relm4/src/factory/mod.rs
+++ b/relm4/src/factory/mod.rs
@@ -23,10 +23,10 @@ pub use traits::*;
 use crate::component::ComponentSenderInner;
 
 /// Contain senders used by the factory component.
-pub type FactoryComponentSender<ParentWidget, ParentMsg, C> = Arc<
+pub type FactoryComponentSender<C> = Arc<
     ComponentSenderInner<
-        <C as FactoryComponent<ParentWidget, ParentMsg>>::Input,
-        <C as FactoryComponent<ParentWidget, ParentMsg>>::Output,
-        <C as FactoryComponent<ParentWidget, ParentMsg>>::CommandOutput,
+        <C as FactoryComponent>::Input,
+        <C as FactoryComponent>::Output,
+        <C as FactoryComponent>::CommandOutput,
     >,
 >;


### PR DESCRIPTION
`FactoryComponent` uses generics to define `ParentWidget` and `ParentMsg`. This way, a single type can have multiple component implementations for different container types. But it comes with a tradeoff: generic arguments must be specified for most factory types. For example, `FactoryVecDeque<gtk::Box, Counter, AppMsg>` or `FactoryComponentSender<gtk::Box, AppMsg, Self>`.

This PR replaces generics with associated types, removing the need to specify generic arguments: `FactoryVecDeque<Counter>`, `FactoryComponentSender<Self>`.

It would still be possible to provide multiple implementations, if the type that implements `FactoryComponent` is itself generic.