### PR TITLE
Port `OpenButton` component to 0.5 syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ relm4-components: Port `OpenButton` to 0.5
 + core: Add `iter()` method to `FactoryVecDeque`
 + core: Rename `ParentMsg` and `output_to_parent_msg` to `ParentInput` and `output_to_parent_input`, respectively.
 + core: Do not call `gtk_init` and `adw_init` in favor of the application startup handler

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Add `iter()` method to `FactoryVecDeque`
 + core: Rename `ParentMsg` and `output_to_parent_msg` to `ParentInput` and `output_to_parent_input`, respectively.
 + core: Do not call `gtk_init` and `adw_init` in favor of the application startup handler
 + core: Remove `Application` type alias in favor of `gtk::Application`

--- a/examples/relm4-components/.gitignore
+++ b/examples/relm4-components/.gitignore
@@ -1,0 +1,1 @@
+.recent_files

--- a/examples/relm4-components/Cargo.toml
+++ b/examples/relm4-components/Cargo.toml
@@ -13,3 +13,7 @@ relm4-components = { path = "../../relm4-components" }
 [[example]]
 name = "file_dialogs"
 path = "file_dialogs.rs"
+
+[[example]]
+name = "open_button"
+path = "open_button.rs"

--- a/examples/relm4-components/open_button.rs
+++ b/examples/relm4-components/open_button.rs
@@ -1,0 +1,73 @@
+use std::path::PathBuf;
+
+use gtk::prelude::*;
+use relm4::{
+    gtk, Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmApp,
+    SimpleComponent,
+};
+use relm4_components::open_button::{OpenButton, OpenButtonSettings};
+use relm4_components::open_dialog::OpenDialogSettings;
+
+#[derive(Debug)]
+enum AppMsg {
+    Open(PathBuf),
+}
+
+struct App {
+    #[allow(unused)]
+    open_button: Controller<OpenButton>,
+}
+
+#[relm4::component]
+impl SimpleComponent for App {
+    type Init = ();
+    type Input = AppMsg;
+    type Output = ();
+    type Widgets = AppWidgets;
+
+    view! {
+        gtk::ApplicationWindow {
+            set_default_width: 300,
+            set_default_height: 100,
+
+            #[wrap(Some)]
+            set_titlebar = &gtk::HeaderBar {
+                pack_start: open_button.widget(),
+            }
+        }
+    }
+
+    fn update(&mut self, msg: Self::Input, _: ComponentSender<Self>) {
+        match msg {
+            AppMsg::Open(path) => {
+                println!("* Opened file {:?} *", path);
+            }
+        }
+    }
+
+    fn init(
+        _: Self::Init,
+        root: &Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let open_button = OpenButton::builder()
+            .launch(OpenButtonSettings {
+                dialog_settings: OpenDialogSettings::default(),
+                text: "Open file",
+                recently_opened_files: Some(".recent_files"),
+                max_recent_files: 10,
+            })
+            .forward(&sender.input, AppMsg::Open);
+
+        let widgets = view_output!();
+
+        let model = App { open_button };
+
+        ComponentParts { model, widgets }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.open_button");
+    app.run::<App>(());
+}

--- a/relm4-components/src/lib.rs
+++ b/relm4-components/src/lib.rs
@@ -9,6 +9,6 @@
 )]
 
 pub mod alert;
-// pub mod open_button;
+pub mod open_button;
 pub mod open_dialog;
 pub mod save_dialog;

--- a/relm4-components/src/open_button/factory.rs
+++ b/relm4-components/src/open_button/factory.rs
@@ -1,6 +1,6 @@
-use gtk::prelude::ButtonExt;
-use relm4::factory::{DynamicIndex, FactoryPrototype, FactoryVecDeque};
-use relm4::{gtk, send, WidgetPlus};
+use gtk::prelude::*;
+use relm4::factory::{DynamicIndex, FactoryComponent, FactoryComponentSender};
+use relm4::{gtk, WidgetPlus};
 
 use super::OpenButtonMsg;
 
@@ -11,53 +11,33 @@ pub(crate) struct FileListItem {
     pub(crate) path: PathBuf,
 }
 
-#[derive(Debug)]
-pub(crate) struct FileListItemWidgets {
-    label: gtk::Button,
-    row: gtk::ListBoxRow,
-}
-
-impl FactoryPrototype for FileListItem {
-    type Factory = FactoryVecDeque<Self>;
-    type View = gtk::Box;
+#[relm4::factory(pub(crate))]
+impl FactoryComponent for FileListItem {
+    type ParentInput = OpenButtonMsg;
+    type CommandOutput = ();
+    type Input = ();
+    type Init = PathBuf;
+    type ParentWidget = gtk::Box;
+    type Output = OpenButtonMsg;
     type Widgets = FileListItemWidgets;
-    type Root = gtk::ListBoxRow;
-    type Msg = OpenButtonMsg;
 
-    fn init_view(&self, key: &DynamicIndex, sender: relm4::Sender<Self::Msg>) -> Self::Widgets {
-        let label = gtk::Button::with_label(
-            self.path
-                .iter()
-                .last()
-                .expect("Empty path")
-                .to_str()
-                .expect("Couldn't convert path to string"),
-        );
-        let row = gtk::ListBoxRow::builder().child(&label).build();
-
-        label.inline_css(b"margin: 0");
-
-        let key = key.clone();
-        label.connect_clicked(move |_| {
-            send!(sender, OpenButtonMsg::OpenRecent(key.clone()));
-        });
-        FileListItemWidgets { label, row }
+    view! {
+        gtk::ListBoxRow {
+            gtk::Button {
+                set_label: self.path.iter().last().expect("Empty path").to_str().unwrap(),
+                set_margin_all: 0,
+                connect_clicked[sender, index] => move |_| {
+                    sender.output(OpenButtonMsg::OpenRecent(index.clone()));
+                }
+            }
+        }
     }
 
-    fn view(&self, _key: &DynamicIndex, widgets: &Self::Widgets) {
-        widgets.label.set_label(
-            self.path
-                .iter()
-                .last()
-                .expect("Empty path")
-                .to_str()
-                .expect("Couldn't convert path to string"),
-        );
+    fn output_to_parent_input(output: Self::Output) -> Option<Self::ParentInput> {
+        Some(output)
     }
 
-    fn position(&self, _key: &DynamicIndex) {}
-
-    fn root_widget(widgets: &Self::Widgets) -> &Self::Root {
-        &widgets.row
+    fn init_model(init: Self::Init, _: &DynamicIndex, _: FactoryComponentSender<Self>) -> Self {
+        Self { path: init }
     }
 }

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -539,4 +539,9 @@ impl<C: FactoryComponent> FactoryVecDeque<C> {
     pub fn widget(&self) -> &C::ParentWidget {
         &self.widget
     }
+
+    /// Returns an iterator over the components.
+    pub fn iter(&self) -> impl Iterator<Item = &C> {
+        self.components.iter().map(|component| component.get())
+    }
 }


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Updates the `OpenButton` component to 0.5 syntax and adds the "open_button" example back.

cc #100.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
