### PR TITLE
Prevent leaking CommandSenderInner struct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
++ core: Prevent leaking `CommandSenderInner` struct
+
 ## 0.5.0-rc.1
 
 ### Added


### PR DESCRIPTION
#### Summary
Earlier, this struct was being leaked due to the implementation of Deref. However, since the struct was never actually exported, documentation was not being generated for it's methods.

This commit just makes the struct private and instead creates wrapper functions over it. This is typically whats done in Rust std.

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
