### PR TITLE
Add ToastOverlay to ContainerChild + SetChildExt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 + core: `add_action` of `RelmActionGroup` now takes a reference to a `RelmAction` as a parameter
++ core: Impl `ContainerChild` and `RelmSetChildExt` for `adw::ToastOverlay`
 + macros: `parse_with_path`, `update_stream`, `inject_view_code` and `generate_tokens` take references for some of their parameters
 
 ## 0.5.0-beta.3 - 2022-9-28

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -180,5 +180,6 @@ mod libadwaita {
         adw::SplitButton
         adw::StatusPage
         adw::PreferencesGroup
+        adw::ToastOverlay
     }
 }

--- a/relm4/src/extensions/set_child.rs
+++ b/relm4/src/extensions/set_child.rs
@@ -57,6 +57,7 @@ mod libadwaita {
         adw::Clamp,
         adw::ClampScrollable,
         adw::SplitButton,
-        adw::StatusPage
+        adw::StatusPage,
+        adw::ToastOverlay
     );
 }


### PR DESCRIPTION
#### Summary

Implement `ContainerChild` and `RelmSetChildExt` for `adw::ToastOverlay`

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
