### PR TITLE
all: Remove documentation field in favor of docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "An idiomatic GUI library inspired by Elm and based on gtk4-rs"
 repository = "https://github.com/Relm4/relm4"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/relm4/"
 
 keywords = ["gui", "gtk", "gtk4"]
 categories = ["gui"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "An idiomatic GUI library inspired by Elm and based on gtk4-rs"
 repository = "https://github.com/Relm4/relm4"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
-documentation = "https://relm4.org/docs/stable/relm4/"
 
 keywords = ["gui", "gtk", "gtk4"]
 categories = ["gui"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/Relm4/relm4/actions/workflows/rust.yml/badge.svg)](https://github.com/Relm4/relm4/actions/workflows/rust.yml)
 [![Matrix](https://img.shields.io/matrix/relm4:matrix.org?label=matrix%20chat)](https://matrix.to/#/#relm4:matrix.org)
 [![Relm4 on crates.io](https://img.shields.io/crates/v/relm4.svg)](https://crates.io/crates/relm4)
-[![Relm4 docs](https://img.shields.io/badge/rust-documentation-blue)](https://relm4.org/docs/stable/relm4/)
+[![Relm4 docs](https://img.shields.io/badge/rust-documentation-blue)](https://docs.rs/relm4/)
 [![Relm4 book](https://img.shields.io/badge/rust-book-fc0060)](https://relm4.org/book/stable/)
 ![Minimum Rust version 1.56](https://img.shields.io/badge/rustc-1.56+-06a096.svg)
 [![dependency status](https://deps.rs/repo/github/Relm4/relm4/status.svg)](https://deps.rs/repo/github/Relm4/relm4)
@@ -29,7 +29,7 @@ Built on top of this foundation, Relm4 makes developing more idiomatic, simpler 
 ## Documentation
 
 + 📖 **[The Relm4 book](https://relm4.org/book/stable/)**
-+ 📜 **[Rust documentation](https://relm4.org/docs/stable/relm4/)**
++ 📜 **[Rust documentation](https://docs.rs/relm4/)**
 
 ## Need help?
 If you find yourself having trouble with anything, feel free to ask questions at:
@@ -61,7 +61,7 @@ The `relm4` crate has four feature flags:
 | &nbsp;Flag       | &nbsp;Purpose                                                                                                                                                  |
 | :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | &nbsp;macros     | &nbsp;Enable macros by re-exporting [`relm4-macros`](https://crates.io/crates/relm4-macros)                                                                    |
-| &nbsp;tokio-rt   | &nbsp;Adds the [`AsyncRelmWorker`](https://relm4.org/docs/stable/relm4/struct.AsyncRelmWorker.html) type that uses an asynchronous update function |
+| &nbsp;tokio-rt   | &nbsp;Adds the [`AsyncRelmWorker`](https://docs.rs/relm4/struct.AsyncRelmWorker.html) type that uses an asynchronous update function |
 | &nbsp;libadwaita | &nbsp;Improved support for [libadwaita](https://gitlab.gnome.org/World/Rust/libadwaita-rs)                                                                     |
 | &nbsp;all        | &nbsp;Enable all features                                                                                                                                      |
 

--- a/relm4-components/Cargo.toml
+++ b/relm4-components/Cargo.toml
@@ -7,6 +7,7 @@ description = "An idiomatic GUI library inspired by Elm and based on gtk4-rs"
 repository = "https://github.com/Relm4/relm4"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/relm4_components/"
 
 keywords = ["gui", "gtk", "gtk4"]
 categories = ["gui"]

--- a/relm4-components/Cargo.toml
+++ b/relm4-components/Cargo.toml
@@ -7,7 +7,6 @@ description = "An idiomatic GUI library inspired by Elm and based on gtk4-rs"
 repository = "https://github.com/Relm4/relm4"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
-documentation = "https://relm4.org/docs/stable/relm4_components/"
 
 keywords = ["gui", "gtk", "gtk4"]
 categories = ["gui"]

--- a/relm4-components/README.md
+++ b/relm4-components/README.md
@@ -1,6 +1,6 @@
 # Relm4 components
 
 [![Relm4-components on crates.io](https://img.shields.io/crates/v/relm4-components.svg)](https://crates.io/crates/relm4-components)
-[![Relm4-components docs](https://img.shields.io/badge/rust-documentation-blue)](https://relm4.org/docs/stable/relm4_components/)
+[![Relm4-components docs](https://img.shields.io/badge/rust-documentation-blue)](https://docs.rs/relm4_components/)
 
 A collection of reusable components that can easily be integrated into Relm4 applications.

--- a/relm4-macros/Cargo.toml
+++ b/relm4-macros/Cargo.toml
@@ -7,7 +7,6 @@ description = "An idiomatic GUI library inspired by Elm and based on gtk4-rs"
 repository = "https://github.com/Relm4/relm4"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
-documentation = "https://relm4.org/docs/stable/relm4_macros/"
 
 keywords = ["gui", "gtk", "gtk4"]
 categories = ["gui"]

--- a/relm4-macros/Cargo.toml
+++ b/relm4-macros/Cargo.toml
@@ -7,6 +7,7 @@ description = "An idiomatic GUI library inspired by Elm and based on gtk4-rs"
 repository = "https://github.com/Relm4/relm4"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/relm4_macros/"
 
 keywords = ["gui", "gtk", "gtk4"]
 categories = ["gui"]

--- a/relm4-macros/README.md
+++ b/relm4-macros/README.md
@@ -1,6 +1,6 @@
 # Relm4-macros
 
 [![Relm4-macros on crates.io](https://img.shields.io/crates/v/relm4-macros.svg)](https://crates.io/crates/relm4-macros)
-[![Relm4-macros docs](https://img.shields.io/badge/rust-documentation-blue)](https://relm4.org/docs/stable/relm4_macros/)
+[![Relm4-macros docs](https://img.shields.io/badge/rust-documentation-blue)](https://docs.rs/relm4_macros/)
 
 A macro to easily generate UIs for Relm4 applications.

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -30,7 +30,7 @@ use item_impl::ItemImpl;
 use menu::Menus;
 use widgets::Widget;
 
-/// Macro that implements [`relm4::Widgets`](https://relm4.org/docs/stable/relm4/trait.Widgets.html) and generates the corresponding struct.
+/// Macro that implements [`relm4::Widgets`](https://docs.rs/relm4/trait.Widgets.html) and generates the corresponding struct.
 ///
 /// # Attributes
 ///
@@ -118,7 +118,7 @@ pub fn widget(attributes: TokenStream, input: TokenStream) -> TokenStream {
     widget_macro::generate_tokens(visibility, relm4_path, data).into()
 }
 
-/// Macro that implements [`relm4::MicrosWidgets`](https://relm4.org/docs/stable/relm4/trait.MicroWidgets.html) and generates the corresponding struct.
+/// Macro that implements [`relm4::MicrosWidgets`](https://docs.rs/relm4/trait.MicroWidgets.html) and generates the corresponding struct.
 ///
 /// It works very similar to [`macro@widget`].
 #[proc_macro_attribute]
@@ -132,7 +132,7 @@ pub fn micro_widget(attributes: TokenStream, input: TokenStream) -> TokenStream 
     micro_widget_macro::generate_tokens(visibility, relm4_path, data).into()
 }
 
-/// Macro that implements [`relm4::factory::FactoryPrototype`](https://relm4.org/docs/stable/relm4/factory/trait.FactoryPrototype.html)
+/// Macro that implements [`relm4::factory::FactoryPrototype`](https://docs.rs/relm4/factory/trait.FactoryPrototype.html)
 /// and generates the corresponding widget struct.
 ///
 /// It works very similar to [`macro@widget`].


### PR DESCRIPTION
I think this is still missing for getting docs.rs working @pentamassiv 

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
