### PR TITLE
Changed method from flat_map to filter_map in relm4-components

### DIFF
--- a/relm4-components/src/open_button/mod.rs
+++ b/relm4-components/src/open_button/mod.rs
@@ -125,7 +125,7 @@ impl SimpleComponent for OpenButton {
 
                     let contents = recent_files
                         .iter()
-                        .flat_map(|recent_path| {
+                        .filter_map(|recent_path| {
                             recent_path.path.to_str().map(|s| format!("{}\n", s))
                         })
                         .collect::<String>();


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

When adding #![warn(clippy::pedantic)] to the code, there was one lint that was easy to solve:

Changed method from flat_map to filter_map
https://rust-lang.github.io/rust-clippy/master/index.html#flat_map_option

Unresolved:
https://rust-lang.github.io/rust-clippy/master/index.html#used_underscore_binding
https://rust-lang.github.io/rust-clippy/master/index.html#module_name_repetitions
https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_drop
https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_wrap

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
