### PR TITLE
Add chain attr to properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
++ macros: Improve error reporting on invalid trait implementations
++ macros: Add chain attribute for properties
 + core: Impl extension traits and `FactoryView` for `adw::PreferencesGroup`
 + components: Add `SimpleComboBox` type as a more idiomatic wrapper around `gtk::ComboBoxText`
 + core: Append children for `gtk::Dialog` to its content area instead of using `set_child`

--- a/examples/macro_reference.rs
+++ b/examples/macro_reference.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::{
     BoxExt, ButtonExt, GridExt, GtkWindowExt, OrientableExt, ToggleButtonExt, WidgetExt,
 };
-use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
+use relm4::{gtk::{self, prelude::ObjectExt}, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
 
 #[tracker::track]
 struct AppModel {
@@ -104,12 +104,20 @@ impl SimpleComponent for AppModel {
                 gtk::Label::new(Some("Constructors work!")),
 
                 /// Counter label
+                #[name = "counter_label"]
                 gtk::Label {
+                    // Mirror property "label" for widget "bind_label"
+                    #[chain(build())]
+                    bind_property: ("label", &bind_label, "label"),
+
                     #[watch]
                     set_label: &format!("Counter: {}", counter.value),
                     #[track]
                     set_margin_all: counter.value.into(),
                 },
+
+                #[name = "bind_label"]
+                gtk::Label {},
 
                 gtk::ToggleButton {
                     set_label: "Counter is even",

--- a/examples/macro_reference.rs
+++ b/examples/macro_reference.rs
@@ -1,7 +1,10 @@
 use gtk::prelude::{
     BoxExt, ButtonExt, GridExt, GtkWindowExt, OrientableExt, ToggleButtonExt, WidgetExt,
 };
-use relm4::{gtk::{self, prelude::ObjectExt}, ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus};
+use relm4::{
+    gtk::{self, prelude::ObjectExt},
+    ComponentParts, ComponentSender, RelmApp, SimpleComponent, WidgetPlus,
+};
 
 #[tracker::track]
 struct AppModel {

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -164,12 +164,8 @@ pub fn component(attributes: TokenStream, input: TokenStream) -> TokenStream {
     let component_impl_res = syn::parse_macro_input::parse::<syn::ItemImpl>(input);
 
     match component_impl_res {
-        Ok(component_impl) => {
-            component::generate_tokens(visibility, component_impl).into()
-        },
-        Err(_) => {
-            util::item_impl_error(backup_input)
-        }
+        Ok(component_impl) => component::generate_tokens(visibility, component_impl).into(),
+        Err(_) => util::item_impl_error(backup_input),
     }
 }
 
@@ -180,12 +176,8 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
     let factory_impl_res = syn::parse_macro_input::parse::<syn::ItemImpl>(input);
 
     match factory_impl_res {
-        Ok(factory_impl) => {
-            factory::generate_tokens(visibility, factory_impl).into()
-        },
-        Err(_) => {
-            util::item_impl_error(backup_input)
-        }
+        Ok(factory_impl) => factory::generate_tokens(visibility, factory_impl).into(),
+        Err(_) => util::item_impl_error(backup_input),
     }
 }
 

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -160,17 +160,33 @@ fn gtk_import() -> syn::Path {
 #[proc_macro_attribute]
 pub fn component(attributes: TokenStream, input: TokenStream) -> TokenStream {
     let Attrs { visibility } = parse_macro_input!(attributes as Attrs);
-    let component_impl = parse_macro_input!(input as syn::ItemImpl);
+    let backup_input = input.clone();
+    let component_impl_res = syn::parse_macro_input::parse::<syn::ItemImpl>(input);
 
-    component::generate_tokens(visibility, component_impl).into()
+    match component_impl_res {
+        Ok(component_impl) => {
+            component::generate_tokens(visibility, component_impl).into()
+        },
+        Err(_) => {
+            util::item_impl_error(backup_input)
+        }
+    }
 }
 
 #[proc_macro_attribute]
 pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
     let Attrs { visibility } = parse_macro_input!(attributes as Attrs);
-    let factory_impl = parse_macro_input!(input as syn::ItemImpl);
+    let backup_input = input.clone();
+    let factory_impl_res = syn::parse_macro_input::parse::<syn::ItemImpl>(input);
 
-    factory::generate_tokens(visibility, factory_impl).into()
+    match factory_impl_res {
+        Ok(factory_impl) => {
+            factory::generate_tokens(visibility, factory_impl).into()
+        },
+        Err(_) => {
+            util::item_impl_error(backup_input)
+        }
+    }
 }
 
 /// A macro to create menus.

--- a/relm4-macros/src/util.rs
+++ b/relm4-macros/src/util.rs
@@ -21,7 +21,7 @@ pub(super) fn strings_to_path(strings: &[&str]) -> Path {
 }
 
 pub(super) fn item_impl_error(original_input: TokenStream) -> TokenStream {
-    let macro_impls = quote::quote!{
+    let macro_impls = quote::quote! {
         macro_rules! view_output {
             () => { todo!() };
         }
@@ -30,6 +30,7 @@ pub(super) fn item_impl_error(original_input: TokenStream) -> TokenStream {
             ($tt:tt) => {};
             ($tt:tt $($y:tt)+) => {}
         }
-    }.into();
+    }
+    .into();
     vec![macro_impls, original_input].into_iter().collect()
 }

--- a/relm4-macros/src/util.rs
+++ b/relm4-macros/src/util.rs
@@ -23,7 +23,7 @@ pub(super) fn strings_to_path(strings: &[&str]) -> Path {
 pub(super) fn item_impl_error(original_input: TokenStream) -> TokenStream {
     let macro_impls = quote::quote! {
         macro_rules! view_output {
-            () => { todo!() };
+            () => { () };
         }
         macro_rules! view {
             () => {};

--- a/relm4-macros/src/util.rs
+++ b/relm4-macros/src/util.rs
@@ -1,3 +1,4 @@
+use proc_macro::TokenStream;
 use proc_macro2::Span as Span2;
 use syn::punctuated::Punctuated;
 
@@ -17,4 +18,18 @@ pub(super) fn strings_to_path(strings: &[&str]) -> Path {
         leading_colon: None,
         segments: Punctuated::from_iter(path_segments),
     }
+}
+
+pub(super) fn item_impl_error(original_input: TokenStream) -> TokenStream {
+    let macro_impls = quote::quote!{
+        macro_rules! view_output {
+            () => { todo!() };
+        }
+        macro_rules! view {
+            () => {};
+            ($tt:tt) => {};
+            ($tt:tt $($y:tt)+) => {}
+        }
+    }.into();
+    vec![macro_impls, original_input].into_iter().collect()
 }

--- a/relm4-macros/src/widgets/gen/assign/assign_property.rs
+++ b/relm4-macros/src/widgets/gen/assign/assign_property.rs
@@ -50,6 +50,12 @@ impl AssignProperty {
             self.expr.to_token_stream()
         };
 
+        let chain = self.chain.as_ref().map(|chain| {
+            quote_spanned! {
+                chain.span() => .#chain
+            }
+        });
+
         let (block_stream, unblock_stream) = if self.block_signals.is_empty() {
             (None, None)
         } else {
@@ -81,7 +87,7 @@ impl AssignProperty {
             (false, false) => {
                 quote_spanned! { span =>
                     #block_stream
-                    #assign_fn(#self_assign_args #assign #args);
+                    #assign_fn(#self_assign_args #assign #args) #chain;
                     #unblock_stream
                 }
             }
@@ -89,7 +95,7 @@ impl AssignProperty {
                 quote_spanned! {
                     span => if let Some(__p_assign) = #assign {
                         #block_stream
-                        #assign_fn(#self_assign_args __p_assign #args);
+                        #assign_fn(#self_assign_args __p_assign #args) #chain;
                         #unblock_stream
                     }
                 }
@@ -99,7 +105,7 @@ impl AssignProperty {
                     span =>
                         #block_stream
                         for __elem in #assign {
-                            #assign_fn(#self_assign_args __elem #args);
+                            #assign_fn(#self_assign_args __elem #args) #chain;
                         }
                         #unblock_stream
                 }
@@ -110,7 +116,7 @@ impl AssignProperty {
                         #block_stream
                         for __elem in #assign {
                             if let Some(__p_assign) = __elem {
-                                #assign_fn(#self_assign_args __p_assign #args);
+                                #assign_fn(#self_assign_args __p_assign #args) #chain;
                             }
                         }
                         #unblock_stream

--- a/relm4-macros/src/widgets/mod.rs
+++ b/relm4-macros/src/widgets/mod.rs
@@ -52,6 +52,7 @@ struct AssignProperty {
     /// Iterate through elements to generate tokens
     iterative: bool,
     block_signals: Vec<Ident>,
+    chain: Option<Box<Expr>>,
 }
 
 struct SignalHandler {
@@ -165,6 +166,7 @@ enum Attr {
     Name(Ident, Ident),
     Transition(Ident, Ident),
     Wrap(Ident, Path),
+    Chain(Ident, Box<Expr>),
 }
 
 struct Attrs {

--- a/relm4-macros/src/widgets/parse/assign_property.rs
+++ b/relm4-macros/src/widgets/parse/assign_property.rs
@@ -12,6 +12,7 @@ struct ProcessedAttrs {
     watch: AssignPropertyAttr,
     iterative: bool,
     block_signals: Vec<Ident>,
+    chain: Option<Box<Expr>>,
 }
 
 impl AssignProperty {
@@ -36,8 +37,7 @@ impl AssignProperty {
         let ProcessedAttrs {
             watch,
             iterative,
-            block_signals,
-        } = Self::process_attributes(&expr, attributes)?;
+            block_signals, chain } = Self::process_attributes(&expr, attributes)?;
 
         Ok(Self {
             attr: watch,
@@ -46,6 +46,7 @@ impl AssignProperty {
             optional_assign,
             iterative,
             block_signals,
+            chain,
         })
     }
 
@@ -54,6 +55,7 @@ impl AssignProperty {
             let mut iterative = false;
             let mut watch = AssignPropertyAttr::None;
             let mut block_signals = Vec::with_capacity(0);
+            let mut chain = None;
 
             for attr in attrs.inner {
                 let span = attr.span();
@@ -92,6 +94,13 @@ impl AssignProperty {
                             return Err(attr_twice_error(span));
                         }
                     }
+                    Attr::Chain(_, expr) => {
+                        if chain.is_none() {
+                            chain = Some(expr);
+                        } else {
+                            return Err(attr_twice_error(span));
+                        }
+                    }
                     _ => {
                         return Err(Error::new(
                             attr.span(),
@@ -104,12 +113,14 @@ impl AssignProperty {
                 watch,
                 iterative,
                 block_signals,
+                chain,
             })
         } else {
             Ok(ProcessedAttrs {
                 watch: AssignPropertyAttr::None,
                 iterative: false,
                 block_signals: Vec::with_capacity(0),
+                chain: None,
             })
         }
     }

--- a/relm4-macros/src/widgets/parse/assign_property.rs
+++ b/relm4-macros/src/widgets/parse/assign_property.rs
@@ -37,7 +37,9 @@ impl AssignProperty {
         let ProcessedAttrs {
             watch,
             iterative,
-            block_signals, chain } = Self::process_attributes(&expr, attributes)?;
+            block_signals,
+            chain,
+        } = Self::process_attributes(&expr, attributes)?;
 
         Ok(Self {
             attr: watch,

--- a/relm4-macros/src/widgets/parse/attributes.rs
+++ b/relm4-macros/src/widgets/parse/attributes.rs
@@ -68,6 +68,9 @@ impl Parse for Attrs {
                         let expr = expect_one_nested_expr(&nested)?;
                         let path = expect_path_from_expr(expr)?;
                         Attr::Wrap(ident.clone(), path)
+                    } else if ident == "chain" {
+                        let expr = expect_one_nested_expr(&nested)?;
+                        Attr::Chain(ident.clone(), Box::new(expr.clone()))
                     } else {
                         return Err(unexpected_attr_name(ident));
                     }

--- a/relm4-macros/src/widgets/span/attr.rs
+++ b/relm4-macros/src/widgets/span/attr.rs
@@ -16,6 +16,7 @@ impl Spanned for Attr {
             | Self::BlockSignal(ident, _)
             | Self::Name(ident, _)
             | Self::Transition(ident, _)
+            | Self::Chain(ident, _)
             | Self::Wrap(ident, _) => ident.span(),
         }
     }

--- a/relm4-macros/tests/ui/compile-fail/bad_impl.rs
+++ b/relm4-macros/tests/ui/compile-fail/bad_impl.rs
@@ -1,0 +1,33 @@
+use relm4::{gtk, ComponentParts, ComponentSender, SimpleComponent};
+
+#[derive(default)]
+struct TestComponent;
+
+#[relm4_macros::component]
+impl SimpleComponent for TestComponent {
+    type Init = ();
+    type Input = ();
+    type Output = ();
+    type Widgets = TestWidgets;
+
+    view! {
+        gtk::Window {}
+    }
+
+    fn init(
+        _init_param: (),
+        _root: &Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = Self::default();
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    // Incorrect impl
+    fn 
+}
+
+fn main() {}

--- a/relm4-macros/tests/ui/compile-fail/bad_impl.rs
+++ b/relm4-macros/tests/ui/compile-fail/bad_impl.rs
@@ -1,6 +1,6 @@
 use relm4::{gtk, ComponentParts, ComponentSender, SimpleComponent};
 
-#[derive(default)]
+#[derive(Default)]
 struct TestComponent;
 
 #[relm4_macros::component]

--- a/relm4-macros/tests/ui/compile-fail/bad_impl.stderr
+++ b/relm4-macros/tests/ui/compile-fail/bad_impl.stderr
@@ -32,14 +32,3 @@ error[E0046]: not all trait items implemented, missing: `Root`, `init_root`
   |
   = help: implement the missing item: `type Root = Type;`
   = help: implement the missing item: `fn init_root() -> <Self as SimpleComponent>::Root { todo!() }`
-
-warning: unreachable expression
-  --> tests/ui/compile-fail/bad_impl.rs:26:9
-   |
-24 |         let widgets = view_output!();
-   |                       -------------- any code following this expression is unreachable
-25 |
-26 |         ComponentParts { model, widgets }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable expression
-   |
-   = note: `#[warn(unreachable_code)]` on by default

--- a/relm4-macros/tests/ui/compile-fail/bad_impl.stderr
+++ b/relm4-macros/tests/ui/compile-fail/bad_impl.stderr
@@ -1,0 +1,25 @@
+error: expected identifier, found `}`
+  --> tests/ui/compile-fail/bad_impl.rs:30:1
+   |
+6  | impl SimpleComponent for TestComponent {
+   |                                        - while parsing this item list starting here
+...
+30 | }
+   | ^
+   | |
+   | expected identifier
+   | the item list ends here
+
+error: unexpected end of input, expected identifier
+  --> tests/ui/compile-fail/bad_impl.rs:30:1
+   |
+30 | }
+   | ^
+
+warning: unused imports: `ComponentParts`, `ComponentSender`, `SimpleComponent`, `gtk`
+ --> tests/ui/compile-fail/bad_impl.rs:1:13
+  |
+1 | use relm4::{gtk, ComponentParts, ComponentSender, SimpleComponent};
+  |             ^^^  ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default

--- a/relm4-macros/tests/ui/compile-fail/bad_impl.stderr
+++ b/relm4-macros/tests/ui/compile-fail/bad_impl.stderr
@@ -1,25 +1,45 @@
 error: expected identifier, found `}`
-  --> tests/ui/compile-fail/bad_impl.rs:30:1
+  --> tests/ui/compile-fail/bad_impl.rs:31:1
    |
-6  | impl SimpleComponent for TestComponent {
+7  | impl SimpleComponent for TestComponent {
    |                                        - while parsing this item list starting here
 ...
-30 | }
+31 | }
    | ^
    | |
    | expected identifier
    | the item list ends here
 
-error: unexpected end of input, expected identifier
-  --> tests/ui/compile-fail/bad_impl.rs:30:1
+error[E0412]: cannot find type `TestWidgets` in this scope
+  --> tests/ui/compile-fail/bad_impl.rs:11:20
    |
-30 | }
-   | ^
+11 |     type Widgets = TestWidgets;
+   |                    ^^^^^^^^^^^ not found in this scope
 
-warning: unused imports: `ComponentParts`, `ComponentSender`, `SimpleComponent`, `gtk`
+warning: unused import: `gtk`
  --> tests/ui/compile-fail/bad_impl.rs:1:13
   |
 1 | use relm4::{gtk, ComponentParts, ComponentSender, SimpleComponent};
-  |             ^^^  ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^
+  |             ^^^
   |
   = note: `#[warn(unused_imports)]` on by default
+
+error[E0046]: not all trait items implemented, missing: `Root`, `init_root`
+ --> tests/ui/compile-fail/bad_impl.rs:7:1
+  |
+7 | impl SimpleComponent for TestComponent {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Root`, `init_root` in implementation
+  |
+  = help: implement the missing item: `type Root = Type;`
+  = help: implement the missing item: `fn init_root() -> <Self as SimpleComponent>::Root { todo!() }`
+
+warning: unreachable expression
+  --> tests/ui/compile-fail/bad_impl.rs:26:9
+   |
+24 |         let widgets = view_output!();
+   |                       -------------- any code following this expression is unreachable
+25 |
+26 |         ComponentParts { model, widgets }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable expression
+   |
+   = note: `#[warn(unreachable_code)]` on by default


### PR DESCRIPTION
#### Summary

Adds a `#[chain(method())]` attribute to work with types returned by property assignments. For example, `bind_property()` returns a builder that needs a call to `build()` in order to take effect.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
