### PR TITLE
all: Add script for publishing the crates

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -23,9 +23,9 @@ fi
 mv examples/Cargo.toml examples/_Cargo.toml
 
 # Publish and pass all arguments to cargo
-cargo publish -p relm4-macros "$@"
-cargo publish -p relm4 "$@"
-cargo publish -p relm4-components "$@"
+cargo publish -p relm4-macros "$@" --allow-dirty
+cargo publish -p relm4 "$@" --allow-dirty
+cargo publish -p relm4-components "$@" --allow-dirty
 
 # Move Cargo.toml from examples into original position
 mv examples/_Cargo.toml examples/Cargo.toml

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Check the code
+cargo update
+cargo fmt --all -- --check
+cargo clippy --all-targets -- --deny warnings
+cargo clippy --features "all" -- --deny warnings
+cargo clippy --examples -- --deny warnings
+cargo test
+
+# Check if everything has been committed
+if [ ! -z "$(git status --untracked-files=no --porcelain)" ]; then 
+  echo "There are uncommitted changes -> exiting"
+  exit 1
+fi
+
+# Temporarily move Cargo.toml from examples
+# Otherwise cargo will not include the examples
+# because it thinks the examples are another crate.
+mv examples/Cargo.toml examples/_Cargo.toml
+
+# Publish and pass all arguments to cargo
+cargo publish -p relm4-macros "$@"
+cargo publish -p relm4 "$@"
+cargo publish -p relm4-components "$@"
+
+# Move Cargo.toml from examples into original position
+mv examples/_Cargo.toml examples/Cargo.toml


### PR DESCRIPTION
This will finally enable scraping of examples on docs.rs and make the publish process easier.
The script renames the Cargo.toml file of the examples so `cargo publish` doesn't ignore the examples because it thinks it's another crate.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
