### PR TITLE
add responsive sidebar example using adw::Leaflet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Added
 
++ examples: Add libadwaita Leaflet sidebar example
 + core: Allow changing the priority of event loops of components
 + core: Impl `ContainerChild` and `RelmSetChildExt` for `adw::ToastOverlay`
 + examples: Port entry, actions and popover examples to 0.5

--- a/examples/libadwaita/Cargo.toml
+++ b/examples/libadwaita/Cargo.toml
@@ -13,6 +13,10 @@ tokio = { version = "1", features = ["time"] }
 #relm4-components = { path = "../../relm4-components" }
 
 [[example]]
+name = "leaflet_sidebar"
+path = "leaflet_sidebar.rs"
+
+[[example]]
 name = "tab_factory"
 path = "tab_factory.rs"
 

--- a/examples/libadwaita/leaflet_sidebar.rs
+++ b/examples/libadwaita/leaflet_sidebar.rs
@@ -1,0 +1,135 @@
+/// Responsive sidebar layout inspired by the example code in the [libadwaita documentation].
+///
+/// Shrink the window small enough to see the sidebar and content pages become folded.
+///
+/// [libadwaita documentation]: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/adaptive-layouts.html#leaflet
+
+use adw::prelude::*;
+use gtk::glib;
+use relm4::prelude::*;
+
+struct App {
+    current_section: u32,
+}
+
+#[relm4::component]
+impl SimpleComponent for App {
+    type Input = u32;
+    type Output = ();
+    type Init = ();
+    type Widgets = AppWidgets;
+
+    view! {
+        adw::Window {
+            #[name = "leaflet"]
+            adw::Leaflet {
+                set_can_navigate_back: true,
+
+                gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+
+                    #[name = "sidebar_header"]
+                    adw::HeaderBar {
+                        #[wrap(Some)]
+                        set_title_widget = &adw::WindowTitle {
+                            set_title: "Sidebar",
+                        }
+                    },
+
+                    gtk::ListBox {
+                        set_selection_mode: gtk::SelectionMode::Single,
+                        add_css_class: "navigation-sidebar",
+
+                        adw::ActionRow {
+                            set_title: "Section 1",
+                        },
+
+                        adw::ActionRow {
+                            set_title: "Section 2",
+                        },
+
+                        adw::ActionRow {
+                            set_title: "Section 3",
+                        },
+
+                        connect_row_selected[sender] => move |_, row| {
+                            if let Some(row) = row {
+                                sender.input((row.index() + 1) as u32);
+                            }
+                        }
+                    }
+                },
+
+                gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                    set_hexpand: true,
+
+                    #[name = "content_header"]
+                    adw::HeaderBar {
+                        #[name = "back_button"]
+                        pack_start = &gtk::Button {
+                            set_icon_name: "go-previous-symbolic",
+                            connect_clicked[leaflet] => move |_| {
+                                leaflet.navigate(adw::NavigationDirection::Back);
+                            }
+                        },
+
+                        #[wrap(Some)]
+                        set_title_widget = &adw::WindowTitle {
+                            set_title: "Content",
+                        }
+                    },
+
+                    gtk::Label {
+                        add_css_class: "title-1",
+                        set_vexpand: true,
+
+                        #[watch]
+                        set_text: &format!("Page {}", model.current_section),
+                    }
+                },
+            }
+        }
+    }
+
+    fn update(&mut self, msg: u32, _: ComponentSender<Self>) {
+        self.current_section = msg;
+    }
+
+    fn init(_: (), root: &Self::Root, sender: ComponentSender<Self>) -> ComponentParts<Self> {
+        let model = App { current_section: 1 };
+
+        let widgets = view_output!();
+
+        widgets
+            .leaflet
+            .bind_property("folded", &widgets.sidebar_header, "show-end-title-buttons")
+            .flags(glib::BindingFlags::SYNC_CREATE)
+            .build();
+        widgets
+            .leaflet
+            .bind_property(
+                "folded",
+                &widgets.content_header,
+                "show-start-title-buttons",
+            )
+            .flags(glib::BindingFlags::SYNC_CREATE)
+            .build();
+        widgets
+            .leaflet
+            .bind_property("folded", &widgets.back_button, "visible")
+            .flags(glib::BindingFlags::SYNC_CREATE)
+            .build();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn pre_view() {
+        widgets.leaflet.navigate(adw::NavigationDirection::Forward);
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.leafletSidebar");
+    app.run::<App>(());
+}


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

This PR creates a new example that uses `adw::Leaflet` for a responsive sidebar.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
