### PR TITLE
rename `ParentMsg` to `ParentInput`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Rename `ParentMsg` and `output_to_parent_msg` to `ParentInput` and `output_to_parent_input`, respectively.
 + core: Do not call `gtk_init` and `adw_init` in favor of the application startup handler
 + core: Remove `Application` type alias in favor of `gtk::Application`
 + core: Make `app` field on `RelmApp` private

--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -26,7 +26,7 @@ impl FactoryComponent for Counter {
     type Init = u8;
     type Input = CounterMsg;
     type Output = CounterOutput;
-    type ParentMsg = AppMsg;
+    type ParentInput = AppMsg;
     type ParentWidget = gtk::Box;
     type Widgets = CounterWidgets;
 
@@ -83,7 +83,7 @@ impl FactoryComponent for Counter {
         }
     }
 
-    fn output_to_parent_msg(output: Self::Output) -> Option<AppMsg> {
+    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -45,12 +45,12 @@ impl FactoryComponent for Counter {
     type Init = u8;
     type Input = CounterMsg;
     type Output = CounterOutput;
-    type ParentMsg = AppMsg;
+    type ParentInput = AppMsg;
     type ParentWidget = gtk::Grid;
     type Root = gtk::Box;
     type Widgets = CounterWidgets;
 
-    fn output_to_parent_msg(output: Self::Output) -> Option<AppMsg> {
+    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -29,7 +29,7 @@ struct CounterWidgets {
 
 impl FactoryComponent for Counter {
     type ParentWidget = adw::TabView;
-    type ParentMsg = AppMsg;
+    type ParentInput = AppMsg;
 
     type Widgets = CounterWidgets;
 
@@ -41,7 +41,7 @@ impl FactoryComponent for Counter {
     type Root = gtk::Box;
     type CommandOutput = ();
 
-    fn output_to_parent_msg(output: Self::Output) -> Option<AppMsg> {
+    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -42,7 +42,7 @@ enum CounterOutput {
 #[relm4::factory]
 impl FactoryComponent for GamePage {
     type ParentWidget = adw::TabView;
-    type ParentMsg = AppMsg;
+    type ParentInput = AppMsg;
 
     type Widgets = CounterWidgets;
 
@@ -53,7 +53,7 @@ impl FactoryComponent for GamePage {
 
     type CommandOutput = ();
 
-    fn output_to_parent_msg(output: Self::Output) -> Option<AppMsg> {
+    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::StartGame(index) => AppMsg::StartGame(index),
             CounterOutput::SelectedGuess(guess) => AppMsg::SelectedGuess(guess),

--- a/examples/to_do.rs
+++ b/examples/to_do.rs
@@ -24,7 +24,7 @@ impl FactoryComponent for Task {
     type Init = String;
     type Input = TaskInput;
     type Output = TaskOutput;
-    type ParentMsg = AppMsg;
+    type ParentInput = AppMsg;
     type ParentWidget = gtk::ListBox;
     type Widgets = TaskWidgets;
 
@@ -65,7 +65,7 @@ impl FactoryComponent for Task {
         widgets.label.set_attributes(Some(&attrs));
     }
 
-    fn output_to_parent_msg(output: Self::Output) -> Option<AppMsg> {
+    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             TaskOutput::Delete(index) => AppMsg::DeleteEntry(index),
         })

--- a/relm4/src/factory/builder.rs
+++ b/relm4/src/factory/builder.rs
@@ -65,11 +65,11 @@ impl<C: FactoryComponent> FactoryBuilder<C> {
         self,
         index: &DynamicIndex,
         returned_widget: <C::ParentWidget as FactoryView>::ReturnedWidget,
-        parent_sender: &Sender<C::ParentMsg>,
+        parent_sender: &Sender<C::ParentInput>,
         transform: Transform,
     ) -> FactoryHandle<C>
     where
-        Transform: Fn(C::Output) -> Option<C::ParentMsg> + 'static,
+        Transform: Fn(C::Output) -> Option<C::ParentInput> + 'static,
     {
         let Self {
             mut data,

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -352,7 +352,7 @@ impl<'a, C: FactoryComponent> IndexMut<usize> for FactoryVecDequeGuard<'a, C> {
 #[derive(Debug)]
 pub struct FactoryVecDeque<C: FactoryComponent> {
     widget: C::ParentWidget,
-    parent_sender: Sender<C::ParentMsg>,
+    parent_sender: Sender<C::ParentInput>,
     components: VecDeque<ComponentStorage<C>>,
     model_state: VecDeque<ModelStateValue>,
     rendered_state: VecDeque<RenderedState>,
@@ -380,7 +380,7 @@ impl<C: FactoryComponent> Index<usize> for FactoryVecDeque<C> {
 impl<C: FactoryComponent> FactoryVecDeque<C> {
     /// Creates a new [`FactoryVecDeque`].
     #[must_use]
-    pub fn new(widget: C::ParentWidget, parent_sender: &Sender<C::ParentMsg>) -> Self {
+    pub fn new(widget: C::ParentWidget, parent_sender: &Sender<C::ParentInput>) -> Self {
         Self {
             widget,
             parent_sender: parent_sender.clone(),

--- a/relm4/src/factory/component_storage.rs
+++ b/relm4/src/factory/component_storage.rs
@@ -57,14 +57,14 @@ impl<C: FactoryComponent> ComponentStorage<C> {
         self,
         index: &DynamicIndex,
         returned_widget: <C::ParentWidget as FactoryView>::ReturnedWidget,
-        parent_sender: &Sender<C::ParentMsg>,
+        parent_sender: &Sender<C::ParentInput>,
     ) -> Option<Self> {
         if let Self::Builder(builder) = self {
             Some(Self::Final(builder.launch(
                 index,
                 returned_widget,
                 parent_sender,
-                C::output_to_parent_msg,
+                C::output_to_parent_input,
             )))
         } else {
             None

--- a/relm4/src/factory/traits.rs
+++ b/relm4/src/factory/traits.rs
@@ -90,8 +90,8 @@ pub trait FactoryComponent:
     /// Container widget to which all widgets of the factory will be added.
     type ParentWidget: FactoryView + 'static;
 
-    /// Messages sent to a parent component.
-    type ParentMsg: Debug + 'static;
+    /// Input messages sent to the parent component.
+    type ParentInput: Debug + 'static;
 
     /// Messages which are received from commands executing in the background.
     type CommandOutput: Debug + Send + 'static;
@@ -130,11 +130,11 @@ pub trait FactoryComponent:
         sender: FactoryComponentSender<Self>,
     ) -> Self::Widgets;
 
-    /// Convert [`Self::Output`] into `ParentMsg` in order to
-    /// send message to the parent.
+    /// Optionally convert an output message from this component to an input message for the
+    /// parent component.
     ///
     /// If [`None`] is returned, nothing is forwarded.
-    fn output_to_parent_msg(_output: Self::Output) -> Option<Self::ParentMsg> {
+    fn output_to_parent_input(_output: Self::Output) -> Option<Self::ParentInput> {
         None
     }
 


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

This PR renames `ParentMsg` to `ParentInput` and `output_to_parent_msg` to `output_to_parent_input` to bring the `FactoryComponent` naming more in-line with `Component`.

<!-- Please replace this comment with a short summary of the changes made in this PR -->
<!-- Fixes #000 -->

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
