### PR TITLE
Add getter for global application

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Add getter for global application for easier quitting of applications
 + core: Add MessageBroker type to allow communication between components on different levels
 + core: Rename InitParams to Init in SimpleComponent and Worker too
 + macros: Fix returned widgets assignment in the view macro

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -8,11 +8,8 @@ use crate::ComponentBuilder;
 /// An app that runs the main application.
 #[derive(Debug)]
 pub struct RelmApp {
-    /// The application that's used internally to setup
-    /// and run the application.
-    ///
-    /// Depending on your feature flag this is either
-    /// [`gtk::Application`] or [`adw::Application`].
+    /// The [`Application`] that's used internally to setup
+    /// and run your application.
     pub app: Application,
 }
 
@@ -20,19 +17,20 @@ impl RelmApp {
     /// Create a Relm4 application.
     #[must_use]
     pub fn new(app_id: &str) -> Self {
-        let app = Application::builder().application_id(app_id).build();
+        crate::init();
 
-        Self::with_app(app)
+        let app = crate::main_application();
+        app.set_application_id(Some(app_id));
+
+        Self { app }
     }
 
     /// Create a Relm4 application.
     pub fn with_app(app: impl IsA<Application> + Cast) -> Self {
-        gtk::init().unwrap();
-
-        #[cfg(feature = "libadwaita")]
-        adw::init();
+        crate::init();
 
         let app = app.upcast();
+        crate::set_main_application(app.clone());
 
         Self { app }
     }

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -52,6 +52,7 @@ pub use tokio::task::JoinHandle;
 pub use util::{WidgetPlus, WidgetRef};
 
 use once_cell::sync::OnceCell;
+use std::cell::Cell;
 use std::future::Future;
 use tokio::runtime::Runtime;
 
@@ -81,12 +82,53 @@ pub use adw;
 pub use panel;
 
 #[cfg(feature = "libadwaita")]
-type Application = adw::Application;
+/// The application type used by [`RelmApp`] internally.
+///
+/// This is either [`gtk::Application`] or [`adw::Application`]
+/// depending on the feature flags.
+pub type Application = adw::Application;
 
 #[cfg(not(feature = "libadwaita"))]
-type Application = gtk::Application;
+/// The application type used by [`RelmApp`] internally.
+///
+/// This is either [`gtk::Application`] or `adw::Application`
+/// depending on the feature flags.
+pub type Application = gtk::Application;
 
+pub use once_cell;
 pub use tokio;
+
+/// Initialize GTK and (optionally) libadwaita
+fn init() {
+    gtk::init().unwrap();
+
+    #[cfg(feature = "libadwaita")]
+    adw::init();
+}
+
+thread_local! {
+    static MAIN_APPLICATION: Cell<Option<Application>> = Cell::default();
+}
+
+fn set_main_application(app: Application) {
+    MAIN_APPLICATION.with(move |cell| cell.set(Some(app)));
+}
+
+/// Returns a global [`Application`] that's used internally
+/// by [`RelmApp`].
+///
+/// This can be useful for graceful shutdown for example
+/// by calling [`gtk::prelude::ApplicationExt::quit()`].
+///
+/// Note: The global application will be overwritten by calling
+/// [`RelmApp::with_app()`].
+pub fn main_application() -> Application {
+    MAIN_APPLICATION.with(|cell| {
+        let app = cell.take().unwrap_or_default();
+        cell.set(Some(app.clone()));
+        app
+    })
+}
 
 /// Sets a custom global stylesheet.
 ///


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Adds a `main_application()` method to receiver the `gtk/adw::Application` used internally by `RelmApp`.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
