### PR TITLE
Fix docs for tokio feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 )]
 #![doc(html_logo_url = "https://relm4.org/icons/relm4_logo.svg")]
 #![doc(html_favicon_url = "https://relm4.org/icons/relm4_org.svg")]
+#![feature(doc_cfg)]
 
 pub mod actions;
 mod app;


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Building the docs with the tokio-rt enabled was broken because `#[doc(cfg)]` is experimental and needs to be explicitly enabled. I didn't enable all features when testing my changes so I missed that issue. This change would mean that Rust Nightly is needed for the builds and the docs! This could be avoided if we disable 

```
[package.metadata.docs.rs]
change all-features = true
```
and only activate the other features. I am not sure which way you want to move forward with, so this is just a draft PR.

The other issue why the build on docs.rs is that libpanels and libadwaita have the dox feature, but their builds also fail on docs.rs. :/ Since that is another issue, I will try to solve that upstream.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
