### PR TITLE
core: Fix crash caused by UID overflow with very large or frequently changing factories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 + core: Support tokio also on local futures
 + core: Prevent leaking `CommandSenderInner` struct
 + core: Improve error message when sending input messages to dropped components
++ core: Fix crash caused by UID overflow with very large or frequently changing factories
 + macros: Fix clippy warning triggered by the view macro in some edge cases
 
 ## 0.5.0-rc.1

--- a/relm4/src/factory/async/collections/mod.rs
+++ b/relm4/src/factory/async/collections/mod.rs
@@ -7,7 +7,7 @@ use crate::factory::DynamicIndex;
 
 #[derive(Debug)]
 struct RenderedState {
-    uid: u16,
+    uid: usize,
     #[cfg(feature = "libadwaita")]
     widget_hash: u64,
 }
@@ -15,6 +15,6 @@ struct RenderedState {
 #[derive(Debug)]
 struct ModelStateValue {
     index: DynamicIndex,
-    uid: u16,
+    uid: usize,
     changed: bool,
 }

--- a/relm4/src/factory/async/collections/vec_deque.rs
+++ b/relm4/src/factory/async/collections/vec_deque.rs
@@ -347,6 +347,10 @@ where
                 self.inner.widget.factory_remove(widget);
             }
         }
+
+        self.inner.rendered_state.clear();
+
+        self.inner.uid_counter = 1;
     }
 
     /// Returns an iterator over the components that returns mutable references.
@@ -395,7 +399,7 @@ where
     components: VecDeque<AsyncComponentStorage<C>>,
     model_state: VecDeque<ModelStateValue>,
     rendered_state: VecDeque<RenderedState>,
-    uid_counter: u16,
+    uid_counter: usize,
 }
 
 impl<C: AsyncFactoryComponent> Drop for AsyncFactoryVecDeque<C>

--- a/relm4/src/factory/sync/collections/mod.rs
+++ b/relm4/src/factory/sync/collections/mod.rs
@@ -7,7 +7,7 @@ use crate::factory::DynamicIndex;
 
 #[derive(Debug)]
 struct RenderedState {
-    uid: u16,
+    uid: usize,
     #[cfg(feature = "libadwaita")]
     widget_hash: u64,
 }
@@ -15,6 +15,6 @@ struct RenderedState {
 #[derive(Debug)]
 struct ModelStateValue {
     index: DynamicIndex,
-    uid: u16,
+    uid: usize,
     changed: bool,
 }

--- a/relm4/src/factory/sync/collections/vec_deque.rs
+++ b/relm4/src/factory/sync/collections/vec_deque.rs
@@ -320,6 +320,9 @@ impl<'a, C: FactoryComponent> FactoryVecDequeGuard<'a, C> {
                 self.inner.widget.factory_remove(widget);
             }
         }
+
+        self.inner.rendered_state.clear();
+        self.inner.uid_counter = 1;
     }
 
     /// Returns an iterator over the components that returns mutable references.
@@ -372,7 +375,7 @@ pub struct FactoryVecDeque<C: FactoryComponent> {
     components: VecDeque<ComponentStorage<C>>,
     model_state: VecDeque<ModelStateValue>,
     rendered_state: VecDeque<RenderedState>,
-    uid_counter: u16,
+    uid_counter: usize,
 }
 
 impl<C: FactoryComponent> Drop for FactoryVecDeque<C> {


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Previously, the UID of a factory collection could overflow when there had been enough changes to a `FactoryVecDeque` to go over the 16-bit integer limit. The type of the UID has been bumped from a `u16` to a `usize`, and every time `clear` is called, the UID is reset to 1. 

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md