### PR TITLE
Change the link of the docs of all crates to docs.rs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
++ All crates now use docs.rs to host the documentation. The documentation on the website will be deprecated.
+
 ### Fixed
 
 + components: Fix doc links to examples on GitHub

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/Relm4/Relm4/actions/workflows/rust.yml/badge.svg)](https://github.com/Relm4/Relm4/actions/workflows/rust.yml)
 [![Matrix](https://img.shields.io/matrix/relm4:matrix.org?label=matrix%20chat)](https://matrix.to/#/#relm4:matrix.org)
 [![Relm4 on crates.io](https://img.shields.io/crates/v/relm4.svg)](https://crates.io/crates/relm4)
-[![Relm4 docs](https://img.shields.io/badge/rust-documentation-blue)](https://relm4.org/docs/stable/relm4/)
+[![Relm4 docs](https://img.shields.io/badge/rust-documentation-blue)](https://docs.rs/relm4/)
 [![Relm4 book](https://img.shields.io/badge/rust-book-fc0060)](https://relm4.org/book/stable/)
 ![Minimum Rust version 1.64](https://img.shields.io/badge/rustc-1.64+-06a096.svg)
 [![dependency status](https://deps.rs/repo/github/Relm4/Relm4/status.svg)](https://deps.rs/repo/github/Relm4/Relm4)
@@ -31,7 +31,7 @@ Built on top of this foundation, Relm4 makes developing more idiomatic, simpler 
 ## Documentation
 
 + 📖 **[The Relm4 book](https://relm4.org/book/stable/)**
-+ 📜 **[Rust documentation](https://relm4.org/docs/stable/relm4/)**
++ 📜 **[Rust documentation](https://docs.rs/relm4/)**
 
 ## Dependencies
 

--- a/examples/settings_list.rs
+++ b/examples/settings_list.rs
@@ -32,7 +32,7 @@ fn main() {
 
                         match id {
                             0 => xdg_open("https://github.com/Relm4/Relm4".into()),
-                            1 => xdg_open("https://relm4.org/docs/stable/relm4/".into()),
+                            1 => xdg_open("https://docs.rs/relm4/".into()),
                             2 => {
                                 sender.send(Input::Clear).unwrap();
                             }

--- a/relm4-components/Cargo.toml
+++ b/relm4-components/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "relm4-components"
 readme = "README.md"
-documentation = "https://relm4.org/docs/stable/relm4_components/"
+documentation = "https://docs.rs/relm4_components/"
 
 version.workspace = true
 authors.workspace = true

--- a/relm4-components/README.md
+++ b/relm4-components/README.md
@@ -1,6 +1,6 @@
 # Relm4 components
 
 [![Relm4-components on crates.io](https://img.shields.io/crates/v/relm4-components.svg)](https://crates.io/crates/relm4-components)
-[![Relm4-components docs](https://img.shields.io/badge/rust-documentation-blue)](https://relm4.org/docs/stable/relm4_components/)
+[![Relm4-components docs](https://img.shields.io/badge/rust-documentation-blue)](https://docs.rs/relm4_components/)
 
 A collection of reusable components that can easily be integrated into Relm4 applications.

--- a/relm4-components/src/lib.rs
+++ b/relm4-components/src/lib.rs
@@ -1,7 +1,7 @@
 //! Collection of reusable and easily configurable components for Relm4.
 //!
 //! The docs are available in two versions.
-//! Use the [stable docs](https://relm4.org/docs/stable/relm4_components/) if you want get information about a version that was already published.
+//! Use the [stable docs](https://docs.rs/relm4_components/) if you want get information about a version that was already published.
 //! Visit the [nightly docs](https://relm4.org/docs/next/relm4_components/) if are trying out the newest but possibly unstable version of the crate.
 //!
 //! Docs of related crates:

--- a/relm4-macros/Cargo.toml
+++ b/relm4-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "relm4-macros"
 readme = "README.md"
 keywords = ["gui", "gtk", "gtk4", "elm", "view"]
-documentation = "https://relm4.org/docs/stable/relm4/"
+documentation = "https://docs.rs/relm4_macros/"
 
 version.workspace = true
 authors.workspace = true
@@ -30,7 +30,12 @@ relm4 = []
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full", "extra-traits", "visit", "visit-mut"] }
+syn = { version = "1.0", features = [
+    "full",
+    "extra-traits",
+    "visit",
+    "visit-mut",
+] }
 
 [dev-dependencies]
 relm4 = { path = "../relm4" }

--- a/relm4-macros/README.md
+++ b/relm4-macros/README.md
@@ -1,6 +1,6 @@
 # Relm4-macros
 
 [![Relm4-macros on crates.io](https://img.shields.io/crates/v/relm4-macros.svg)](https://crates.io/crates/relm4-macros)
-[![Relm4-macros docs](https://img.shields.io/badge/rust-documentation-blue)](https://relm4.org/docs/stable/relm4_macros/)
+[![Relm4-macros docs](https://img.shields.io/badge/rust-documentation-blue)](https://docs.rs/relm4_macros/)
 
 A macro to easily generate UIs for Relm4 applications.

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -1,7 +1,7 @@
 //! A collection of macros for gtk-rs, Relm4 and Rust in general.
 //!
 //! The docs are available in two versions.
-//! Use the [stable docs](https://relm4.org/docs/stable/relm4_macros/) if you want get information about a version that was already published.
+//! Use the [stable docs](https://docs.rs/relm4_macros/) if you want get information about a version that was already published.
 //! Visit the [nightly docs](https://relm4.org/docs/next/relm4_macros/) if are trying out the newest but possibly unstable version of the crate.
 //!
 //! Docs of related crates:

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relm4"
-documentation = "https://relm4.org/docs/stable/relm4/"
+documentation = "https://docs.rs/relm4/"
 
 version.workspace = true
 authors.workspace = true
@@ -56,7 +56,12 @@ relm4-macros = { path = "../relm4-macros" }
 criterion = { version = "0.4", default-features = false }
 
 # For the examples
-tokio = { version = "1.25", features = ["rt", "macros", "time", "rt-multi-thread"] }
+tokio = { version = "1.25", features = [
+    "rt",
+    "macros",
+    "time",
+    "rt-multi-thread",
+] }
 futures = "0.3.26"
 rand = "0.8.5"
 tracker = "0.2"

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -1,7 +1,7 @@
 //! An idiomatic GUI library inspired by Elm and based on gtk4-rs.
 //!
 //! The docs are available in two versions.
-//! Use the [stable docs](https://relm4.org/docs/stable/relm4/) if you want get information about a version that was already published.
+//! Use the [stable docs](https://docs.rs/relm4/) if you want get information about a version that was already published.
 //! Visit the [nightly docs](https://relm4.org/docs/next/relm4/) if are trying out the newest but possibly unstable version of the crate.
 //!
 //! Docs of related crates:


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

This will make crates.io link to the docs hosted on docs.rs.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md