### PR TITLE
Add method `broadcast` to `FactoryVecDeque`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
++ core: Add `broadcast` to `FactoryVecDeque`
+
 ### Fixed
 
 + core: Prevent leaking `CommandSenderInner` struct

--- a/relm4/src/factory/async/collections/vec_deque.rs
+++ b/relm4/src/factory/async/collections/vec_deque.rs
@@ -550,6 +550,14 @@ where
         self.components[index].send(msg);
     }
 
+    /// Send clone of a message to all of the elements.
+    pub fn broadcast(&self, msg: C::Input)
+    where
+        C::Input: Clone,
+    {
+        self.components.iter().for_each(|c| c.send(msg.clone()));
+    }
+
     /// Tries to get an immutable reference to
     /// the model of one element.
     ///

--- a/relm4/src/factory/sync/collections/vec_deque.rs
+++ b/relm4/src/factory/sync/collections/vec_deque.rs
@@ -530,6 +530,14 @@ impl<C: FactoryComponent> FactoryVecDeque<C> {
         self.components[index].send(msg);
     }
 
+    /// Send clone of a message to all of the elements.
+    pub fn broadcast(&self, msg: C::Input)
+    where
+        C::Input: Clone,
+    {
+        self.components.iter().for_each(|c| c.send(msg.clone()));
+    }
+
     /// Tries to get an immutable reference to
     /// the model of one element.
     ///


### PR DESCRIPTION
#### Summary

In order to send a message to all elements in `FactoryVecDeque`, it was previously necessary to manually cycle through all the indices (from 0 to `len()`) and send message to each element, one by one, using an existing `send` method. This new method makes this process cleaner and safer by avoiding the need to use panic-prone indices.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
