### PR TITLE
Move the pre-proccessed doc headers into source

### DIFF
--- a/relm4-components/src/lib.rs
+++ b/relm4-components/src/lib.rs
@@ -1,7 +1,7 @@
 //! Collection of reusable and easily configurable components for Relm4.
 //!
 //! The docs are available in two versions.
-//! Use the [stable docs](https://docs.rs/relm4_components) if you want get information about a version that was already published.
+//! Use the [stable docs](https://relm4.org/docs/stable/relm4_components/) if you want get information about a version that was already published.
 //! Visit the [nightly docs](https://relm4.org/docs/next/relm4_components/) if are trying out the newest but possibly unstable version of the crate.
 //!
 //! Docs of related crates:

--- a/relm4-components/src/lib.rs
+++ b/relm4-components/src/lib.rs
@@ -1,4 +1,22 @@
 //! Collection of reusable and easily configurable components for Relm4.
+//!
+//! The docs are available in two versions.
+//! Use the [stable docs](https://docs.rs/relm4_components) if you want get information about a version that was already published.
+//! Visit the [nightly docs](https://relm4.org/docs/next/relm4_components/) if are trying out the newest but possibly unstable version of the crate.
+//!
+//! Docs of related crates:
+//! [relm4](../relm4/index.html)
+//! | [relm4-macros](../relm4_macros/index.html)
+//! | [relm4-components](../relm4_components/index.html)
+//! | [gtk4-rs](https://gtk-rs.org/gtk4-rs/git/docs)
+//! | [gtk-rs-core](https://gtk-rs.org/gtk-rs-core/git/docs)
+//! | [libadwaita-rs](https://world.pages.gitlab.gnome.org/Rust/libadwaita-rs/git/docs/libadwaita)
+//! | [libpanel-rs](https://world.pages.gitlab.gnome.org/Rust/libpanel-rs/git/docs/libpanel)
+//!
+//! [GitHub](https://github.com/Relm4/Relm4)
+//! | [Website](https://relm4.org)
+//! | [Book](https://relm4.org/book/stable/)
+//! | [Blog](https://relm4.org/blog)
 
 #![doc(html_logo_url = "https://relm4.org/icons/relm4_logo.svg")]
 #![doc(html_favicon_url = "https://relm4.org/icons/relm4_org.svg")]

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -1,7 +1,7 @@
 //! A collection of macros for gtk-rs, Relm4 and Rust in general.
 //!
 //! The docs are available in two versions.
-//! Use the [stable docs](https://docs.rs/relm4_macros) if you want get information about a version that was already published.
+//! Use the [stable docs](https://relm4.org/docs/stable/relm4_macros/) if you want get information about a version that was already published.
 //! Visit the [nightly docs](https://relm4.org/docs/next/relm4_macros/) if are trying out the newest but possibly unstable version of the crate.
 //!
 //! Docs of related crates:

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -1,4 +1,22 @@
 //! A collection of macros for gtk-rs, Relm4 and Rust in general.
+//!
+//! The docs are available in two versions.
+//! Use the [stable docs](https://docs.rs/relm4_macros) if you want get information about a version that was already published.
+//! Visit the [nightly docs](https://relm4.org/docs/next/relm4_macros/) if are trying out the newest but possibly unstable version of the crate.
+//!
+//! Docs of related crates:
+//! [relm4](../relm4/index.html)
+//! | [relm4-macros](../relm4_macros/index.html)
+//! | [relm4-components](../relm4_components/index.html)
+//! | [gtk4-rs](https://gtk-rs.org/gtk4-rs/git/docs)
+//! | [gtk-rs-core](https://gtk-rs.org/gtk-rs-core/git/docs)
+//! | [libadwaita-rs](https://world.pages.gitlab.gnome.org/Rust/libadwaita-rs/git/docs/libadwaita)
+//! | [libpanel-rs](https://world.pages.gitlab.gnome.org/Rust/libpanel-rs/git/docs/libpanel)
+//!
+//! [GitHub](https://github.com/Relm4/Relm4)
+//! | [Website](https://relm4.org)
+//! | [Book](https://relm4.org/book/stable/)
+//! | [Blog](https://relm4.org/blog)
 
 #![doc(html_logo_url = "https://relm4.org/icons/relm4_logo.svg")]
 #![doc(html_favicon_url = "https://relm4.org/icons/relm4_org.svg")]

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -1,7 +1,7 @@
 //! An idiomatic GUI library inspired by Elm and based on gtk4-rs.
 //!
 //! The docs are available in two versions.
-//! Use the [stable docs](https://docs.rs/relm4) if you want get information about a version that was already published.
+//! Use the [stable docs](https://relm4.org/docs/stable/relm4/) if you want get information about a version that was already published.
 //! Visit the [nightly docs](https://relm4.org/docs/next/relm4/) if are trying out the newest but possibly unstable version of the crate.
 //!
 //! Docs of related crates:

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -1,4 +1,22 @@
 //! An idiomatic GUI library inspired by Elm and based on gtk4-rs.
+//!
+//! The docs are available in two versions.
+//! Use the [stable docs](https://docs.rs/relm4) if you want get information about a version that was already published.
+//! Visit the [nightly docs](https://relm4.org/docs/next/relm4/) if are trying out the newest but possibly unstable version of the crate.
+//!
+//! Docs of related crates:
+//! [relm4](../relm4/index.html)
+//! | [relm4-macros](../relm4_macros/index.html)
+//! | [relm4-components](../relm4_components/index.html)
+//! | [gtk4-rs](https://gtk-rs.org/gtk4-rs/git/docs)
+//! | [gtk-rs-core](https://gtk-rs.org/gtk-rs-core/git/docs)
+//! | [libadwaita-rs](https://world.pages.gitlab.gnome.org/Rust/libadwaita-rs/git/docs/libadwaita)
+//! | [libpanel-rs](https://world.pages.gitlab.gnome.org/Rust/libpanel-rs/git/docs/libpanel)
+//!
+//! [GitHub](https://github.com/Relm4/Relm4)
+//! | [Website](https://relm4.org)
+//! | [Book](https://relm4.org/book/stable/)
+//! | [Blog](https://relm4.org/blog)
 
 #![doc(html_logo_url = "https://relm4.org/icons/relm4_logo.svg")]
 #![doc(html_favicon_url = "https://relm4.org/icons/relm4_org.svg")]


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

As mentioned in https://github.com/Relm4/Relm4/issues/292, in order to have the same content in the docs regardless of where they are built, the preprocessed doc headers need to be moved to the source. I moved the collection of links to the source. There are two downsides

- I am not sure it is possible to add the timestamp of the creation to it so I left it out
- The links point to the nightly versions of the other libraries ([gtk4-rs](https://gtk-rs.org/gtk4-rs/git/docs) | [gtk-rs-core](https://gtk-rs.org/gtk-rs-core/git/docs) | [libadwaita-rs](https://world.pages.gitlab.gnome.org/Rust/libadwaita-rs/git/docs/libadwaita) | [libpanel-rs](https://world.pages.gitlab.gnome.org/Rust/libpanel-rs/git/docs/libpanel))
- The link to the book goes to the stable version https://relm4.org/book/stable/

The reason I pointed the links to the nightly versions of the crates is that I don't know how the comments can be conditionally compiled so that they point to the nightly or the stable version. However there is a popup that warns the users about visiting the nightly version.

Are those the only pre-proccessed doc headers?
