### PR TITLE
macros: Prevent early returns in pre_view

### DIFF
--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -111,18 +111,25 @@ pub(crate) fn generate_tokens(
                 widgets: &mut Self::Widgets,
                 sender: ComponentSender<Self>,
             ) {
-                #[allow(unused_variables)]
-                let Self::Widgets {
-                    #destructure_fields
-                    #additional_fields_return_stream
-                } = widgets;
+                struct __DoNotReturnManually;
 
-                #[allow(unused_variables)]
-                let #model_name = self;
+                let _no_manual_return: __DoNotReturnManually = (move || {
+                    #[allow(unused_variables)]
+                    let Self::Widgets {
+                        #destructure_fields
+                        #additional_fields_return_stream
+                    } = widgets;
 
-                #(#pre_view)*
-                #update_view
-                (|| { #(#post_view)* })();
+                    #[allow(unused_variables)]
+                    let #model_name = self;
+
+                    #(#pre_view)*
+                    #update_view
+                    // In post_view returning early is ok
+                    (move || { #(#post_view)* })();
+
+                    __DoNotReturnManually
+                })();
             }
         });
 

--- a/relm4-macros/src/factory/mod.rs
+++ b/relm4-macros/src/factory/mod.rs
@@ -113,16 +113,22 @@ pub(crate) fn generate_tokens(
                 widgets: &mut Self::Widgets,
                 sender: relm4::factory::FactoryComponentSender<Self>,
             ) {
-                #[allow(unused_variables)]
-                let Self::Widgets {
-                    #destructure_fields
-                    #additional_fields_return_stream
-                } = widgets;
+                struct __DoNotReturnManually;
 
-                // Wrap post_view code to prevent early returns from skipping other view code.
-                #(#pre_view)*
-                #update_view
-                (|| { #(#post_view)* })();
+                let _no_manual_return: __DoNotReturnManually = (move || {
+                    #[allow(unused_variables)]
+                    let Self::Widgets {
+                        #destructure_fields
+                        #additional_fields_return_stream
+                    } = widgets;
+
+                    #(#pre_view)*
+                    #update_view
+                    // In post_view returning early is ok
+                    (move || { #(#post_view)* })();
+
+                    __DoNotReturnManually
+                })();
             }
         });
 

--- a/relm4-macros/tests/ui/compile-fail/pre-view-return.rs
+++ b/relm4-macros/tests/ui/compile-fail/pre-view-return.rs
@@ -1,8 +1,9 @@
-#![deny(unreachable_code)]
-
 use relm4::{gtk, ComponentParts, ComponentSender, SimpleComponent};
 
-struct TestComponent;
+#[derive(Default)]
+struct TestComponent {
+    counter: u8,
+}
 
 #[relm4_macros::component]
 impl SimpleComponent for TestComponent {
@@ -16,7 +17,9 @@ impl SimpleComponent for TestComponent {
     }
 
     fn pre_view() {
-        return;
+        if model.counter == 0 {
+            return;
+        }
     }
 
     fn init(
@@ -24,7 +27,7 @@ impl SimpleComponent for TestComponent {
         _root: &Self::Root,
         _sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let model = Self;
+        let model = Self::default();
 
         let widgets = view_output!();
 

--- a/relm4-macros/tests/ui/compile-fail/pre-view-return.stderr
+++ b/relm4-macros/tests/ui/compile-fail/pre-view-return.stderr
@@ -1,15 +1,23 @@
-error: unreachable statement
-  --> tests/ui/compile-fail/pre-view-return.rs:7:1
+error[E0308]: mismatched types
+  --> tests/ui/compile-fail/pre-view-return.rs:8:1
    |
-7  | #[relm4_macros::component]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-...
-19 |         return;
-   |         ------ any code following this expression is unreachable
+8  | #[relm4_macros::component]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found struct `__DoNotReturnManually`
    |
-note: the lint level is defined here
-  --> tests/ui/compile-fail/pre-view-return.rs:1:9
+note: return type inferred to be `()` here
+  --> tests/ui/compile-fail/pre-view-return.rs:21:13
    |
-1  | #![deny(unreachable_code)]
-   |         ^^^^^^^^^^^^^^^^
+21 |             return;
+   |             ^^^^^^
    = note: this error originates in the attribute macro `relm4_macros::component` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> tests/ui/compile-fail/pre-view-return.rs:8:1
+  |
+8 | #[relm4_macros::component]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | |
+  | expected struct `__DoNotReturnManually`, found `()`
+  | expected due to this
+  |
+  = note: this error originates in the attribute macro `relm4_macros::component` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Add IIFE guards around the whole `update_view` block of the macro codegen to prevent early returns in `pre_view`.

Fixes #256 

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
