### PR TITLE
Port tracker and to_do examples to 0.5

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ relm4 = { path = "../relm4", features = ["macros"] }
 #relm4-components = { path = "../relm4-components" }
 tokio = { version = "1.15", features = ["rt", "macros", "time", "rt-multi-thread"] }
 futures = "0.3.19"
+rand = "0.8.5"
 tracker = "0.1"
 
 # log example
@@ -62,3 +63,7 @@ path = "log.rs"
 [[example]]
 name = "worker"
 path = "worker.rs"
+
+[[example]]
+name = "tracker"
+path = "tracker.rs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -67,3 +67,7 @@ path = "worker.rs"
 [[example]]
 name = "tracker"
 path = "tracker.rs"
+
+[[example]]
+name = "to_do"
+path = "to_do.rs"

--- a/examples/to_do.rs
+++ b/examples/to_do.rs
@@ -1,0 +1,162 @@
+use gtk::prelude::*;
+use relm4::factory::{DynamicIndex, FactoryComponent, FactoryComponentSender, FactoryVecDeque};
+use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
+
+#[derive(Debug)]
+struct Task {
+    name: String,
+    completed: bool,
+}
+
+#[derive(Debug)]
+enum TaskInput {
+    Toggle(bool),
+}
+
+#[derive(Debug)]
+enum TaskOutput {
+    Delete(DynamicIndex),
+}
+
+#[relm4::factory]
+impl FactoryComponent for Task {
+    type Widgets = TaskWidgets;
+    type ParentWidget = gtk::ListBox;
+    type ParentMsg = AppMsg;
+
+    type InitParams = String;
+
+    type Input = TaskInput;
+    type Output = TaskOutput;
+
+    type CommandOutput = ();
+
+    view! {
+        gtk::Box {
+            set_orientation: gtk::Orientation::Horizontal,
+
+            gtk::CheckButton {
+                set_active: false,
+                set_margin_all: 12,
+                connect_toggled[sender] => move |checkbox| {
+                    sender.input(TaskInput::Toggle(checkbox.is_active()));
+                }
+            },
+
+            #[name = "label"]
+            gtk::Label {
+                set_label: &self.name,
+                set_hexpand: true,
+                set_halign: gtk::Align::Start,
+                set_margin_all: 12,
+            },
+
+            gtk::Button {
+                set_icon_name: "edit-delete",
+                set_margin_all: 12,
+
+                connect_clicked[sender, index] => move |_| {
+                    sender.output(TaskOutput::Delete(index.clone()));
+                }
+            }
+        }
+    }
+
+    fn pre_view() {
+        let attrs = widgets.label.attributes().unwrap_or_default();
+        attrs.change(gtk::pango::AttrInt::new_strikethrough(self.completed));
+        widgets.label.set_attributes(Some(&attrs));
+    }
+
+    fn output_to_parent_msg(output: Self::Output) -> Option<AppMsg> {
+        Some(match output {
+            TaskOutput::Delete(index) => AppMsg::DeleteEntry(index),
+        })
+    }
+
+    fn init_model(
+        name: Self::InitParams,
+        _index: &DynamicIndex,
+        _sender: &FactoryComponentSender<Self>,
+    ) -> Self {
+        Self {
+            name,
+            completed: false,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AppMsg {
+    DeleteEntry(DynamicIndex),
+    AddEntry(String),
+}
+
+struct AppModel {
+    tasks: FactoryVecDeque<Task>,
+}
+
+#[relm4::component]
+impl SimpleComponent for AppModel {
+    type Input = AppMsg;
+    type Output = ();
+    type Widgets = AppWidgets;
+    type InitParams = ();
+
+    view! {
+        main_window = gtk::ApplicationWindow {
+            set_width_request: 360,
+            set_title: Some("To-Do"),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_margin_all: 12,
+                set_spacing: 6,
+
+                gtk::Entry {
+                    connect_activate[sender] => move |entry| {
+                        let buffer = entry.buffer();
+                        sender.input(AppMsg::AddEntry(buffer.text()));
+                        buffer.delete_text(0, None);
+                    }
+                },
+
+                gtk::ScrolledWindow {
+                    set_hscrollbar_policy: gtk::PolicyType::Never,
+                    set_min_content_height: 360,
+                    set_vexpand: true,
+
+                    #[name = "tasks"]
+                    gtk::ListBox {}
+                }
+            }
+
+        }
+    }
+
+    fn update(&mut self, msg: AppMsg, _sender: &ComponentSender<Self>) {
+        match msg {
+            AppMsg::DeleteEntry(index) => {
+                self.tasks.guard().remove(index.current_index());
+            }
+            AppMsg::AddEntry(name) => {
+                self.tasks.guard().push_back(name);
+            }
+        }
+    }
+
+    fn init(_param: (), root: &Self::Root, sender: &ComponentSender<Self>) -> ComponentParts<Self> {
+        let widgets = view_output!();
+
+        let model = AppModel {
+            tasks: FactoryVecDeque::new(widgets.tasks.clone(), &sender.input),
+        };
+
+        ComponentParts { model, widgets }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.to_do");
+    app.run::<AppModel>(());
+}

--- a/examples/tracker.rs
+++ b/examples/tracker.rs
@@ -1,0 +1,130 @@
+use gtk::prelude::{BoxExt, ButtonExt, OrientableExt};
+use rand::prelude::IteratorRandom;
+use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
+
+const ICON_LIST: &[&str] = &[
+    "bookmark-new-symbolic",
+    "edit-copy-symbolic",
+    "edit-cut-symbolic",
+    "edit-find-symbolic",
+    "starred-symbolic",
+    "system-run-symbolic",
+    "emoji-objects-symbolic",
+    "emoji-nature-symbolic",
+    "display-brightness-symbolic",
+];
+
+fn random_icon_name() -> &'static str {
+    ICON_LIST
+        .iter()
+        .choose(&mut rand::thread_rng())
+        .expect("Could not choose a random icon")
+}
+
+#[derive(Debug)]
+enum AppMsg {
+    UpdateFirst,
+    UpdateSecond,
+}
+
+// The track proc macro allows to easily track changes to different
+// fields of the model
+#[tracker::track]
+struct AppModel {
+    first_icon: &'static str,
+    second_icon: &'static str,
+    identical: bool,
+}
+
+#[relm4::component]
+impl SimpleComponent for AppModel {
+    type InitParams = ();
+    type Input = AppMsg;
+    type Output = ();
+    type Widgets = AppWidgets;
+
+    view! {
+        gtk::Window {
+            #[track(model.changed(AppModel::identical()))]
+            set_class_active: ("identical", model.identical),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Horizontal,
+                set_spacing: 10,
+                set_margin_all: 10,
+
+                gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                    set_spacing: 10,
+
+                    gtk::Image {
+                        set_pixel_size: 50,
+                        #[track(model.changed(AppModel::first_icon()))]
+                        set_icon_name: Some(model.first_icon),
+                    },
+
+                    gtk::Button {
+                        set_label: "New random image",
+                        connect_clicked[sender] => move |_| {
+                            sender.input(AppMsg::UpdateFirst);
+                        }
+                    }
+                },
+
+                gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                    set_spacing: 10,
+
+                    gtk::Image {
+                        set_pixel_size: 50,
+                        #[track(model.changed(AppModel::second_icon()))]
+                        set_icon_name: Some(model.second_icon),
+                    },
+
+                    gtk::Button {
+                        set_label: "New random image",
+                        connect_clicked[sender] => move |_| {
+                            sender.input(AppMsg::UpdateSecond);
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    fn update(&mut self, msg: AppMsg, _sender: ComponentSender<Self>) {
+        // reset tracker value of the model
+        self.reset();
+
+        match msg {
+            AppMsg::UpdateFirst => {
+                self.set_first_icon(random_icon_name());
+            }
+            AppMsg::UpdateSecond => {
+                self.set_second_icon(random_icon_name());
+            }
+        }
+        self.set_identical(self.first_icon == self.second_icon);
+    }
+
+    fn init(_param: (), root: &Self::Root, sender: ComponentSender<Self>) -> ComponentParts<Self> {
+        let model = AppModel {
+            first_icon: random_icon_name(),
+            second_icon: random_icon_name(),
+            identical: false,
+            tracker: 0,
+        };
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.tracker");
+
+    relm4::set_global_css(b".identical { background: #00ad5c; }");
+
+    app.run::<AppModel>(());
+}


### PR DESCRIPTION
cc #100 

This PR also adds a delete button to the to_do example, which helps demonstrate internal communication in the factory component versus communication with the parent.