### PR TITLE
Fixed some pedantic clippy lints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 
 ### Changed
 
++ core: `add_action` of `RelmActionGroup` now takes a reference to a `RelmAction` as a parameter
 + core: Improve `SharedState` interface and prefer method names related to `RwLock`
 + core: Remove Debug requirement for FactoryComponent
 + core: Remove `input` and `output` fields on `ComponentSender` and `FactoryComponentSender` in favor of `input_sender` and `output_sender` methods

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -127,8 +127,8 @@ impl SimpleComponent for AppModel {
                 dbg!(state);
             });
 
-        group.add_action(action);
-        group.add_action(action2);
+        group.add_action(&action);
+        group.add_action(&action2);
 
         let actions = group.into_action_group();
         widgets

--- a/relm4/src/actions/mod.rs
+++ b/relm4/src/actions/mod.rs
@@ -204,7 +204,7 @@ pub struct RelmActionGroup<GroupName: ActionGroupName> {
 
 impl<GroupName: ActionGroupName> RelmActionGroup<GroupName> {
     /// Add an action to the group.
-    pub fn add_action<Name: ActionName>(&self, action: RelmAction<Name>) {
+    pub fn add_action<Name: ActionName>(&self, action: &RelmAction<Name>) {
         self.group.add_action(&action.action);
     }
 

--- a/relm4/src/component/builder.rs
+++ b/relm4/src/component/builder.rs
@@ -82,7 +82,7 @@ where
             if let Some(window) = widget.toplevel_window() {
                 root.as_ref().set_transient_for(Some(&window));
             } else {
-                tracing::error!("Couldn't find root of transient widget")
+                tracing::error!("Couldn't find root of transient widget");
             }
         }));
 
@@ -111,7 +111,7 @@ where
             if let Some(window) = widget.toplevel_window() {
                 root.as_ref().set_transient_for(Some(&window));
             } else {
-                tracing::error!("Couldn't find root of transient widget")
+                tracing::error!("Couldn't find root of transient widget");
             }
         }));
 
