### PR TITLE
macros: Add shorthand syntax for input messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ macros: Add shorthand syntax for simple input messages
 + macros: Don't generate dead code in the widgets struct
 + macros: Improve error reporting on invalid trait implementations
 + macros: Add chain attribute for properties

--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -44,17 +44,13 @@ impl FactoryComponent for Counter {
             #[name = "add_button"]
             gtk::Button {
                 set_label: "+",
-                connect_clicked[sender] => move |_| {
-                    sender.input(CounterMsg::Increment)
-                }
+                connect_clicked => CounterMsg::Increment,
             },
 
             #[name = "remove_button"]
             gtk::Button {
                 set_label: "-",
-                connect_clicked[sender] => move |_| {
-                    sender.input(CounterMsg::Decrement)
-                }
+                connect_clicked => CounterMsg::Decrement,
             },
 
             #[name = "move_up_button"]

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -93,18 +93,14 @@ impl FactoryComponent for Counter {
         relm4::view! {
             add_button = gtk::Button {
                 set_label: "+",
-                connect_clicked[sender] => move |_| {
-                    sender.input(CounterMsg::Increment)
-                }
+                connect_clicked => CounterMsg::Increment,
             }
         }
 
         relm4::view! {
             remove_button = gtk::Button {
                 set_label: "-",
-                connect_clicked[sender] => move |_| {
-                    sender.input(CounterMsg::Decrement)
-                }
+                connect_clicked => CounterMsg::Decrement,
             }
         }
 

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -32,16 +32,12 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Increment",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AppMsg::Increment);
-                    }
+                    connect_clicked => AppMsg::Increment,
                 },
 
                 gtk::Button {
                     set_label: "Decrement",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AppMsg::Decrement);
