### PR TITLE
core: Pass root to update and update_cmd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 ### Changed
 
 + core: Add `gnome_42` and `gnome_43` feature flags
++ core: Pass `Root` during `update` and `update_cmd` for `Component` and `AsyncComponent`
 + core: Rename `OnDestroy` to `RelmObjectExt`
 + core: Remove `EmptyRoot` in favor of the unit type
 + macros: Allow using methods calls as widget initializers in the `view` macro

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -66,7 +66,7 @@ impl Component for App {
       }
     }
 
-    fn update(&mut self, msg: Msg, _sender: ComponentSender<Self>) {
+    fn update(&mut self, msg: Msg, _sender: ComponentSender<Self>, _root: &Self::Root) {
         let cx = self.handler.get_context();
 
         match msg {
@@ -87,7 +87,7 @@ impl Component for App {
         draw(&cx, &self.points);
     }
 
-    fn update_cmd(&mut self, _: UpdatePointsMsg, _: ComponentSender<Self>) {
+    fn update_cmd(&mut self, _: UpdatePointsMsg, _: ComponentSender<Self>, _root: &Self::Root) {
         for point in &mut self.points {
             let Point { x, y, .. } = point;
             if *x < 0.0 {

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -254,7 +254,7 @@ impl Component for App {
         ComponentParts { model, widgets }
     }
 
-    fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>) {
+    fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
         match msg {
             AppMsg::StartGame(index) => {
                 self.start_index = Some(index);
@@ -281,7 +281,12 @@ impl Component for App {
         }
     }
 
-    fn update_cmd(&mut self, msg: Self::CommandOutput, sender: ComponentSender<Self>) {
+    fn update_cmd(
+        &mut self,
+        msg: Self::CommandOutput,
+        sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
         if msg {
             sender.input(AppMsg::StopGame);
         } else {

--- a/examples/non_blocking_async.rs
+++ b/examples/non_blocking_async.rs
@@ -71,7 +71,12 @@ impl Component for App {
         ComponentParts { model, widgets }
     }
 
-    fn update_cmd(&mut self, msg: Self::CommandOutput, _sender: ComponentSender<Self>) {
+    fn update_cmd(
+        &mut self,
+        msg: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
         match msg {
             Msg::Increment => {
                 self.counter = self.counter.wrapping_add(1);

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -117,7 +117,7 @@ impl Component for App {
         }
     }
 
-    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
         match message {
             Input::Compute => {
                 self.computing = true;
@@ -144,7 +144,12 @@ impl Component for App {
         }
     }
 
-    fn update_cmd(&mut self, message: Self::CommandOutput, _sender: ComponentSender<Self>) {
+    fn update_cmd(
+        &mut self,
+        message: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
         if let CmdOut::Finished(_) = message {
             self.computing = false;
         }

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -147,7 +147,7 @@ impl Component for App {
         }
     }
 
-    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
         match message {
             Input::AddSetting {
                 description,
@@ -173,7 +173,12 @@ impl Component for App {
         }
     }
 
-    fn update_cmd(&mut self, message: Self::CommandOutput, sender: ComponentSender<Self>) {
+    fn update_cmd(
+        &mut self,
+        message: Self::CommandOutput,
+        sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
         match message {
             CmdOut::Reload => {
                 sender.output(Output::Reload);

--- a/examples/simple_async.rs
+++ b/examples/simple_async.rs
@@ -84,7 +84,12 @@ impl AsyncComponent for App {
         AsyncComponentParts { model, widgets }
     }
 
-    async fn update(&mut self, msg: Self::Input, _sender: AsyncComponentSender<Self>) {
+    async fn update(
+        &mut self,
+        msg: Self::Input,
+        _sender: AsyncComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
         async_std::task::sleep(Duration::from_secs(1)).await;
         match msg {
             Msg::Increment => {

--- a/examples/transient_dialog.rs
+++ b/examples/transient_dialog.rs
@@ -20,11 +20,10 @@ enum DialogMsg {
 }
 
 #[relm4::component]
-impl Component for Dialog {
+impl SimpleComponent for Dialog {
     type Init = ();
     type Input = DialogMsg;
     type Output = ButtonMsg;
-    type CommandOutput = ();
 
     view! {
         dialog = gtk::Dialog {

--- a/relm4-components/src/simple_combo_box.rs
+++ b/relm4-components/src/simple_combo_box.rs
@@ -72,6 +72,7 @@ where
         widgets: &mut Self::Widgets,
         input: Self::Input,
         sender: ComponentSender<Self>,
+        _root: &Self::Root,
     ) {
         match input {
             SimpleComboBoxMsg::UpdateIndex(idx) => {

--- a/relm4/src/component/async/builder.rs
+++ b/relm4/src/component/async/builder.rs
@@ -181,7 +181,7 @@ impl<C: AsyncComponent> AsyncComponentBuilder<C> {
         // updates, and send `Self::Output` messages externally.
         let id = crate::spawn_local_with_priority(priority, async move {
             let id = source_id_receiver.await.unwrap();
-            let mut state = C::init(payload, rt_root, component_sender.clone()).await;
+            let mut state = C::init(payload, rt_root.clone(), component_sender.clone()).await;
             let mut cmd = GuardedReceiver::new(cmd_receiver);
             let mut input = GuardedReceiver::new(input_rx);
 
@@ -203,7 +203,7 @@ impl<C: AsyncComponent> AsyncComponentBuilder<C> {
                         );
                         let _enter = span.enter();
 
-                        model.update_with_view(widgets, message, component_sender.clone()).await;
+                        model.update_with_view(widgets, message, component_sender.clone(), &rt_root).await;
                     }
 
                     // Handles responses from a command.
@@ -221,7 +221,7 @@ impl<C: AsyncComponent> AsyncComponentBuilder<C> {
                         );
                         let _enter = span.enter();
 
-                        model.update_cmd_with_view(widgets, message, component_sender.clone()).await;
+                        model.update_cmd_with_view(widgets, message, component_sender.clone(), &rt_root).await;
                     }
 
                     // Triggered when the component is destroyed

--- a/relm4/src/component/async/traits.rs
+++ b/relm4/src/component/async/traits.rs
@@ -57,7 +57,13 @@ pub trait AsyncComponent: Sized + 'static {
 
     /// Processes inputs received by the component.
     #[allow(unused)]
-    async fn update(&mut self, message: Self::Input, sender: AsyncComponentSender<Self>) {}
+    async fn update(
+        &mut self,
+        message: Self::Input,
+        sender: AsyncComponentSender<Self>,
+        root: &Self::Root,
+    ) {
+    }
 
     /// Defines how the component should respond to command updates.
     #[allow(unused)]
@@ -65,6 +71,7 @@ pub trait AsyncComponent: Sized + 'static {
         &mut self,
         message: Self::CommandOutput,
         sender: AsyncComponentSender<Self>,
+        root: &Self::Root,
     ) {
     }
 
@@ -86,8 +93,9 @@ pub trait AsyncComponent: Sized + 'static {
         widgets: &mut Self::Widgets,
         message: Self::CommandOutput,
         sender: AsyncComponentSender<Self>,
+        root: &Self::Root,
     ) {
-        self.update_cmd(message, sender.clone()).await;
+        self.update_cmd(message, sender.clone(), root).await;
         self.update_view(widgets, sender);
     }
 
@@ -113,8 +121,9 @@ pub trait AsyncComponent: Sized + 'static {
         widgets: &mut Self::Widgets,
         message: Self::Input,
         sender: AsyncComponentSender<Self>,
+        root: &Self::Root,
     ) {
-        self.update(message, sender.clone()).await;
+        self.update(message, sender.clone(), root).await;
         self.update_view(widgets, sender);
     }
 
@@ -212,7 +221,12 @@ where
         C::init(init, root, sender).await
     }
 
-    async fn update(&mut self, message: Self::Input, sender: AsyncComponentSender<Self>) {
+    async fn update(
+        &mut self,
+        message: Self::Input,
+        sender: AsyncComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
         C::update(self, message, sender).await;
     }
 

--- a/relm4/src/component/sync/builder.rs
+++ b/relm4/src/component/sync/builder.rs
@@ -202,6 +202,7 @@ impl<C: Component> ComponentBuilder<C> {
         };
 
         let rt_state = watcher.state.clone();
+        let rt_root = root.clone();
 
         // Spawns the component's service. It will receive both `Self::Input` and
         // `Self::CommandOutput` messages. It will spawn commands as requested by
@@ -229,7 +230,7 @@ impl<C: Component> ComponentBuilder<C> {
                         );
                         let _enter = span.enter();
 
-                        model.update_with_view(widgets, message, component_sender.clone());
+                        model.update_with_view(widgets, message, component_sender.clone(), &rt_root);
                     }
 
                     // Handles responses from a command.
@@ -247,7 +248,7 @@ impl<C: Component> ComponentBuilder<C> {
                         );
                         let _enter = span.enter();
 
-                        model.update_cmd_with_view(widgets, message, component_sender.clone());
+                        model.update_cmd_with_view(widgets, message, component_sender.clone(), &rt_root);
                     }
 
                     // Triggered when the model and view have been updated externally.

--- a/relm4/src/component/sync/stream.rs
+++ b/relm4/src/component/sync/stream.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use flume::r#async::RecvStream;
-use futures::{pin_mut, Stream};
+use futures::{pin_mut, Stream, StreamExt};
 
 use crate::{Component, ShutdownOnDrop};
 
@@ -28,6 +28,14 @@ impl<C: Component> Stream for ComponentStream<C> {
         let stream = &mut self.stream;
         pin_mut!(stream);
         stream.poll_next(cx)
+    }
+}
+
+impl<C: Component> ComponentStream<C> {
+    /// Receive one message and drop the component afterwards.
+    /// This can be used for dialogs.
+    pub async fn recv_one(mut self) -> Option<C::Output> {
+        self.stream.next().await
     }
 }
 

--- a/relm4/src/component/sync/traits.rs
+++ b/relm4/src/component/sync/traits.rs
@@ -29,7 +29,7 @@ pub trait Component: Sized + 'static {
     type Init;
 
     /// The widget that was constructed by the component.
-    type Root: Debug;
+    type Root: Debug + Clone;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;
@@ -52,11 +52,17 @@ pub trait Component: Sized + 'static {
 
     /// Processes inputs received by the component.
     #[allow(unused)]
-    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {}
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>, root: &Self::Root) {}
 
     /// Defines how the component should respond to command updates.
     #[allow(unused)]
-    fn update_cmd(&mut self, message: Self::CommandOutput, sender: ComponentSender<Self>) {}
+    fn update_cmd(
+        &mut self,
+        message: Self::CommandOutput,
+        sender: ComponentSender<Self>,
+        root: &Self::Root,
+    ) {
+    }
 
     /// Updates the model and view upon completion of a command.
     ///
@@ -76,8 +82,9 @@ pub trait Component: Sized + 'static {
         widgets: &mut Self::Widgets,
         message: Self::CommandOutput,
         sender: ComponentSender<Self>,
+        root: &Self::Root,
     ) {
-        self.update_cmd(message, sender.clone());
+        self.update_cmd(message, sender.clone(), root);
         self.update_view(widgets, sender);
     }
 
@@ -103,8 +110,9 @@ pub trait Component: Sized + 'static {
         widgets: &mut Self::Widgets,
         message: Self::Input,
         sender: ComponentSender<Self>,
+        root: &Self::Root,
     ) {
-        self.update(message, sender.clone());
+        self.update(message, sender.clone(), root);
         self.update_view(widgets, sender);
     }
 
@@ -133,7 +141,7 @@ pub trait SimpleComponent: Sized + 'static {
     type Init;
 
     /// The widget that was constructed by the component.
-    type Root: Debug;
+    type Root: Debug + Clone;
 
     /// The type that's used for storing widgets created for this component.
     type Widgets: 'static;
@@ -189,7 +197,7 @@ where
         C::init(init, root, sender)
     }
 
-    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
         C::update(self, message, sender);
     }
 

--- a/relm4/src/component/worker.rs
+++ b/relm4/src/component/worker.rs
@@ -121,7 +121,7 @@ where
                             );
                             let _enter = span.enter();
 
-                            model.update_with_view(widgets, message, component_sender.clone());
+                            model.update_with_view(widgets, message, component_sender.clone(), &root);
                         }
 
                         // Handles responses from a command.
@@ -139,7 +139,7 @@ where
                             );
                             let _enter = span.enter();
 
-                            model.update_cmd_with_view(widgets, message, component_sender.clone());
+                            model.update_cmd_with_view(widgets, message, component_sender.clone(), &root);
                         },
 
                         // Triggered when the component is destroyed


### PR DESCRIPTION
#### Summary

Currently, the root is only passed to the `init()` function but not available later. Therefore, if you want to create a dialog as response to a message, you can't simply call `set_transient_for()`. As a workaround, you can use `update_with_view()` which isn't a great solution.

This PR adds the root as a parameter of `update()` and `update_cmd()` for `Component` and `AsyncComponent`.
All sub-traits like `SimpleComponent` are not affected.
This makes it easier to use dialogs the way they are intended to be used by the GTK developers (a window that waits for a response and is destroyed afterwards).

The changes in the "message_stream" example show how this helps with creating dialogs.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
