### PR TITLE
Improve deps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         run: cargo clippy -- --deny warnings
 
       - name: "clippy all features"
-        run: cargo clippy --all-features -- --deny warnings
+        run: cargo clippy --features "all" -- --deny warnings
 
       - name: "test"
         run: xvfb-run --auto-servernum cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,8 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
+          # Disable nightly due to a false positive with the unreachable_pub lint
+          #- nightly
           - "1.63"
     env:
         DISPLAY: ":99.0"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,6 @@
 
 + core: Improved `DrawHandler`
 + core: Made the `macros` feature a default feature
-+ core: Removed `all` feature
 + core: Remove async-oneshot dependency and replace it with tokio's oneshot channel
 + core: Remove WidgetPlus in favor of RelmWidgetExt
 + core: Add convenience getter-methods to Controller

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Relm4 depends on GTK4: [How to install GTK4](https://www.gtk.org/docs/installati
 To use all features, just add this to your `Cargo.toml`:
 
 ```toml
-relm4 = { git = "https://github.com/Relm4/Relm4.git", features = ["macros"] }
+relm4 = { git = "https://github.com/Relm4/Relm4.git" }
 relm4-components = { git = "https://github.com/Relm4/Relm4.git" }
-# relm4 = { version = "0.5", features = ["macros"] }
+# relm4 = "0.5"
 # relm4-components = "0.5"
 ```
 

--- a/relm4-components/Cargo.toml
+++ b/relm4-components/Cargo.toml
@@ -20,8 +20,7 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 [dependencies]
 log = "0.4.17"
 once_cell = "1.13"
-#relm4 = { version = "0.4.0", features = ["macros"] }
-relm4 = { path = "../relm4", features = ["macros"] }
+relm4 = { version = "0.5.0-beta.3", path = "../relm4", features = ["macros"] }
 tracker = "0.1.1"
 
 [features]

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -26,6 +26,8 @@ dox = ["gtk/dox", "adw/dox"] #, "panel/dox"]
 libadwaita = ["adw"]
 #libpanel = ["panel"]
 macros = ["relm4-macros"]
+# All features except docs. This is also used in the CI
+all = ["macros", "libadwaita"] #, "panel"]
 
 [dependencies]
 adw = { version = "0.2", optional = true, package = "libadwaita" }

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -22,34 +22,29 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 [features]
 default = ["macros"]
 # The dox feature can be used for building the docs without the dependencies and requires Rust Nightly
-dox = ["gtk/dox", "adw/dox", "panel/dox"]
+dox = ["gtk/dox", "adw/dox"] #, "panel/dox"]
 libadwaita = ["adw"]
-libpanel = ["panel"]
+#libpanel = ["panel"]
 macros = ["relm4-macros"]
 
 [dependencies]
-#adw = { version = "0.2", optional = true, package = "libadwaita" }
-adw = { git = "https://gitlab.gnome.org/World/Rust/libadwaita-rs", optional = true, package = "libadwaita" }
+adw = { version = "0.2", optional = true, package = "libadwaita" }
 
 async-broadcast = "0.4"
 flume = "0.10.14"
 futures = "0.3.21"
 fragile = "2.0.0"
-gtk = { git = "https://github.com/gtk-rs/gtk4-rs", package = "gtk4" }
-#gtk = { version = "0.5", package = "gtk4" }
+gtk = { version = "0.5", package = "gtk4" }
 once_cell = "1.13"
-panel = { git = "https://gitlab.gnome.org/World/Rust/libpanel-rs", rev = "517d3f0459a9da16d300e2ee0b7508205494f845", optional = true, package = "libpanel" }
-#panel = { version = "0.1.0-alpha-0", optional = true, package = "libpanel }
+#panel = { version = "0.1.0-alpha.4", git = "https://gitlab.gnome.org/World/Rust/libpanel-rs", optional = true, package = "libpanel" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread", "sync"] }
 
-#relm4-macros = { version = "0.4.1", optional = true }
-relm4-macros = { path = "../relm4-macros", optional = true }
-tracing = { version = "0.1.36", features = ["log"] }
+relm4-macros = { version = "0.5.0-beta.3", path = "../relm4-macros", optional = true }
+tracing = "0.1.36"
 
 [dev-dependencies]
 relm4-macros = { path = "../relm4-macros" }
-tokio = { version = "1.20", features = ["full"] }
-criterion = "0.4"
+criterion = { version = "0.4", default-features = false }
 
 [[bench]]
 name = "stress_test"


### PR DESCRIPTION
#### Summary

- Use [multiple locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations) to simplify `cargo publish`
- Exclude libpanel until it's compatible with the other gtk-rs crates
- Disable the nightly workflow that has been causing problems for weeks due to a regression in the Rust compiler

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
