### PR TITLE
Fix app init

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
++ core: Take `&str` instead of `&[u8]` in `set_global_css()`
 + macros: Allow expressions for names of menu entries
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,18 @@
 # Changelog
 
 ## Unreleased
-+ core: Support factories with adw::PreferencePage
+
+### Added
+
++ core: Support factories with `adw::PreferencePage`
 
 ### Changed
 
 + macros: Allow expressions for names of menu entries
+
+### Fixed
+
++ core: Initialize GTK when calling `RelmApp::new()`
 
 ## 0.5.0-beta.5 - 2022-11-26
 

--- a/examples/tracker.rs
+++ b/examples/tracker.rs
@@ -122,7 +122,7 @@ impl SimpleComponent for App {
 
 fn main() {
     let app = RelmApp::new("relm4.example.tracker");
-    relm4::set_global_css(b".identical { background: #00ad5c; }");
+    relm4::set_global_css(".identical { background: #00ad5c; }");
 
     app.run::<App>(());
 }

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -21,6 +21,7 @@ impl RelmApp {
     /// object to [`RelmApp::with_app`].
     #[must_use]
     pub fn new(app_id: &str) -> Self {
+        crate::init();
         let app = crate::main_application();
         app.set_application_id(Some(app_id));
 

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -144,10 +144,10 @@ pub fn main_application() -> gtk::Application {
 ///
 /// This function panics if [`RelmApp::new`] wasn't called before
 /// or this function is not called on the thread that also called [`RelmApp::new`].
-pub fn set_global_css(style_data: &[u8]) {
+pub fn set_global_css(style_data: &str) {
     let display = gtk::gdk::Display::default().unwrap();
     let provider = gtk::CssProvider::new();
-    provider.load_from_data(style_data);
+    provider.load_from_data(style_data.as_bytes());
     gtk::StyleContext::add_provider_for_display(
         &display,
         &provider,
@@ -164,7 +164,7 @@ pub fn set_global_css(style_data: &[u8]) {
 /// This function panics if [`RelmApp::new`] wasn't called before
 /// or this function is not called on the thread that also called [`RelmApp::new`].
 pub fn set_global_css_from_file<P: AsRef<std::path::Path>>(path: P) {
-    match std::fs::read(path) {
+    match std::fs::read_to_string(path) {
         Ok(bytes) => {
             set_global_css(&bytes);
         }

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -105,14 +105,10 @@ fn set_main_application(app: impl IsA<gtk::Application>) {
     MAIN_APPLICATION.with(move |cell| cell.set(Some(app.upcast())));
 }
 
-#[cfg(feature = "libadwaita")]
-fn new_application() -> gtk::Application {
-    adw::Application::default().upcast()
-}
-
-#[cfg(not(feature = "libadwaita"))]
-fn new_application() -> gtk::Application {
-    gtk::Application::default()
+fn init() {
+    gtk::init().unwrap();
+    #[cfg(feature = "libadwaita")]
+    adw::init().unwrap();
 }
 
 /// Returns the global [`gtk::Application`] that's used internally
@@ -125,6 +121,16 @@ fn new_application() -> gtk::Application {
 /// [`RelmApp::with_app()`].
 #[must_use]
 pub fn main_application() -> gtk::Application {
+    #[cfg(feature = "libadwaita")]
+    fn new_application() -> gtk::Application {
+        adw::Application::default().upcast()
+    }
+
+    #[cfg(not(feature = "libadwaita"))]
+    fn new_application() -> gtk::Application {
+        gtk::Application::default()
+    }
+
     MAIN_APPLICATION.with(|cell| {
         let app = cell.take().unwrap_or_else(new_application);
         cell.set(Some(app.clone()));


### PR DESCRIPTION
#### Summary

Fixes #364

Also, `set_global_css()` now takes  `&str` instead of `&[u8]` which should make it easier to use with regular string literals and CSS should be valid UTF-8 anyway.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md