### PR TITLE
macros: Use type fullname

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 + core: Fix scaping of examples on docs.rs
 + core: Fix crash caused by UID overflow with very large or frequently changing factories
 + macros: Fix clippy warning triggered by the view macro in some edge cases
++ macros: Import `relm4::ComponentSender` isn’t longer required
 
 ## 0.5.0-rc.1 - 2022-12-21
 

--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -123,10 +123,10 @@ pub(crate) fn generate_tokens(
             ..
         } = PreAndPostView::extract(&mut component_impl, errors);
 
-        let sender_ty: syn::Ident = if asyncness.is_some() {
-            parse_quote! { AsyncComponentSender }
+        let sender_ty: syn::TypePath = if asyncness.is_some() {
+            parse_quote! { relm4::AsyncComponentSender }
         } else {
-            parse_quote! { ComponentSender }
+            parse_quote! { relm4::ComponentSender }
         };
 
         component_impl.items.push(parse_quote! {


### PR DESCRIPTION
#### Summary

The code generated by macro requires importing `ComponentSender`:

```
error[E0412]: cannot find type `ComponentSender` in this scope
  --> src/application/widget.rs:14:1
   |
14 | #[relm4::component(pub)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
   |
   = note: this error originates in the attribute macro `relm4::component` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing this struct
   |
1  | use relm4::ComponentSender;
   |

For more information about this error, try `rustc --explain E0412`.
```

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [ ] updated CHANGES.md