### PR TITLE
Make commands use FnOnce

### DIFF
--- a/relm4/src/component/sender.rs
+++ b/relm4/src/component/sender.rs
@@ -35,7 +35,7 @@ impl<Input, Output, CommandOutput: Send + 'static>
     /// Spawn a command managed by the lifetime of the component.
     pub fn command<Cmd, Fut>(&self, cmd: Cmd)
     where
-        Cmd: (Fn(Sender<CommandOutput>, ShutdownReceiver) -> Fut) + Send + Sync + 'static,
+        Cmd: (FnOnce(Sender<CommandOutput>, ShutdownReceiver) -> Fut) + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send,
     {
         let recipient = self.shutdown.clone();


### PR DESCRIPTION
Makes `sender.command()` take `FnOnce` to avoid issues with moving values. Often you want to move a value into the closures and then into the async block, but that doesn't work with `Fn` because it might be called multiple times.

Example:

```rust
// Make sure password is owned to move it into the async block
let password = self.password.clone();
sender.command(move |out, shutdown| {
    shutdown.register(async move {
        // Only works after the patch because Fn might be called multiple times.
        use_password(password).await;
    }).drop_on_shutdown()
});
```

@mmstick can you review since you wrote this part of the code originally?