### PR TITLE
Added dox feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 ### Added
-
++ relm4: Added `dox` feature to be able to build the docs without the dependencies
++ relm4-components: Added `dox` feature to be able to build the docs without the dependencies
 + core: Added widget templates
 + examples: Add libadwaita Leaflet sidebar example
 + core: Allow changing the priority of event loops of components

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 ### Changed
 
++ relm4: Made the `macros` feature a default feature
++ relm4: Removed `all` feature
 + core: Remove async-oneshot dependency and replace it with tokio's oneshot channel
 + core: Remove WidgetPlus in favor of RelmWidgetExt
 + core: Add convenience getter-methods to Controller

--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ relm4-components = { git = "https://github.com/Relm4/Relm4.git" }
 
 ### Features
 
-The `relm4` crate has three feature flags:
+The `relm4` crate has four feature flags:
 
 | Flag | Purpose |
 | :--- | :------ |
 | macros | Enable macros by re-exporting [`relm4-macros`](https://crates.io/crates/relm4-macros) |
 | libadwaita | Improved support for [libadwaita](https://gitlab.gnome.org/World/Rust/libadwaita-rs) |
 | libpanel | Improved support for [libpanel](https://gitlab.gnome.org/World/Rust/libpanel-rs) |
+| dox | Linking to the underlying C libraries is skipped to allow building the docs without the dependencies |
+
+The `macros` feature is a default feature.
 
 ## Examples
 

--- a/relm4-components/Cargo.toml
+++ b/relm4-components/Cargo.toml
@@ -13,9 +13,16 @@ keywords = ["gui", "gtk", "gtk4"]
 categories = ["gui"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.docs.rs]
+features = ["dox"]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+
 [dependencies]
 log = "0.4.17"
 once_cell = "1.13"
 #relm4 = { version = "0.4.0", features = ["macros"] }
 relm4 = { path = "../relm4", features = ["macros"] }
 tracker = "0.1.1"
+
+[features]
+dox = ["relm4/dox"]

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -20,17 +20,12 @@ all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [features]
-default = []
+default = ["macros"]
 # The dox feature can be used for building the docs without the dependencies and requires Rust Nightly
 dox = ["gtk/dox", "adw/dox", "panel/dox"]
 libadwaita = ["adw"]
 libpanel = ["panel"]
 macros = ["relm4-macros"]
-all = [
-    "libadwaita",
-    "macros",
-    # dox is not part of the 'all' feature, because it is only used for generating the documentation
-]
 
 [dependencies]
 #adw = { version = "0.2", optional = true, package = "libadwaita" }

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -15,12 +15,22 @@ documentation = "https://relm4.org/docs/stable/relm4/"
 keywords = ["gui", "gtk", "gtk4", "elm"]
 categories = ["gui"]
 
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
+
 [features]
 default = []
+# The dox feature can be used for building the docs without the dependencies and requires Rust Nightly
+dox = ["gtk/dox", "adw/dox", "panel/dox"]
 libadwaita = ["adw"]
 libpanel = ["panel"]
 macros = ["relm4-macros"]
-all = ["libadwaita", "macros"]
+all = [
+    "libadwaita",
+    "macros",
+    # dox is not part of the 'all' feature, because it is only used for generating the documentation
+]
 
 [dependencies]
 #adw = { version = "0.2", optional = true, package = "libadwaita" }


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary
This adds the `dox` feature so that docs.rs can activate it and build the docs without having all dependencies. See issue https://github.com/Relm4/Relm4/issues/292 for a detailed description.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
