### PR TITLE
clarify component documentation

### DIFF
--- a/relm4/src/component/async/traits.rs
+++ b/relm4/src/component/async/traits.rs
@@ -8,7 +8,10 @@ use crate::{sender::AsyncComponentSender, Sender};
 
 use super::{AsyncComponentBuilder, AsyncComponentParts};
 
-/// Elm-style variant of a Component with view updates separated from input updates
+/// Asynchronous variant of [`Component`](crate::Component).
+///
+/// `AsyncComponent` is powerful and flexible, but for many use-cases the [`SimpleAsyncComponent`]
+/// convenience trait will suffice.
 #[async_trait::async_trait(?Send)]
 pub trait AsyncComponent: Sized + 'static {
     /// Messages which are received from commands executing in the background.
@@ -58,7 +61,19 @@ pub trait AsyncComponent: Sized + 'static {
     ) {
     }
 
-    /// Handles updates from a command.
+    /// Updates the model and view upon completion of a command.
+    ///
+    /// Overriding this method is helpful if you need access to the widgets while processing a
+    /// command output.
+    ///
+    /// The default implementation of this method calls [`update_cmd`] followed by [`update_view`].
+    /// If you override this method while using the [`component`] macro, you must remember to call
+    /// [`update_view`] in your implementation. Otherwise, the view will not reflect the updated
+    /// model.
+    ///
+    /// [`update_cmd`]: Self::update_cmd
+    /// [`update_view`]: Self::update_view
+    /// [`component`]: relm4_macros::component
     async fn update_cmd_with_view(
         &mut self,
         widgets: &mut Self::Widgets,
@@ -73,7 +88,19 @@ pub trait AsyncComponent: Sized + 'static {
     #[allow(unused)]
     fn update_view(&self, widgets: &mut Self::Widgets, sender: AsyncComponentSender<Self>) {}
 
-    /// Updates the model and view. Optionally returns a command to run.
+    /// Updates the model and view when a new input is received.
+    ///
+    /// Overriding this method is helpful if you need access to the widgets while processing an
+    /// input.
+    ///
+    /// The default implementation of this method calls [`update`] followed by [`update_view`]. If
+    /// you override this method while using the [`component`] macro, you must remember to
+    /// call [`update_view`] in your implementation. Otherwise, the view will not reflect the
+    /// updated model.
+    ///
+    /// [`update`]: Self::update
+    /// [`update_view`]: Self::update_view
+    /// [`component`]: relm4_macros::component
     async fn update_with_view(
         &mut self,
         widgets: &mut Self::Widgets,
@@ -97,7 +124,7 @@ pub trait AsyncComponent: Sized + 'static {
     }
 }
 
-/// Elm-style variant of a Component with view updates separated from input updates
+/// Asynchronous variant of [`SimpleComponent`](crate::SimpleComponent).
 #[async_trait::async_trait(?Send)]
 pub trait SimpleAsyncComponent: Sized + 'static {
     /// The message type that the component accepts as inputs.

--- a/relm4/src/component/sync/traits.rs
+++ b/relm4/src/component/sync/traits.rs
@@ -6,7 +6,15 @@ use std::fmt::Debug;
 
 use crate::{ComponentBuilder, ComponentParts, ComponentSender, Sender};
 
-/// Elm-style variant of a Component with view updates separated from input updates
+/// The fundamental building block of a Relm4 application.
+///
+/// A `Component` is an element of an application that defines initialization, state, behavior and
+/// communication as a modular unit.
+///
+/// `Component` is powerful and flexible, but for many use-cases the [`SimpleComponent`]
+/// convenience trait will suffice. [`SimpleComponent`] enforces separation between model and view
+/// updates, and provides no-op implementations for advanced features that are not relevant for most
+/// use-cases.
 pub trait Component: Sized + 'static {
     /// Messages which are received from commands executing in the background.
     type CommandOutput: Debug + Send + 'static;
@@ -32,7 +40,7 @@ pub trait Component: Sized + 'static {
         ComponentBuilder::<Self>::default()
     }
 
-    /// Initializes the root widget
+    /// Initializes the root widget.
     fn init_root() -> Self::Root;
 
     /// Creates the initial model and view, docking it into the component.
@@ -50,7 +58,19 @@ pub trait Component: Sized + 'static {
     #[allow(unused)]
     fn update_cmd(&mut self, message: Self::CommandOutput, sender: ComponentSender<Self>) {}
 
-    /// Handles updates from a command.
+    /// Updates the model and view upon completion of a command.
+    ///
+    /// Overriding this method is helpful if you need access to the widgets while processing a
+    /// command output.
+    ///
+    /// The default implementation of this method calls [`update_cmd`] followed by [`update_view`].
+    /// If you override this method while using the [`component`] macro, you must remember to call
+    /// [`update_view`] in your implementation. Otherwise, the view will not reflect the updated
+    /// model.
+    ///
+    /// [`update_cmd`]: Self::update_cmd
+    /// [`update_view`]: Self::update_view
+    /// [`component`]: relm4_macros::component
     fn update_cmd_with_view(
         &mut self,
         widgets: &mut Self::Widgets,
@@ -65,7 +85,19 @@ pub trait Component: Sized + 'static {
     #[allow(unused)]
     fn update_view(&self, widgets: &mut Self::Widgets, sender: ComponentSender<Self>) {}
 
-    /// Updates the model and view. Optionally returns a command to run.
+    /// Updates the model and view when a new input is received.
+    ///
+    /// Overriding this method is helpful if you need access to the widgets while processing an
+    /// input.
+    ///
+    /// The default implementation of this method calls [`update`] followed by [`update_view`]. If
+    /// you override this method while using the [`component`] macro, you must remember to
+    /// call [`update_view`] in your implementation. Otherwise, the view will not reflect the
+    /// updated model.
+    ///
+    /// [`update`]: Self::update
+    /// [`update_view`]: Self::update_view
+    /// [`component`]: relm4_macros::component
     fn update_with_view(
         &mut self,
         widgets: &mut Self::Widgets,
@@ -89,7 +121,7 @@ pub trait Component: Sized + 'static {
     }
 }
 
-/// Elm-style variant of a Component with view updates separated from input updates
+/// Elm-style variant of a [`Component`] with view updates separated from input updates.
 pub trait SimpleComponent: Sized + 'static {
     /// The message type that the component accepts as inputs.
     type Input: Debug + 'static;


### PR DESCRIPTION
#### Summary

This PR updates the `Component` documentation to remove some incorrect information and expand on some gotchas.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [ ] updated CHANGES.md
