### PR TITLE
re-enable libpanel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,7 @@ jobs:
         rust:
           - stable
           - beta
-          # Disable nightly due to a false positive with the unreachable_pub lint
-          #- nightly
+          - nightly
           - "1.63.0"
     env:
         DISPLAY: ":99.0"

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -24,7 +24,7 @@ default = ["macros"]
 # The dox feature can be used for building the docs without the dependencies and requires Rust Nightly
 dox = ["gtk/dox", "adw/dox"] #, "panel/dox"]
 libadwaita = ["adw"]
-#libpanel = ["panel"]
+libpanel = ["panel"]
 macros = ["relm4-macros"]
 # All features except docs. This is also used in the CI
 all = ["macros", "libadwaita"] #, "panel"]
@@ -38,7 +38,7 @@ futures = "0.3.21"
 fragile = "2.0.0"
 gtk = { version = "0.5", package = "gtk4" }
 once_cell = "1.13"
-#panel = { version = "0.1.0-alpha.4", git = "https://gitlab.gnome.org/World/Rust/libpanel-rs", optional = true, package = "libpanel" }
+panel = { version = "0.1", optional = true, package = "libpanel" }
 tokio = { version = "1.20", features = ["rt", "rt-multi-thread", "sync"] }
 
 relm4-macros = { version = "0.5.0-beta.3", path = "../relm4-macros", optional = true }


### PR DESCRIPTION
#### Summary

Now that libpanel-rs has a 0.1 release, we can re-enable the library and feature.

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [x] cargo test
- [ ] updated CHANGES.md
