### PR TITLE
core: Fix shutdown in factories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixed
+
++ core: `shutdown` on `FactoryComponent` now works as expected
+
 ## 0.5.0-beta.4 - 2022-10-24
 
 ### Added

--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -18,6 +18,7 @@ enum CounterOutput {
     SendFront(DynamicIndex),
     MoveUp(DynamicIndex),
     MoveDown(DynamicIndex),
+    Remove(DynamicIndex),
 }
 
 #[relm4::factory]
@@ -76,6 +77,13 @@ impl FactoryComponent for Counter {
                 connect_clicked[sender, index] => move |_| {
                     sender.output(CounterOutput::SendFront(index.clone()))
                 }
+            },
+
+            gtk::Button {
+                set_label: "Remove",
+                connect_clicked[sender, index] => move |_| {
+                    sender.output(CounterOutput::Remove(index.clone()))
+                }
             }
         }
     }
@@ -85,6 +93,7 @@ impl FactoryComponent for Counter {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),
             CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
+            CounterOutput::Remove(index) => AppMsg::Remove(index),
         })
     }
 
@@ -106,6 +115,10 @@ impl FactoryComponent for Counter {
             }
         }
     }
+
+    fn shutdown(&mut self, _widgets: &mut Self::Widgets, _output: relm4::Sender<Self::Output>) {
+        println!("Counter with value {} was destroyed", self.value);
+    }
 }
 
 struct App {
@@ -120,6 +133,7 @@ enum AppMsg {
     SendFront(DynamicIndex),
     MoveUp(DynamicIndex),
     MoveDown(DynamicIndex),
+    Remove(DynamicIndex),
 }
 
 #[relm4::component]
@@ -202,6 +216,9 @@ impl SimpleComponent for App {
                 if index != 0 {
                     counters_guard.move_to(index, index - 1);
                 }
+            }
+            AppMsg::Remove(index) => {
+                counters_guard.remove(index.current_index());
             }
         }
     }

--- a/relm4/src/factory/data_guard.rs
+++ b/relm4/src/factory/data_guard.rs
@@ -1,25 +1,39 @@
-use std::{cell::Cell, mem::ManuallyDrop, rc::Rc};
+use std::mem::ManuallyDrop;
 
 use futures::Future;
 use gtk::glib;
+
+use crate::{shutdown::ShutdownSender, Sender};
+
+use super::FactoryComponent;
 
 /// # SAFETY
 ///
 /// This type is a safe wrapper that prevent's misuse,
 /// except if you move the data passed to the runtime outside
 /// of the runtime (through senders for example).
