### PR TITLE
Return a clone of the `DynamicIndex` after inserting into a factory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 + core: Add getter for global application for easier quitting of applications
 + core: Add MessageBroker type to allow communication between components on different levels
 + core: Rename InitParams to Init in SimpleComponent and Worker too
++ core: Return a clone of the `DynamicIndex` after inserting into a factory
 + macros: Fix returned widgets assignment in the view macro
 
 ## 0.5.0-beta.2 - 2022-8-12
@@ -43,9 +44,9 @@
 + core: Always initialize GTK/Libadwaita before running apps
 + macros: Some doc link fixes
 
-## 0.4.3 - 2022-3-13 
+## 0.4.3 - 2022-3-13
 
-### Added 
+### Added
 
 + core: Add WidgetRef trait to make AsRef easier accessible for widgets
 + macros: Destructure widgets in Widgets::view
@@ -58,7 +59,7 @@
 + core: Fixed state changes in FactoryVec (by [V02460](https://github.com/V02460))
 + macros: Parse whole expressions instead of just literals
 
-## 0.4.2 - 2022-2-4 
+## 0.4.2 - 2022-2-4
 
 ### Added
 
@@ -111,7 +112,7 @@
 + core: A factory view implementation for libadwaita's StackView
 + macros: Allow early returns in manual_view (by [euclio](https://github.com/euclio))
 
-### Changed 
+### Changed
 
 + core: Make GTK's command line argument handling optional (by [euclio](https://github.com/euclio))
 + core: DynamicIndex now implements Send but panics when used on other threads
@@ -217,7 +218,7 @@
 ### Fixed
 
 + macros: Parsing additional fields should be more stable now
-+ macros: Widgets can not include comments at the top 
++ macros: Widgets can not include comments at the top
 
 ## 0.1.0-beta.8 - 2021-08-20
 
@@ -254,7 +255,7 @@
 
 + core: Improved and adjusted the FactoryPrototype trait
 
-### Added 
+### Added
 
 + core: Added the FactoryListView trait for more flexibility
 + core: Added a FactoryVecDeque container

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -176,14 +176,14 @@ impl<'a, C: FactoryComponent> FactoryVecDequeGuard<'a, C> {
     }
 
     /// Appends an element at the end of the [`FactoryVecDeque`].
-    pub fn push_back(&mut self, init_params: C::Init) {
+    pub fn push_back(&mut self, init_params: C::Init) -> DynamicIndex {
         let index = self.len();
-        self.insert(index, init_params);
+        self.insert(index, init_params)
     }
 
     /// Prepends an element to the [`FactoryVecDeque`].
-    pub fn push_front(&mut self, init_params: C::Init) {
-        self.insert(0, init_params);
+    pub fn push_front(&mut self, init_params: C::Init) -> DynamicIndex {
+        self.insert(0, init_params)
     }
 
     /// Inserts an element at index within the [`FactoryVecDeque`],
@@ -195,7 +195,7 @@ impl<'a, C: FactoryComponent> FactoryVecDequeGuard<'a, C> {
     /// # Panics
     ///
     /// Panics if index is greater than [`FactoryVecDeque`]’s length.
-    pub fn insert(&mut self, index: usize, init_params: C::Init) {
+    pub fn insert(&mut self, index: usize, init_params: C::Init) -> DynamicIndex {
         let dyn_index = DynamicIndex::new(index);
 
         // Increment the indexes of the following elements.
@@ -211,12 +211,14 @@ impl<'a, C: FactoryComponent> FactoryVecDequeGuard<'a, C> {
         self.inner.model_state.insert(
             index,
             ModelStateValue {
-                index: dyn_index,
+                index: dyn_index.clone(),
                 uid: self.uid_counter,
                 changed: false,
             },
         );
         self.inner.uid_counter += 1;
+
+        dyn_index
     }
 
     /// Swaps elements at indices `first` and `second`.


### PR DESCRIPTION
#### Summary

Gonna need it myself anyway. Fixes #257.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [ ] cargo test*
- [x] updated CHANGES.md

\* On an unrelated note, compiling `libadwaita-examples` results in a memory leak and a crash on my system...