### PR TITLE
Changed methods to take refs instead of values in relm4-macros

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@
 
 ### Changed
 
++ macros: `parse_with_path` takes a reference to the `Path` instead of a value
++ macros: `update_stream` takes a reference to the `inner_update_tokens: TokenStream2` instead of a value
++ macros: `inject_view_code` takes references to the two `TokenStream2` instead of a value in components and factory
++ macros: `generate_tokens` takes a reference to `Option<Visibility>` instead of a value in components and factory
 + core: Improve `SharedState` interface and prefer method names related to `RwLock`
 + core: Remove Debug requirement for FactoryComponent
 + core: Remove `input` and `output` fields on `ComponentSender` and `FactoryComponentSender` in favor of `input_sender` and `output_sender` methods

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
++ macros: `parse_with_path`, `update_stream`, `inject_view_code` and `generate_tokens` take references for some of their parameters
+
 ## 0.5.0-beta.3 - 2022-9-28
 
 ### Added
@@ -22,10 +24,6 @@
 
 ### Changed
 
-+ macros: `parse_with_path` takes a reference to the `Path` instead of a value
-+ macros: `update_stream` takes a reference to the `inner_update_tokens: TokenStream2` instead of a value
-+ macros: `inject_view_code` takes references to the two `TokenStream2` instead of a value in components and factory
-+ macros: `generate_tokens` takes a reference to `Option<Visibility>` instead of a value in components and factory
 + core: Improve `SharedState` interface and prefer method names related to `RwLock`
 + core: Remove Debug requirement for FactoryComponent
 + core: Remove `input` and `output` fields on `ComponentSender` and `FactoryComponentSender` in favor of `input_sender` and `output_sender` methods

--- a/relm4-macros/src/component/inject_view_code.rs
+++ b/relm4-macros/src/component/inject_view_code.rs
@@ -5,8 +5,8 @@ use syn::{Error, Expr, ImplItemMethod, Pat, Result, Stmt};
 
 pub(crate) fn inject_view_code(
     mut func: ImplItemMethod,
-    view_code: TokenStream2,
-    widgets_return_code: TokenStream2,
+    view_code: &TokenStream2,
+    widgets_return_code: &TokenStream2,
 ) -> Result<ImplItemMethod> {
     let func_span = func.span();
     let mut stmts = func.block.stmts;

--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -11,7 +11,7 @@ pub(super) mod inject_view_code;
 use inject_view_code::inject_view_code;
 
 pub(crate) fn generate_tokens(
-    vis: Option<Visibility>,
+    vis: &Option<Visibility>,
     mut component_impl: syn::ItemImpl,
 ) -> TokenStream2 {
     let mut errors = vec![];
@@ -93,7 +93,7 @@ pub(crate) fn generate_tokens(
             }
         };
 
-        let init_injected = match inject_view_code(init, view_code, widgets_return_code) {
+        let init_injected = match inject_view_code(init, &view_code, &widgets_return_code) {
             Ok(method) => method,
             Err(err) => return err.to_compile_error(),
         };

--- a/relm4-macros/src/factory/inject_view_code.rs
+++ b/relm4-macros/src/factory/inject_view_code.rs
@@ -6,8 +6,8 @@ use crate::component;
 
 pub(super) fn inject_view_code(
     func: Option<ImplItemMethod>,
-    view_code: TokenStream2,
-    widgets_return_code: TokenStream2,
+    view_code: &TokenStream2,
+    widgets_return_code: &TokenStream2,
 ) -> Result<ImplItemMethod> {
     if let Some(func) = func {
         Ok(component::inject_view_code::inject_view_code(

--- a/relm4-macros/src/factory/mod.rs
+++ b/relm4-macros/src/factory/mod.rs
@@ -11,7 +11,7 @@ mod inject_view_code;
 use inject_view_code::inject_view_code;
 
 pub(crate) fn generate_tokens(
-    vis: Option<Visibility>,
+    vis: &Option<Visibility>,
     mut factory_impl: syn::ItemImpl,
 ) -> TokenStream2 {
     let mut errors = vec![];
@@ -90,7 +90,7 @@ pub(crate) fn generate_tokens(
             }
         };
 
-        let init_injected = match inject_view_code(init_widgets, view_code, widgets_return_code) {
+        let init_injected = match inject_view_code(init_widgets, &view_code, &widgets_return_code) {
             Ok(method) => method,
             Err(err) => return err.to_compile_error(),
         };

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -171,7 +171,7 @@ pub fn component(attributes: TokenStream, input: TokenStream) -> TokenStream {
     let component_impl_res = syn::parse_macro_input::parse::<syn::ItemImpl>(input);
 
     match component_impl_res {
-        Ok(component_impl) => component::generate_tokens(visibility, component_impl).into(),
+        Ok(component_impl) => component::generate_tokens(&visibility, component_impl).into(),
         Err(_) => util::item_impl_error(backup_input),
     }
 }
@@ -289,7 +289,7 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
     let factory_impl_res = syn::parse_macro_input::parse::<syn::ItemImpl>(input);
 
     match factory_impl_res {
-        Ok(factory_impl) => factory::generate_tokens(visibility, factory_impl).into(),
+        Ok(factory_impl) => factory::generate_tokens(&visibility, factory_impl).into(),
         Err(_) => util::item_impl_error(backup_input),
     }
 }

--- a/relm4-macros/src/visitors.rs
+++ b/relm4-macros/src/visitors.rs
@@ -439,7 +439,7 @@ impl VisitMut for PreAndPostView<'_> {
             }
         }
 
-        visit_mut::visit_impl_item_mut(self, item)
+        visit_mut::visit_impl_item_mut(self, item);
     }
 }
 

--- a/relm4-macros/src/widgets/gen/conditional_init.rs
+++ b/relm4-macros/src/widgets/gen/conditional_init.rs
@@ -86,7 +86,7 @@ impl ConditionalWidget {
                         model_name,
                         true,
                     );
-                    branch.update_stream(&mut stream, inner_update_stream, index);
+                    branch.update_stream(&mut stream, &inner_update_stream, index);
                 }
                 stream
             }

