### PR TITLE
Have dependabot check the Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary
Dependabot can check the versions of the Github Actions. This will help keep them updated.
I also could not find any opened PRs from dependabot, even though I created a pull request to update criterion a few days ago. This leads me to believe dependabot is not working as expected. I pointed dependabot to the folders containing the Cargo.toml files, which should fix it.

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
