### PR TITLE
always use `gtk::Application` in public APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Make `app` field on `RelmApp` private
 + core: Use late initialization for transient_for and its native variant
 + core: Add getter for global application to simplify graceful shutdown of applications
 + core: Add MessageBroker type to allow communication between components on different levels

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Do not call `gtk_init` and `adw_init` in favor of the application startup handler
 + core: Remove `Application` type alias in favor of `gtk::Application`
 + core: Make `app` field on `RelmApp` private
 + core: Use late initialization for transient_for and its native variant

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Remove `Application` type alias in favor of `gtk::Application`
 + core: Make `app` field on `RelmApp` private
 + core: Use late initialization for transient_for and its native variant
 + core: Add getter for global application to simplify graceful shutdown of applications

--- a/examples/components.rs
+++ b/examples/components.rs
@@ -1,10 +1,10 @@
 use std::convert::identity;
 
 use gtk::prelude::{BoxExt, ButtonExt, DialogExt, GtkWindowExt, ToggleButtonExt, WidgetExt};
+use relm4::gtk;
 use relm4::gtk::prelude::{ApplicationExt, Cast};
-use relm4::gtk::{self};
 use relm4::{
-    adw, Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmApp,
+    Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmApp,
     SimpleComponent,
 };
 
@@ -145,14 +145,13 @@ enum AppMsg {
 
 struct App {
     mode: AppMode,
-    application: adw::Application,
     dialog: Controller<Dialog>,
     header: Controller<Header>,
 }
 
 #[relm4::component]
 impl SimpleComponent for App {
-    type Init = adw::Application;
+    type Init = ();
     type Input = AppMsg;
     type Output = ();
     type Widgets = AppWidgets;
@@ -176,7 +175,7 @@ impl SimpleComponent for App {
     }
 
     fn init(
-        application: Self::Init,
+        _: Self::Init,
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
@@ -191,7 +190,6 @@ impl SimpleComponent for App {
             mode: AppMode::View,
             header,
             dialog,
-            application,
         };
 
         let widgets = view_output!();
@@ -208,7 +206,7 @@ impl SimpleComponent for App {
                 self.dialog.emit(DialogMsg::Show);
             }
             AppMsg::Close => {
-                self.application.quit();
+                relm4::main_application().quit();
             }
         }
     }
@@ -216,6 +214,5 @@ impl SimpleComponent for App {
 
 fn main() {
     let relm_app = RelmApp::new("relm4.example.components");
-    let application = relm_app.app.clone();
-    relm_app.run::<App>(application);
+    relm_app.run::<App>(());
 }

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -157,8 +157,7 @@ relm4::new_stateful_action!(TestU8Action, WindowActionGroup, "test2", u8, u8);
 
 fn main() {
     let app = RelmApp::new("relm4.example.menu");
-    app.app
-        .set_accelerators_for_action::<TestAction>(&["<primary>W"]);
+    relm4::main_application().set_accelerators_for_action::<TestAction>(&["<primary>W"]);
 
     app.run::<AppModel>(0);
 }

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -2,19 +2,24 @@ use gtk::prelude::{ApplicationExt, ApplicationExtManual, Cast, GtkApplicationExt
 
 use crate::component::Component;
 use crate::component::ComponentController;
-use crate::Application;
 use crate::ComponentBuilder;
 
 /// An app that runs the main application.
 #[derive(Debug)]
 pub struct RelmApp {
-    /// The [`Application`] that's used internally to setup
+    /// The [`gtk::Application`] that's used internally to setup
     /// and run your application.
-    app: Application,
+    app: gtk::Application,
 }
 
 impl RelmApp {
-    /// Create a Relm4 application.
+    /// Create a new Relm4 application.
+    ///
+    /// This function will create a new [`gtk::Application`] object if necessary.
+    ///
+    /// If the `libadwaita` feature is enabled, then the created [`gtk::Application`] will be an
+    /// instance of [`adw::Application`]. This can be overridden by passing your own application
+    /// object to [`RelmApp::with_app`].
     #[must_use]
     pub fn new(app_id: &str) -> Self {
         crate::init();
@@ -25,8 +30,8 @@ impl RelmApp {
         Self { app }
     }
 
-    /// Create a Relm4 application.
-    pub fn with_app(app: impl IsA<Application> + Cast) -> Self {
+    /// Create a Relm4 application with a provided [`gtk::Application`].
+    pub fn with_app(app: impl IsA<gtk::Application>) -> Self {
         crate::init();
 
         let app = app.upcast();

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -10,7 +10,7 @@ use crate::ComponentBuilder;
 pub struct RelmApp {
     /// The [`Application`] that's used internally to setup
     /// and run your application.
-    pub app: Application,
+    app: Application,
 }
 
 impl RelmApp {

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -22,8 +22,6 @@ impl RelmApp {
     /// object to [`RelmApp::with_app`].
     #[must_use]
     pub fn new(app_id: &str) -> Self {
-        crate::init();
-
         let app = crate::main_application();
         app.set_application_id(Some(app_id));
 
@@ -32,8 +30,6 @@ impl RelmApp {
 
     /// Create a Relm4 application with a provided [`gtk::Application`].
     pub fn with_app(app: impl IsA<gtk::Application>) -> Self {
-        crate::init();
-
         let app = app.upcast();
         crate::set_main_application(app.clone());
 

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -86,14 +86,6 @@ pub use panel;
 pub use once_cell;
 pub use tokio;
 
-/// Initialize GTK and (optionally) libadwaita
-fn init() {
-    gtk::init().unwrap();
-
-    #[cfg(feature = "libadwaita")]
-    adw::init();
-}
-
 thread_local! {
     static MAIN_APPLICATION: Cell<Option<gtk::Application>> = Cell::default();
 }

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -52,6 +52,7 @@ pub use app::RelmApp;
 pub use tokio::task::JoinHandle;
 pub use util::{WidgetPlus, WidgetRef};
 
+use gtk::prelude::*;
 use once_cell::sync::OnceCell;
 use std::cell::Cell;
 use std::future::Future;
@@ -82,20 +83,6 @@ pub use adw;
 /// Re-export of libpanel
 pub use panel;
 
-#[cfg(feature = "libadwaita")]
-/// The application type used by [`RelmApp`] internally.
-///
-/// This is either [`gtk::Application`] or [`adw::Application`]
-/// depending on the feature flags.
-pub type Application = adw::Application;
-
-#[cfg(not(feature = "libadwaita"))]
-/// The application type used by [`RelmApp`] internally.
-///
-/// This is either [`gtk::Application`] or `adw::Application`
-/// depending on the feature flags.
-pub type Application = gtk::Application;
-
 pub use once_cell;
 pub use tokio;
 
@@ -108,24 +95,34 @@ fn init() {
 }
 
 thread_local! {
-    static MAIN_APPLICATION: Cell<Option<Application>> = Cell::default();
+    static MAIN_APPLICATION: Cell<Option<gtk::Application>> = Cell::default();
 }
 
-fn set_main_application(app: Application) {
-    MAIN_APPLICATION.with(move |cell| cell.set(Some(app)));
+fn set_main_application(app: impl IsA<gtk::Application>) {
+    MAIN_APPLICATION.with(move |cell| cell.set(Some(app.upcast())));
 }
 
-/// Returns a global [`Application`] that's used internally
+#[cfg(feature = "libadwaita")]
+fn new_application() -> gtk::Application {
+    adw::Application::default().upcast()
+}
+
+#[cfg(not(feature = "libadwaita"))]
+fn new_application() -> gtk::Application {
+    gtk::Application::default()
+}
+
+/// Returns the global [`gtk::Application`] that's used internally
 /// by [`RelmApp`].
 ///
-/// This can be useful for graceful shutdown for example
-/// by calling [`gtk::prelude::ApplicationExt::quit()`].
+/// Retrieving this value can be useful for graceful shutdown
+/// by calling [`ApplicationExt::quit()`][gtk::prelude::ApplicationExt::quit] on it.
 ///
-/// Note: The global application will be overwritten by calling
+/// Note: The global application can be overwritten by calling
 /// [`RelmApp::with_app()`].
-pub fn main_application() -> Application {
+pub fn main_application() -> gtk::Application {
     MAIN_APPLICATION.with(|cell| {
-        let app = cell.take().unwrap_or_default();
+        let app = cell.take().unwrap_or_else(new_application);
         cell.set(Some(app.clone()));
         app
     })


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

This PR contains a few improvements to how we handle GTK application types. Chiefly, it replaces the `Application` type alias with `IsA<gtk::Application>`, because `adw::Application` is a subclass of `gtk::Application`. This, along with a change to not manually initialize GTK or libadwaita, allows users to enable the libadwaita feature without being forced into using `adw::Application` or libadwaita styles. Lastly, this PR makes the `app` field on `RelmApp` private, because it can be accessed through `relm4::main_application`.

Fixes #255.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
