### PR TITLE
core: Support tokio on local futures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
++ core: Support tokio also on local futures
 + core: Prevent leaking `CommandSenderInner` struct
 + macros: Fix clippy warning triggered by the view macro in some edge cases
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dev-dependencies]
 relm4 = { path = "../relm4" }
 tokio = { version = "1.25", features = ["rt", "macros", "time", "rt-multi-thread"] }
-async-std = "1"
 futures = "0.3.26"
 rand = "0.8.5"
 tracker = "0.2"

--- a/examples/factory_async.rs
+++ b/examples/factory_async.rs
@@ -123,12 +123,12 @@ impl AsyncFactoryComponent for Counter {
         _index: &DynamicIndex,
         _sender: AsyncFactorySender<Self>,
     ) -> Self {
-        async_std::task::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
         Self { value }
     }
 
     async fn update(&mut self, msg: Self::Input, _sender: AsyncFactorySender<Self>) {
-        async_std::task::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
         match msg {
             CounterMsg::Increment => {
                 self.value = self.value.wrapping_add(1);

--- a/examples/simple_async.rs
+++ b/examples/simple_async.rs
@@ -78,7 +78,7 @@ impl AsyncComponent for App {
         root: Self::Root,
         sender: AsyncComponentSender<Self>,
     ) -> AsyncComponentParts<Self> {
-        async_std::task::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
 
         let model = App { counter };
 
@@ -94,7 +94,7 @@ impl AsyncComponent for App {
         _sender: AsyncComponentSender<Self>,
         _root: &Self::Root,
     ) {
-        async_std::task::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
         match msg {
             Msg::Increment => {
                 self.counter = self.counter.wrapping_add(1);

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::{ApplicationExt, ApplicationExtManual, Cast, GtkApplicationExt, IsA, WidgetExt};
 
 use crate::component::{AsyncComponent, AsyncComponentBuilder, AsyncComponentController};
-use crate::{Component, ComponentBuilder, ComponentController};
+use crate::{Component, ComponentBuilder, ComponentController, RUNTIME};
 
 /// An app that runs the main application.
 #[derive(Debug)]
@@ -88,6 +88,7 @@ impl RelmApp {
             }
         });
 
+        let _guard = RUNTIME.enter();
         app.run_with_args(args);
     }
 
@@ -143,6 +144,7 @@ impl RelmApp {
             }
         });
 
+        let _guard = RUNTIME.enter();
         app.run_with_args(args);
     }
 }


### PR DESCRIPTION
#### Summary

This PR adds a hack also used by async-std to archive compatibility with tokio. More or less this just means entering the tokio context before running the application. 

@edfloreshz can you maybe test this with Done? This should remove the need to wrap tokio-depndant futures into `relm4::spawn()`.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