-pub(super) struct DataGuard<Data> {
-    data: Box<Data>,
-    rt: RuntimeDropper,
+#[derive(Debug)]
+pub(super) struct DataGuard<C: FactoryComponent> {
+    data: Box<C>,
+    widgets: Box<C::Widgets>,
+    rt_dropper: RuntimeDropper,
+    output_tx: Sender<C::Output>,
+    shutdown_notifier: ShutdownSender,
 }
 
-impl<Data> DataGuard<Data> {
+impl<C: FactoryComponent> DataGuard<C> {
     /// DO NOT MOVE THE DATA PASSED TO THE CLOSURE OUTSIDE OF THE RUNTIME!
     /// SAFETY IS ONLY GUARANTEED BECAUSE THE DATA IS BOUND TO THE LIFETIME OF THE RUNTIME!
-    pub(super) fn new<F, Fut>(data: Box<Data>, f: F) -> (Self, Rc<Cell<Option<glib::SourceId>>>)
+    pub(super) fn new<F, Fut>(
+        data: Box<C>,
+        widgets: Box<C::Widgets>,
+        shutdown_notifier: ShutdownSender,
+        output_tx: Sender<C::Output>,
+        f: F,
+    ) -> Self
     where
         Fut: Future<Output = ()> + 'static,
-        F: FnOnce(ManuallyDrop<Box<Data>>) -> Fut,
+        F: FnOnce(ManuallyDrop<Box<C>>, ManuallyDrop<Box<C::Widgets>>) -> Fut,
     {
         // Duplicate the references to `data`
         //
@@ -37,40 +51,51 @@ impl<Data> DataGuard<Data> {
         // Unsoundness only occurs when data that was moved into the runtime is moved out on
         // purpose. This would allow the first reference to outlive the second one, becoming
         // a dangling pointer.
-        let (data, model_data) = unsafe {
+        let (data, runtime_data) = unsafe {
             let raw = Box::into_raw(data);
             let data = Box::from_raw(raw);
             let runtime_data = ManuallyDrop::new(Box::from_raw(raw));
             (data, runtime_data)
         };
+        let (widgets, runtime_widgets) = unsafe {
+            let raw = Box::into_raw(widgets);
+            let widgets = Box::from_raw(raw);
+            let runtime_widgets = ManuallyDrop::new(Box::from_raw(raw));
+            (widgets, runtime_widgets)
+        };
 
-        let future = f(model_data);
-        let rt = Rc::new(Cell::new(Some(crate::spawn_local(future))));
-        let rt_ref = Rc::clone(&rt);
-        (
-            Self {
-                data,
-                rt: RuntimeDropper(rt),
-            },
-            rt_ref,
-        )
+        let future = f(runtime_data, runtime_widgets);
+        let rt_dropper = RuntimeDropper(Some(crate::spawn_local(future)));
+
+        Self {
+            data,
+            widgets,
+            output_tx,
+            shutdown_notifier,
+            rt_dropper,
+        }
     }
 
-    pub(super) const fn get(&self) -> &Data {
+    pub(super) const fn get(&self) -> &C {
         &self.data
     }
 
-    pub(super) fn get_mut(&mut self) -> &mut Data {
+    pub(super) fn get_mut(&mut self) -> &mut C {
         &mut self.data
     }
 
-    pub(super) fn into_inner(self) -> Data {
-        drop(self.rt);
+    pub(super) fn into_inner(mut self) -> C {
+        drop(self.rt_dropper);
+        self.shutdown_notifier.shutdown();
+        self.data
+            .shutdown(&mut self.widgets, self.output_tx.clone());
+        drop(self.widgets);
         *self.data
     }
 }
 
-struct RuntimeDropper(Rc<Cell<Option<glib::SourceId>>>);
+#[derive(Debug)]
+struct RuntimeDropper(Option<glib::SourceId>);
 
 /// A type that will drop a runtime behind a shared reference
 /// when it is dropped.
@@ -82,17 +107,11 @@ impl Drop for RuntimeDropper {
     }
 }
 
-impl<Data: std::fmt::Debug> std::fmt::Debug for DataGuard<Data> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DataGuard")
-            .field("data", &self.data)
-            .finish()
-    }
-}
-
 #[cfg(test)]
 mod test {
     use gtk::glib::MainContext;
+
+    use crate::{prelude::FactoryComponent, shutdown};
 
     use super::DataGuard;
 
@@ -117,6 +136,43 @@ mod test {
         }
     }
 
+    impl FactoryComponent for DontDropBelow4 {
+        type ParentWidget = gtk::Box;
+        type ParentInput = ();
+        type CommandOutput = ();
+        type Input = ();
+        type Output = ();
+        type Init = ();
+        type Root = gtk::Box;
+        type Widgets = ();
+
+        fn init_model(
+            _: Self::Init,
+            _: &crate::prelude::DynamicIndex,
+            _: crate::prelude::FactoryComponentSender<Self>,
+        ) -> Self {
+            Self(0)
+        }
+
+        fn init_root(&self) -> Self::Root {
+            gtk::Box::default()
+        }
+
+        fn init_widgets(
+            &mut self,
+            _: &crate::prelude::DynamicIndex,
+            _: &Self::Root,
+            _: &<Self::ParentWidget as crate::factory::FactoryView>::ReturnedWidget,
+            _: crate::prelude::FactoryComponentSender<Self>,
+        ) -> Self::Widgets {
+            ()
+        }
+
+        fn shutdown(&mut self, _: &mut Self::Widgets, _: crate::Sender<Self::Output>) {
+            self.add();
+        }
+    }
+
     #[test]
     #[should_panic]
     fn test_drop_panic() {
@@ -126,76 +182,39 @@ mod test {
     #[gtk::test]
     fn test_data_guard_drop() {
         let data = Box::new(DontDropBelow4(0_u8));
+        let widgets = Box::new(());
+        let (shutdown_notifier, mut shutdown_receiver) = shutdown::channel();
+        let (output_sender, _) = crate::channel();
         let (tx, rx) = flume::unbounded();
 
-        let main_ctx = MainContext::default();
+        let data = DataGuard::new(
+            data,
+            widgets,
+            shutdown_notifier,
+            output_sender,
+            |mut rt_data, _| async move {
+                while (rx.recv_async().await).is_ok() {
+                    rt_data.add();
+                }
+            },
+        );
 
-        let (data, rt) = DataGuard::new(data, |mut rt_data| async move {
-            while (rx.recv_async().await).is_ok() {
-                rt_data.add();
-            }
-        });
+        let main_ctx = MainContext::default();
 
         main_ctx.iteration(false);
         assert_eq!(data.get().value(), 0);
 
         tx.send(()).unwrap();
         tx.send(()).unwrap();
-        tx.send(()).unwrap();
         main_ctx.iteration(false);
 
-        assert_eq!(data.get().value(), 3);
+        assert_eq!(data.get().value(), 2);
 
         let mut data = data.into_inner();
-        // If destructor was called, it should have panicked by now
+        // Make sure the shutdown is called with yet another increment.
         assert_eq!(data.value(), 3);
-        assert!(rt.take().is_none());
-
-        main_ctx.iteration(false);
-
-        // Make sure the destructor doesn't panic
-        data.add();
-        assert_eq!(data.value(), 4);
-
-        tx.send(()).unwrap_err();
-        main_ctx.iteration(false);
-    }
-
-    #[gtk::test]
-    fn test_data_guard_rt_kill() {
-        let data = Box::new(DontDropBelow4(0_u8));
-        let (tx, rx) = flume::unbounded();
-
-        let main_ctx = MainContext::default();
-
-        let (data, rt) = DataGuard::new(data, |mut rt_data| async move {
-            while (rx.recv_async().await).is_ok() {
-                rt_data.add();
-            }
-        });
-
-        main_ctx.iteration(false);
-        assert_eq!(data.get().value(), 0);
-
-        tx.send(()).unwrap();
-        tx.send(()).unwrap();
-        tx.send(()).unwrap();
-        main_ctx.iteration(false);
-
-        assert_eq!(data.get().value(), 3);
-
-        // Manually drop the runtime from outside
-        rt.take().unwrap().remove();
-
-        // Value shouldn't change
-        tx.send(()).unwrap_err();
-        main_ctx.iteration(false);
-        assert_eq!(data.get().value(), 3);
-
-        let mut data = data.into_inner();
-        // If destructor was called, it should have panicked by now
-        assert_eq!(data.value(), 3);
-        assert!(rt.take().is_none());
+        // Make sure the shutdown receiver was notified.
+        shutdown_receiver.try_recv().unwrap();
 
         main_ctx.iteration(false);
 

--- a/relm4/src/factory/data_guard.rs
+++ b/relm4/src/factory/data_guard.rs
@@ -164,9 +164,7 @@ mod test {
             _: &Self::Root,
             _: &<Self::ParentWidget as crate::factory::FactoryView>::ReturnedWidget,
             _: crate::prelude::FactoryComponentSender<Self>,
-        ) -> Self::Widgets {
-            ()
-        }
+        ) -> Self::Widgets {}
 
         fn shutdown(&mut self, _: &mut Self::Widgets, _: crate::Sender<Self::Output>) {
             self.add();

--- a/relm4/src/factory/data_guard.rs
+++ b/relm4/src/factory/data_guard.rs
@@ -164,7 +164,8 @@ mod test {
             _: &Self::Root,
             _: &<Self::ParentWidget as crate::factory::FactoryView>::ReturnedWidget,
             _: crate::prelude::FactoryComponentSender<Self>,
-        ) -> Self::Widgets {}
+        ) -> Self::Widgets {
+        }
 
         fn shutdown(&mut self, _: &mut Self::Widgets, _: crate::Sender<Self::Output>) {
             self.add();

--- a/relm4/src/factory/traits.rs
+++ b/relm4/src/factory/traits.rs
@@ -3,7 +3,7 @@
 use gtk::prelude::IsA;
 
 use super::{DynamicIndex, FactoryComponentSender};
-use crate::{OnDestroy, Sender};
+use crate::Sender;
 
 use std::fmt::Debug;
 
@@ -106,7 +106,7 @@ pub trait FactoryComponent:
     type Init;
 
     /// The widget that was constructed by the factory component.
-    type Root: AsRef<<Self::ParentWidget as FactoryView>::Children> + Debug + OnDestroy + Clone;
+    type Root: AsRef<<Self::ParentWidget as FactoryView>::Children> + Debug + Clone;
 
     /// The type that's used for storing widgets created for this factory component.
     type Widgets: 'static;

--- a/relm4/src/shutdown/attached.rs
+++ b/relm4/src/shutdown/attached.rs
@@ -48,6 +48,6 @@ where
     ///
     /// Ignores any output when we don't care about it.
     pub async fn drop_on_shutdown(self) {
-        drop(self.wait().await);
+        let _ = self.wait().await;
     }
 }

--- a/relm4/src/shutdown/mod.rs
+++ b/relm4/src/shutdown/mod.rs
@@ -9,22 +9,12 @@ pub use attached::AttachedShutdown;
 pub use receiver::ShutdownReceiver;
 pub use sender::ShutdownSender;
 
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
-
 /// Creates a broadcasting shutdown channel.
 ///
 /// The sending side is responsible for initiating a shutdown.
 /// The receiving side is responsible for responding to shutdowns.
 #[must_use]
 pub fn channel() -> (ShutdownSender, ShutdownReceiver) {
-    let alive = Arc::new(AtomicBool::new(true));
     let (sender, receiver) = async_broadcast::broadcast(1);
-    (
-        ShutdownSender {
-            alive: alive.clone(),
-            sender,
-        },
-        ShutdownReceiver { alive, receiver },
-    )
+    (ShutdownSender { sender }, ShutdownReceiver { receiver })
 }

--- a/relm4/src/shutdown/receiver.rs
+++ b/relm4/src/shutdown/receiver.rs
@@ -1,18 +1,12 @@
 // Copyright 2022 System76 <info@system76.com>
 // SPDX-License-Identifier: MIT or Apache-2.0
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
-
 use super::AttachedShutdown;
 use async_broadcast::Receiver;
 
 /// Listens to shutdown signals and constructs shutdown futures.
 #[derive(Debug)]
 pub struct ShutdownReceiver {
-    pub(super) alive: Arc<AtomicBool>,
     pub(super) receiver: Receiver<()>,
 }
 
@@ -27,16 +21,18 @@ impl ShutdownReceiver {
 
     /// Waits until a shutdown signal is received.
     pub async fn wait(mut self) {
-        if self.alive.load(Ordering::SeqCst) {
-            let _ = self.receiver.recv().await;
-        }
+        drop(self.receiver.recv().await)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_recv(&mut self) -> Option<()> {
+        self.receiver.try_recv().ok()
     }
 }
 
 impl Clone for ShutdownReceiver {
     fn clone(&self) -> Self {
         Self {
-            alive: self.alive.clone(),
             receiver: self.receiver.clone(),
         }
     }

--- a/relm4/src/shutdown/receiver.rs
+++ b/relm4/src/shutdown/receiver.rs
@@ -21,7 +21,7 @@ impl ShutdownReceiver {
 
     /// Waits until a shutdown signal is received.
     pub async fn wait(mut self) {
-        drop(self.receiver.recv().await)
+        let _ = self.receiver.recv().await;
     }
 
     #[cfg(test)]

--- a/relm4/src/shutdown/sender.rs
+++ b/relm4/src/shutdown/sender.rs
@@ -2,26 +2,22 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 
 use async_broadcast::Sender;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
 /// Sends shutdown signals to receivers.
 #[derive(Debug)]
 pub struct ShutdownSender {
-    pub(super) alive: Arc<AtomicBool>,
     pub(super) sender: Sender<()>,
 }
 
 impl ShutdownSender {
     /// Broadcasts a shutdown signal to listening receivers.
     pub fn shutdown(&self) {
-        drop(self.sender.broadcast(()));
+        drop(self.sender.try_broadcast(()));
     }
 }
 
 impl Drop for ShutdownSender {
     fn drop(&mut self) {
-        self.alive.store(false, Ordering::SeqCst);
         self.shutdown();
     }
 }

--- a/relm4/src/shutdown/sender.rs
+++ b/relm4/src/shutdown/sender.rs
@@ -12,7 +12,7 @@ pub struct ShutdownSender {
 impl ShutdownSender {
     /// Broadcasts a shutdown signal to listening receivers.
     pub fn shutdown(&self) {
-        drop(self.sender.try_broadcast(()));
+        let _ = self.sender.try_broadcast(());
     }
 }
 


### PR DESCRIPTION
#### Summary

The previous way this was handled was pretty bad actually.
First of all, there were two ways to drop the runtime: When the `FactoryHandle` was dropped or when the root widget was dropped. The problem: the root widget cannot be dropped because it's stored in the `FactoryHandle` and likely also in the runtime itself. This is kind of a cyclic reference problem, the runtime stops when the root is dropped while the runtime keeps the root alive.

To solve this, `FactoryHandle` is now the only point that drops the runtime.
It also calls the `shutdown` method, so there's no weird sending of messages to the runtime to let it shutdown itself, instead it is properly stopped from outside (which also fixes all potential synchronization issues because we don't know how long it takes for messages to arrive). Actually, the previous implementation might have been unsound, but I can't confirm. 

This is also a problem for regular components, but I'll address that in another PR to make it easier to review.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
