### PR TITLE
Remove actions rs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,10 +51,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: "Check if the formatting is correct"
+        run: cargo fmt --all -- --check
 
   docs:
     name: check-docs
@@ -66,10 +64,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all-features
+      - name: "Build docs for all features"
+        run: cargo doc --all-features
 
   codespell:
     runs-on: ubuntu-latest

--- a/relm4-macros/src/widgets/gen/util/widget_func.rs
+++ b/relm4-macros/src/widgets/gen/util/widget_func.rs
@@ -18,7 +18,7 @@ impl Widget {
             (&ty.segments, ty.segments.len())
         } else if is_local {
             return Error::new(func.span().unwrap().into(),
-                    &format!("You need to specify the type of the local variable. Use this instead: {} -> Type {{ ...", 
+                    format!("You need to specify the type of the local variable. Use this instead: {} -> Type {{ ...", 
                     self.name)).into_compile_error();
         } else if func.args.is_some() {
             // If for example gtk::Box::new() was used, ignore ::new()
@@ -28,7 +28,7 @@ impl Widget {
                 panic!("Path can't be empty");
             } else if len == 1 {
                 return Error::new(func.span().unwrap().into(),
-                        &format!("You need to specify a type of your function. Use this instead: {}() -> Type {{ ...",
+                        format!("You need to specify a type of your function. Use this instead: {}() -> Type {{ ...",
                         path.to_token_stream())).into_compile_error();
             } else {
                 (&path.segments, len - 1)

--- a/relm4-macros/src/widgets/parse/attributes.rs
+++ b/relm4-macros/src/widgets/parse/attributes.rs
@@ -117,7 +117,7 @@ impl Parse for Attrs {
 fn unexpected_attr_name(ident: &Ident) -> Error {
     Error::new(
         ident.span(),
-        &format!("Unexpected attribute name `{}`.", ident),
+        format!("Unexpected attribute name `{}`.", ident),
     )
 }
 
@@ -138,7 +138,7 @@ fn expect_path_from_expr(expr: &Expr) -> Result<Path> {
     } else {
         Err(Error::new(
             expr.span(),
-            &format!("Expected path `{}`.", expr.to_token_stream()),
+            format!("Expected path `{}`.", expr.to_token_stream()),
         ))
     }
 }
@@ -149,7 +149,7 @@ fn expect_ident_from_expr(expr: &Expr) -> Result<Ident> {
     } else {
         Err(Error::new(
             expr.span(),
-            &format!("Expected identifier `{}`.", expr.to_token_stream()),
+            format!("Expected identifier `{}`.", expr.to_token_stream()),
         ))
     }
 }


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

All Actions from actions-rs seem to no longer be maintained. This also applies to actions-rs/cargo. It can just be replaced by the cargo command. I also fixed a small clippy lint to fix the workflows

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
