### PR TITLE
add a prelude module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Add a `prelude` module that contains commonly imported traits and types
 + core: Increase MSRV to 1.63 to match the gtk4 crate
 + core: Implement RelmContainerExt for Leaflet, Carousel and TabView
 + relm4-components: Port `OpenButton` to 0.5

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
-use gtk::prelude::{BoxExt, ButtonExt, GtkWindowExt, OrientableExt};
-use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
+use gtk::prelude::*;
+use relm4::prelude::*;
 
 struct AppModel {
     counter: u8,

--- a/examples/to_do.rs
+++ b/examples/to_do.rs
@@ -1,6 +1,6 @@
 use gtk::prelude::*;
-use relm4::factory::{DynamicIndex, FactoryComponent, FactoryComponentSender, FactoryVecDeque};
-use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
+use relm4::factory::FactoryVecDeque;
+use relm4::prelude::*;
 
 #[derive(Debug)]
 struct Task {

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -68,6 +68,8 @@ pub static RELM_THREADS: OnceCell<usize> = OnceCell::new();
 /// NOTE: The default max is 512.
 pub static RELM_BLOCKING_THREADS: OnceCell<usize> = OnceCell::new();
 
+pub mod prelude;
+
 /// Re-export of gtk4
 pub use gtk;
 

--- a/relm4/src/prelude.rs
+++ b/relm4/src/prelude.rs
@@ -1,0 +1,15 @@
+//! Commonly-imported traits and types.
+//!
+//! Modules that contain components can glob import this module to bring all needed types and
+//! traits into scope.
+
+pub use crate::factory::{DynamicIndex, FactoryComponent, FactoryComponentSender};
+pub use crate::{
+    Component, ComponentController, ComponentParts, ComponentSender, RelmApp, SimpleComponent,
+    WidgetPlus,
+};
+#[cfg(feature = "libadwaita")]
+pub use adw;
+pub use gtk;
+#[cfg(feature = "libpanel")]
+pub use panel;


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

This PR adds a prelude module that contains the traits and types that are needed to implement a component. This helps reduce the import boilerplate required to implement a new component. Two examples are modified to demonstrate the benefit.

I purposely tried to keep it pretty conservative. Right now it only contains traits, the types required to implement the methods on those traits, and the gtk crates. It might be helpful to include `RelmApp` or `FactoryVecDeque`, but those are left out for now.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