--- a/relm4-macros/src/widgets/gen/update_view.rs
+++ b/relm4-macros/src/widgets/gen/update_view.rs
@@ -80,7 +80,7 @@ impl ConditionalWidget {
                     branch
                         .widget
                         .update_view_stream(&mut inner_update_stream, model_name, true);
-                    branch.update_stream(&mut stream, inner_update_stream, index);
+                    branch.update_stream(&mut stream, &inner_update_stream, index);
                 }
                 stream
             }

--- a/relm4-macros/src/widgets/gen/util/if_branch.rs
+++ b/relm4-macros/src/widgets/gen/util/if_branch.rs
@@ -7,7 +7,7 @@ impl IfBranch {
     pub(crate) fn update_stream(
         &self,
         stream: &mut TokenStream2,
-        inner_update_tokens: TokenStream2,
+        inner_update_tokens: &TokenStream2,
         index: usize,
     ) {
         let index = index.to_string();

--- a/relm4-macros/src/widgets/parse/widget_func.rs
+++ b/relm4-macros/src/widgets/parse/widget_func.rs
@@ -6,10 +6,10 @@ use syn::{token, Ident, Path, Token};
 use crate::widgets::{parse_util, ParseError, WidgetFunc};
 
 impl WidgetFunc {
-    pub(super) fn parse_with_path(input: ParseStream<'_>, path: Path) -> Result<Self, ParseError> {
-        match Self::parse_with_path_internal(input, &path) {
+    pub(super) fn parse_with_path(input: ParseStream<'_>, path: &Path) -> Result<Self, ParseError> {
+        match Self::parse_with_path_internal(input, path) {
             Ok(func) => Ok(func),
-            Err(err) => Err(err.add_path(&path)),
+            Err(err) => Err(err.add_path(path)),
         }
     }
 
@@ -58,7 +58,7 @@ impl WidgetFunc {
 
 impl WidgetFunc {
     pub(super) fn parse(input: ParseStream<'_>) -> Result<Self, ParseError> {
-        let path = input.parse()?;
+        let path = &input.parse()?;
         Self::parse_with_path(input, path)
     }
 }


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

When adding #![warn(clippy::pedantic)] to the code, there were a few lints that were easy to solve. A few of the functions were called by value when they could have also been called by reference instead. I changed it so the API changed, which I mentioned in the CHANGES.md file.

I solved the following lints:

Added semicolon
https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned
Passed by reference instead of by value
https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value
Removed borrow
https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow


Unresolved:
https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_drop

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
