### PR TITLE
macros: Allow expressions for menu entry names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
++ macros: Allow expressions for names of menu entries
+
 ## 0.5.0-beta.5 - 2022-11-26
 
 ### Added

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -323,6 +323,10 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```
+/// # fn gettext(string: &str) -> String {
+/// #     string.to_owned()
+/// # }
+/// #
 /// // Define some actions
 /// relm4::new_action_group!(WindowActionGroup, "win");
 /// relm4::new_stateless_action!(TestAction, WindowActionGroup, "test");
@@ -332,7 +336,8 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
 /// relm4_macros::menu! {
 ///     main_menu: {
 ///         custom: "my_widget",
-///         "Test" => TestAction,
+///         // Translate with gettext-rs, for example.
+///         &gettext("Test") => TestAction,
 ///         "Test2" => TestAction,
 ///         "Test toggle" => TestU8Action(1_u8),
 ///         section! {
@@ -353,6 +358,10 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
 /// The code generation for the example above looks like this (plus comments):
 ///
 /// ```
+/// # fn gettext(string: &str) -> String {
+/// #     string.to_owned()
+/// # }
+/// #
 /// struct WindowActionGroup;
 /// impl relm4::actions::ActionGroupName for WindowActionGroup {
 ///     const NAME: &'static str = "win";
@@ -385,7 +394,7 @@ pub fn factory(attributes: TokenStream, input: TokenStream) -> TokenStream {
 /// new_entry.set_attribute_value("custom", Some(&variant));
 /// main_menu.append_item(&new_entry);
 ///
-/// let new_entry = relm4::actions::RelmAction::<TestAction>::to_menu_item("Test");
+/// let new_entry = relm4::actions::RelmAction::<TestAction>::to_menu_item(&gettext("Test"));
 /// main_menu.append_item(&new_entry);
 /// let new_entry = relm4::actions::RelmAction::<TestAction>::to_menu_item("Test2");
 /// main_menu.append_item(&new_entry);

--- a/relm4-macros/src/menu/gen.rs
+++ b/relm4-macros/src/menu/gen.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
-use syn::{Ident, LitStr};
+use syn::{spanned::Spanned, Ident, LitStr};
 
 use super::{Menu, MenuEntry, MenuItem, MenuSection, Menus};
 

--- a/relm4-macros/src/menu/mod.rs
+++ b/relm4-macros/src/menu/mod.rs
@@ -25,7 +25,7 @@ enum MenuItem {
 
 #[derive(Debug)]
 struct MenuEntry {
-    string: LitStr,
+    string: Expr,
     action_ty: Path,
     value: Option<Expr>,
 }


### PR DESCRIPTION
#### Summary

Fixes #360

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md

CC @MTRNord