### PR TITLE
set_child() vs content_area().append() for gtk::Dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
++ core: Append children for `gtk::Dialog` to its content area instead of using `set_child`
 + core: Remove `input` and `output` fields on `ComponentSender` and `FactoryComponentSender` in favor of `input_sender` and `output_sender` methods
 + core: Make `ComponentSender` and `FactoryComponentSender` structs instead of type aliases
 + core: Add a `prelude` module that contains commonly imported traits and types

--- a/relm4/src/extensions/container.rs
+++ b/relm4/src/extensions/container.rs
@@ -14,6 +14,12 @@ impl<T: RelmSetChildExt> RelmContainerExt for T {
     }
 }
 
+impl RelmContainerExt for gtk::Dialog {
+    fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
+        self.content_area().append(widget.as_ref());
+    }
+}
+
 macro_rules! append_impl {
     ($($type:ty),+) => {
         $(

--- a/relm4/src/extensions/set_child.rs
+++ b/relm4/src/extensions/set_child.rs
@@ -30,7 +30,6 @@ set_child_impl!(
     gtk::Window,
     gtk::ScrolledWindow,
     gtk::ApplicationWindow,
-    gtk::Dialog,
     gtk::Overlay,
     gtk::Revealer
 );


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

<!-- Please replace this comment with a short summary of the changes made in this PR -->
<!-- Fixes #000 -->
Append children for `gtk::Dialog` to its content area instead of using `set_child`

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