-                    }
+                    connect_clicked => AppMsg::Decrement,
                 },
 
                 gtk::Label {

--- a/examples/macro_reference.rs
+++ b/examples/macro_reference.rs
@@ -53,9 +53,7 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Decrement",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AppMsg::Decrement);
-                    }
+                    connect_clicked => AppMsg::Decrement,
                 },
 
                 gtk::Grid {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -32,16 +32,12 @@ impl SimpleComponent for AppModel {
 
                 gtk::Button {
                     set_label: "Increment",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AppMsg::Increment);
-                    }
+                    connect_clicked => AppMsg::Increment,
                 },
 
                 gtk::Button {
                     set_label: "Decrement",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(AppMsg::Decrement);
-                    }
+                    connect_clicked => AppMsg::Decrement,
                 },
 
                 gtk::Label {

--- a/relm4-macros/src/factory/mod.rs
+++ b/relm4-macros/src/factory/mod.rs
@@ -3,7 +3,7 @@ use quote::{quote, ToTokens};
 use syn::visit_mut::VisitMut;
 use syn::{parse_quote, Ident, Visibility};
 
-use crate::component::token_streams;
+use crate::token_streams::{TokenStreams, TraitImplDetails};
 use crate::visitors::{FactoryComponentVisitor, PreAndPostView};
 
 mod inject_view_code;
@@ -33,7 +33,7 @@ pub(crate) fn generate_tokens(
         ..
     } = factory_visitor
     {
-        let token_streams::TokenStreams {
+        let TokenStreams {
             error,
             init_root,
             rename_root,
@@ -45,9 +45,14 @@ pub(crate) fn generate_tokens(
             destructure_fields,
             update_view,
         } = view_widgets.generate_streams(
-            &vis,
-            &Ident::new("self", Span2::call_site()),
-            Some(&root_name.unwrap_or_else(|| Ident::new("root", Span2::call_site()))),
+            &TraitImplDetails {
+                vis: vis.clone(),
+                model_name: Ident::new("self", Span2::call_site()),
+                root_name: Some(
+                    root_name.unwrap_or_else(|| Ident::new("root", Span2::call_site())),
+                ),
+                sender_name: Ident::new("sender", Span2::call_site()),
+            },
             false,
         );
 

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -16,6 +16,7 @@ mod widgets;
 #[macro_use]
 mod util;
 mod factory;
+mod token_streams;
 
 use attrs::Attrs;
 use menu::Menus;

--- a/relm4-macros/src/view.rs
+++ b/relm4-macros/src/view.rs
@@ -3,20 +3,27 @@ use proc_macro2::Span as Span2;
 use quote::quote;
 use syn::{parse_macro_input, Ident};
 
-use crate::component;
+use crate::token_streams::{TokenStreams, TraitImplDetails};
 use crate::widgets::ViewWidgets;
 
 pub(super) fn generate_tokens(input: TokenStream) -> TokenStream {
     let view_widgets: ViewWidgets = parse_macro_input!(input);
-    let model_name = Ident::new("_", Span2::call_site());
 
-    let component::token_streams::TokenStreams {
+    let TokenStreams {
         error,
         init,
         assign,
         connect,
         ..
-    } = view_widgets.generate_streams(&None, &model_name, None, true);
+    } = view_widgets.generate_streams(
+        &TraitImplDetails {
+            vis: None,
+            model_name: Ident::new("_", Span2::call_site()),
+            sender_name: Ident::new("sender", Span2::call_site()),
+            root_name: None,
+        },
+        true,
+    );
 
     let output = quote! {
         #init

--- a/relm4-macros/src/widgets/gen/connect_signals.rs
+++ b/relm4-macros/src/widgets/gen/connect_signals.rs
@@ -1,22 +1,27 @@
 use proc_macro2::TokenStream as TokenStream2;
-use quote::quote_spanned;
+use quote::{quote_spanned, ToTokens};
 use syn::spanned::Spanned;
 use syn::{Expr, Ident};
 
 use crate::widgets::{
     ConditionalBranches, ConditionalWidget, Properties, Property, PropertyName, PropertyType,
-    ReturnedWidget, SignalHandler, Widget,
+    ReturnedWidget, SignalHandler, SignalHandlerVariant, Widget,
 };
 
 impl Property {
-    fn connect_signals_stream(&self, stream: &mut TokenStream2, w_name: &Ident) {
+    fn connect_signals_stream(
+        &self,
+        stream: &mut TokenStream2,
+        w_name: &Ident,
+        sender_name: &Ident,
+    ) {
         match &self.ty {
             PropertyType::SignalHandler(signal_handler) => {
-                signal_handler.connect_signals_stream(stream, &self.name, w_name);
+                signal_handler.connect_signals_stream(stream, &self.name, w_name, sender_name);
             }
-            PropertyType::Widget(widget) => widget.connect_signals_stream(stream),
+            PropertyType::Widget(widget) => widget.connect_signals_stream(stream, sender_name),
             PropertyType::ConditionalWidget(cond_widget) => {
-                cond_widget.connect_signals_stream(stream);
+                cond_widget.connect_signals_stream(stream, sender_name);
             }
             PropertyType::Assign(_) | PropertyType::ParseError(_) => (),
         }
@@ -24,34 +29,40 @@ impl Property {
 }
 
 impl Properties {
-    fn connect_signals_stream(&self, stream: &mut TokenStream2, w_name: &Ident) {
+    fn connect_signals_stream(
+        &self,
+        stream: &mut TokenStream2,
+        w_name: &Ident,
+        sender_name: &Ident,
+    ) {
         for prop in &self.properties {
-            prop.connect_signals_stream(stream, w_name);
+            prop.connect_signals_stream(stream, w_name, sender_name);
         }
     }
 }
 
 impl Widget {
-    pub fn connect_signals_stream(&self, stream: &mut TokenStream2) {
+    pub fn connect_signals_stream(&self, stream: &mut TokenStream2, sender_name: &Ident) {
         let w_name = &self.name;
-        self.properties.connect_signals_stream(stream, w_name);
+        self.properties
+            .connect_signals_stream(stream, w_name, sender_name);
         if let Some(returned_widget) = &self.returned_widget {
-            returned_widget.connect_signals_stream(stream);
+            returned_widget.connect_signals_stream(stream, sender_name);
         }
     }
 }
 
 impl ConditionalWidget {
-    fn connect_signals_stream(&self, stream: &mut TokenStream2) {
+    fn connect_signals_stream(&self, stream: &mut TokenStream2, sender_name: &Ident) {
         match &self.branches {
             ConditionalBranches::If(if_branches) => {
                 for branch in if_branches {
-                    branch.widget.connect_signals_stream(stream);
+                    branch.widget.connect_signals_stream(stream, sender_name);
                 }
             }
             ConditionalBranches::Match((_, _, match_arms)) => {
                 for arm in match_arms {
-                    arm.widget.connect_signals_stream(stream);
+                    arm.widget.connect_signals_stream(stream, sender_name);
                 }
             }
         }
@@ -59,9 +70,10 @@ impl ConditionalWidget {
 }
 
 impl ReturnedWidget {
-    fn connect_signals_stream(&self, stream: &mut TokenStream2) {
+    fn connect_signals_stream(&self, stream: &mut TokenStream2, sender_name: &Ident) {
         let w_name = &self.name;
-        self.properties.connect_signals_stream(stream, w_name);
+        self.properties
+            .connect_signals_stream(stream, w_name, sender_name);
     }
 }
 
@@ -71,47 +83,62 @@ impl SignalHandler {
         stream: &mut TokenStream2,
         p_name: &PropertyName,
         w_name: &Ident,
+        sender_name: &Ident,
     ) {
+        let span = p_name.span();
         let assign_fn = p_name.assign_fn_stream(w_name);
         let self_assign_args = p_name.assign_args_stream(w_name);
-        let assign = &self.closure;
-        let span = p_name.span();
 
-        let mut clone_stream = TokenStream2::new();
-        if let Some(args) = &self.args {
-            for arg in &args.inner {
-                if let Expr::Path(path) = arg {
-                    if let Some(ident) = path.path.get_ident() {
-                        // Just an ident was used. Simply clone it.
+        let (clone_stream, assignment) = match &self.inner {
+            SignalHandlerVariant::Expr(expr) => (
+                quote_spanned! {
+                    span => let sender = #sender_name.clone();
+                },
+                quote_spanned! {
+                    span => move |_| {
+                        sender.input(#expr)
+                    }
+                },
+            ),
+            SignalHandlerVariant::Closure(inner) => {
+                let mut clone_stream = TokenStream2::new();
+                if let Some(args) = &inner.args {
+                    for arg in &args.inner {
+                        if let Expr::Path(path) = arg {
+                            if let Some(ident) = path.path.get_ident() {
+                                // Just an ident was used. Simply clone it.
+                                clone_stream.extend(quote_spanned! { arg.span() =>
+                                    #[allow(clippy::redundant_clone)]
+                                    #[allow(clippy::clone_on_copy)]
+                                    let #ident = #ident.clone();
+                                });
+                                continue;
+                            }
+                        }
+                        // Allow more complex expressions such as `value = data.sender()`
                         clone_stream.extend(quote_spanned! { arg.span() =>
                             #[allow(clippy::redundant_clone)]
                             #[allow(clippy::clone_on_copy)]
-                            let #ident = #ident.clone();
+                            let #arg;
                         });
-                        continue;
                     }
                 }
-                // Allow more complex expressions such as `value = data.sender()`
-                clone_stream.extend(quote_spanned! { arg.span() =>
-                    #[allow(clippy::redundant_clone)]
-                    #[allow(clippy::clone_on_copy)]
-                    let #arg;
-                });
+                (clone_stream, inner.closure.to_token_stream())
             }
-        }
+        };
 
         stream.extend(if let Some(signal_handler_id) = &self.handler_id {
             quote_spanned! {
                 span => let #signal_handler_id = {
                     #clone_stream
-                    #assign_fn(#self_assign_args #assign)
+                    #assign_fn(#self_assign_args #assignment)
                 };
             }
         } else {
             quote_spanned! {
                 span => {
                     #clone_stream
-                    #assign_fn(#self_assign_args #assign);
+                    #assign_fn(#self_assign_args #assignment);
                 }
             }
         });

--- a/relm4-macros/src/widgets/mod.rs
+++ b/relm4-macros/src/widgets/mod.rs
@@ -56,8 +56,17 @@ struct AssignProperty {
 }
 
 struct SignalHandler {
-    closure: ExprClosure,
+    inner: SignalHandlerVariant,
     handler_id: Option<Ident>,
+}
+
+enum SignalHandlerVariant {
+    Expr(Expr),
+    Closure(ClosureSignalHandler),
+}
+
+struct ClosureSignalHandler {
+    closure: ExprClosure,
     args: Option<Args<Expr>>,
 }
 

--- a/relm4-macros/src/widgets/parse/signal_handler.rs
+++ b/relm4-macros/src/widgets/parse/signal_handler.rs
@@ -1,11 +1,15 @@
 use syn::parse::ParseStream;
 use syn::{Expr, Result, Token};
 
-use crate::widgets::{Args, SignalHandler};
+use crate::widgets::{Args, ClosureSignalHandler, SignalHandler, SignalHandlerVariant};
 
 impl SignalHandler {
     pub(super) fn parse_with_args(input: ParseStream, args: Option<Args<Expr>>) -> Result<Self> {
-        let closure = input.parse()?;
+        let inner = if args.is_some() || input.peek(Token![move]) || input.peek(Token![|]) {
+            ClosureSignalHandler::parse_with_args(input, args).map(SignalHandlerVariant::Closure)
+        } else {
+            input.parse().map(SignalHandlerVariant::Expr)
+        }?;
 
         let handler_id = if input.peek(Token![@]) {
             let _arrow: Token![@] = input.parse()?;
@@ -14,10 +18,14 @@ impl SignalHandler {
             None
         };
 
-        Ok(Self {
-            closure,
-            handler_id,
-            args,
-        })
+        Ok(Self { inner, handler_id })
+    }
+}
+
+impl ClosureSignalHandler {
+    pub(super) fn parse_with_args(input: ParseStream, args: Option<Args<Expr>>) -> Result<Self> {
+        let closure = input.parse()?;
+
+        Ok(Self { closure, args })
     }
 }


### PR DESCRIPTION
#### Summary

Allow just using `=> #Expr` instead of 

```rust
[sender] => move |_| {
    sender.input(#Expr);
}
```

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