@@ -120,7 +120,7 @@ where
 }
 
 impl<C: Component> ComponentBuilder<C> {
-    /// Starts the component, passing ownership to a future attached to a GLib context.
+    /// Starts the component, passing ownership to a future attached to a ``GLib`` context.
     pub fn launch(self, payload: C::Init) -> Connector<C> {
         // Used for all events to be processed by this component's internal service.
         let (input_tx, input_rx) = crate::channel::<C::Input>();

--- a/relm4/src/factory/builder.rs
+++ b/relm4/src/factory/builder.rs
@@ -54,7 +54,7 @@ impl<C: FactoryComponent> FactoryBuilder<C> {
         }
     }
 
-    /// Starts the component, passing ownership to a future attached to a GLib context.
+    /// Starts the component, passing ownership to a future attached to a ``GLib`` context.
     pub(super) fn launch<Transform>(
         self,
         index: &DynamicIndex,

--- a/relm4/src/factory/collections/vec_deque.rs
+++ b/relm4/src/factory/collections/vec_deque.rs
@@ -560,6 +560,8 @@ impl<C: FactoryComponent> FactoryVecDeque<C> {
     pub fn iter(
         &self,
     ) -> impl Iterator<Item = &C> + DoubleEndedIterator + ExactSizeIterator + FusedIterator {
-        self.components.iter().map(|component| component.get())
+        self.components
+            .iter()
+            .map(crate::factory::component_storage::ComponentStorage::get)
     }
 }

--- a/relm4/src/factory/data_guard.rs
+++ b/relm4/src/factory/data_guard.rs
@@ -105,7 +105,7 @@ mod test {
         }
 
         fn add(&mut self) {
-            self.0 += 1
+            self.0 += 1;
         }
     }
 

--- a/relm4/src/sender.rs
+++ b/relm4/src/sender.rs
@@ -40,7 +40,7 @@ impl<C: Component> ComponentSender<C> {
         Cmd: FnOnce(Sender<C::CommandOutput>, ShutdownReceiver) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send,
     {
-        self.shared.command(cmd)
+        self.shared.command(cmd);
     }
 
     /// Spawns a future that will be dropped as soon as the component is shut down.
@@ -50,12 +50,12 @@ impl<C: Component> ComponentSender<C> {
     where
         Fut: Future<Output = C::CommandOutput> + Send + 'static,
     {
-        self.shared.oneshot_command(future)
+        self.shared.oneshot_command(future);
     }
 
     /// Emit an input to the component.
     pub fn input(&self, message: C::Input) {
-        self.shared.input.send(message)
+        self.shared.input.send(message);
     }
 
     /// Retrieve the sender for input messages.
@@ -69,7 +69,7 @@ impl<C: Component> ComponentSender<C> {
 
     /// Emit an output to the component.
     pub fn output(&self, message: C::Output) {
-        self.shared.output.send(message)
+        self.shared.output.send(message);
     }
 
     /// Retrieve the sender for output messages.
@@ -121,7 +121,7 @@ impl<C: FactoryComponent> FactoryComponentSender<C> {
         Cmd: FnOnce(Sender<C::CommandOutput>, ShutdownReceiver) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send,
     {
-        self.shared.command(cmd)
+        self.shared.command(cmd);
     }
 
     /// Spawns a future that will be dropped as soon as the component is shut down.
@@ -131,12 +131,12 @@ impl<C: FactoryComponent> FactoryComponentSender<C> {
     where
         Fut: Future<Output = C::CommandOutput> + Send + 'static,
     {
-        self.shared.oneshot_command(future)
+        self.shared.oneshot_command(future);
     }
 
     /// Emit an input to the component.
     pub fn input(&self, message: C::Input) {
-        self.shared.input.send(message)
+        self.shared.input.send(message);
     }
 
     /// Retrieve the sender for input messages.
@@ -150,7 +150,7 @@ impl<C: FactoryComponent> FactoryComponentSender<C> {
 
     /// Emit an output to the component.
     pub fn output(&self, message: C::Output) {
-        self.shared.output.send(message)
+        self.shared.output.send(message);
     }
 
     /// Retrieve the sender for output messages.

--- a/relm4/src/shared_state.rs
+++ b/relm4/src/shared_state.rs
@@ -241,7 +241,7 @@ impl<'a, Data> Deref for SharedStateReadGuard<'a, Data> {
     type Target = Data;
 
     fn deref(&self) -> &Self::Target {
-        self.inner.deref()
+        &self.inner
     }
 }
 
@@ -265,13 +265,13 @@ impl<'a, Data> Deref for SharedStateWriteGuard<'a, Data> {
     type Target = Data;
 
     fn deref(&self) -> &Self::Target {
-        self.data.deref()
+        &self.data
     }
 }
 
 impl<'a, Data> DerefMut for SharedStateWriteGuard<'a, Data> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.data.deref_mut()
+        &mut self.data
     }
 }
 

--- a/relm4/src/worker.rs
+++ b/relm4/src/worker.rs
@@ -69,7 +69,7 @@ where
     C::CommandOutput: Send,
 {
     /// Starts a worker on a separate thread,
-    /// passing ownership to a future attached to a GLib context.
+    /// passing ownership to a future attached to a ``GLib`` context.
     pub fn detach_worker(self, payload: C::Init) -> WorkerHandle<C> {
         let Self { root, .. } = self;
 


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

When adding `#![warn(clippy::pedantic)]` to the code, there were a few lints that were easy to solve. The only change worth mentioning was that the `add_action` of `RelmActionGroup` is able to take a reference to a `RelmAction` as a parameter. I changed it so the API changed.

I solved the following lints:

Added backticks to doc comments
https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
Removed explicit dereference
https://rust-lang.github.io/rust-clippy/master/index.html#explicit_deref_methods
Removed explicit auto dereference
https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
Added optional semicolon
https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned
Removed unneeded closure
https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_for_method_calls
Took a reference instead
https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value

I did not resolve the following lints:
https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_wrap
https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
https://rust-lang.github.io/rust-clippy/master/index.html#module_name_repetitions
https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc
https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
I get the following error, but it is unrelated to my changes:
```
warning: unreachable `pub` item
  --> relm4/src/lib.rs:43:34
   |
43 | pub use self::channel::{channel, Receiver, Sender};
   | ---                              ^^^^^^^^
   | |
   | help: consider restricting its visibility: `pub(crate)`
   |
   = help: or consider exporting it for use by other crates
note: the lint level is defined here
  --> relm4/src/lib.rs:11:5
   |
11 |     unreachable_pub
   |     ^^^^^^^^^^^^^^^

warning: unreachable `pub` item
  --> relm4/src/lib.rs:43:44
   |
43 | pub use self::channel::{channel, Receiver, Sender};
   | ---                                        ^^^^^^
   | |
   | help: consider restricting its visibility: `pub(crate)`
   |
   = help: or consider exporting it for use by other crates
```
- [x] cargo test
- [x] updated CHANGES.md
