### PR TITLE
core: Add macro for declaring global widgets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Add macro for declaring global (thread local) widgets
 + macros: Add shorthand syntax for simple input messages
 + core: Improve `SharedState` interface and prefer method names related to `RwLock`
 + macros: Don't generate dead code in the widgets struct

--- a/examples/libadwaita/Cargo.toml
+++ b/examples/libadwaita/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.0.0"
 publish = false
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dev-dependencies]
 rand = "0.8.5"
 relm4 = { path = "../../relm4", features = ["libadwaita", "macros"] }

--- a/examples/relm4-components/Cargo.toml
+++ b/examples/relm4-components/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.0.0"
 publish = false
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dev-dependencies]
 relm4 = { path = "../../relm4", features = ["macros"] }
 relm4-components = { path = "../../relm4-components" }

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -29,24 +29,25 @@ adw = { git = "https://gitlab.gnome.org/World/Rust/libadwaita-rs", optional = tr
 async-broadcast = "0.4"
 async-oneshot = "0.5.0"
 flume = "0.10.14"
-futures = "0.3.21"
 fragile = "1.2.1"
+futures = "0.3.21"
 gtk = { git = "https://github.com/gtk-rs/gtk4-rs", package = "gtk4" }
 #gtk = { version = "0.5", package = "gtk4" }
 log = "0.4.17"
 once_cell = "1.13"
+paste = "1"
 panel = { git = "https://gitlab.gnome.org/World/Rust/libpanel-rs", rev = "517d3f0459a9da16d300e2ee0b7508205494f845", optional = true, package = "libpanel" }
-#panel = { version = "0.1.0-alpha-0", optional = true, package = "libpanel }
-tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
 
 #relm4-macros = { version = "0.4.1", optional = true }
 relm4-macros = { path = "../relm4-macros", optional = true }
+#panel = { version = "0.1.0-alpha-0", optional = true, package = "libpanel }
+tokio = { version = "1.20", features = ["rt", "rt-multi-thread"] }
 tracing = { version = "0.1.36", features = ["log"] }
 
 [dev-dependencies]
+criterion = "0.4"
 relm4-macros = { path = "../relm4-macros" }
 tokio = { version = "1.20", features = ["full"] }
-criterion = "0.3"
 
 [[bench]]
 name = "stress_test"

--- a/relm4/src/global_widgets.rs
+++ b/relm4/src/global_widgets.rs
@@ -1,0 +1,66 @@
+/// Creates a widget that is globally accessible.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use relm4::{gtk, global_widget};
+/// global_widget!(my_box, gtk::Box);
+///
+/// // Get the global widget
+/// let my_box = my_box();
+/// ```
+///
+/// If your widget doesn't have a [`Default`] implementation
+/// or you want to specify a constructor, you can use the
+/// third argument of the macro.
+///
+/// ```no_run
+/// # use relm4::{gtk, global_widget};
+/// global_widget!(my_label, gtk::Label, gtk::Label::new(Some("text")));
+///
+/// // Get the global widget
+/// let my_label = my_label();
+/// ```
+///
+/// # Panics
+///
+/// This macro uses [`thread_local`] internally.
+/// Using the generated function from another thread
+/// will cause a panic, at least if you use a [`gtk::Widget`]
+/// because GTK isn't thread safe.
+///
+/// ```should_panic
+/// # use relm4::{gtk, global_widget};
+/// global_widget!(my_box, gtk::Box);
+///
+/// # let join_handle =
+/// std::thread::spawn(|| {
+///     // Get the global widget from another thread...
+///     let my_box= my_box();
+/// });
+/// # join_handle.join().unwrap();
+/// ```
+#[macro_export]
+macro_rules! global_widget {
+    ($name:ident, $ty:ty, $init:expr) => {
+        // Paste is necessary to generate unique module names
+        // to support multiple invocations in the same module.
+        $crate::__relm4_private_paste! {
+            mod [<__widget_private_ $name>] {
+                use super::*;
+                use $ty as __Type;
+                thread_local!(static GLOBAL_WIDGET: __Type = $init);
+
+                pub fn $name() -> $ty {
+                    GLOBAL_WIDGET.with(|w| w.clone())
+                }
+            }
+
+            pub use [<__widget_private_ $name>]::$name;
+        }
+    };
+
+    ($name:ident, $ty:ty) => {
+        global_widget!($name, $ty, __Type::default())
+    };
+}

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -35,6 +35,7 @@ pub mod shared_state;
 
 pub mod util;
 
+mod global_widgets;
 pub(crate) mod late_initialization;
 /// A simpler version of components that does work
 /// in the background.
@@ -90,6 +91,9 @@ pub use panel;
 
 pub use once_cell;
 pub use tokio;
+
+#[doc(hidden)]
+pub use paste::paste as __relm4_private_paste;
 
 thread_local! {
     static MAIN_APPLICATION: Cell<Option<gtk::Application>> = Cell::default();


### PR DESCRIPTION
#### Summary

Adds a convenience macro for defining global (or rather thread local) widgets with a convenient getter method (instead of the rather verbose thread_local! API).

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
