### PR TITLE
macros: Fix ordering in codegen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
++ macros: Fix order of assignment and connect statements
+
 ## 0.5.0 - 2023-2-17
 
 ### Fixed

--- a/relm4-macros/src/component/mod.rs
+++ b/relm4-macros/src/component/mod.rs
@@ -91,11 +91,11 @@ pub(crate) fn generate_tokens(
             #rename_root
             #menus_stream
             #init_widgets
+            #assign
             #connect
             {
                 #error
             }
-            #assign
         };
 
         let widgets_return_code = parse_quote! {

--- a/relm4-macros/src/factory/mod.rs
+++ b/relm4-macros/src/factory/mod.rs
@@ -88,11 +88,11 @@ pub(crate) fn generate_tokens(
             #rename_root
             #menus_stream
             #init
+            #assign
             #connect
             {
                 #error
             }
-            #assign
         };
 
         let widgets_return_code = parse_quote! {

--- a/relm4-macros/src/view.rs
+++ b/relm4-macros/src/view.rs
@@ -27,8 +27,8 @@ pub(super) fn generate_tokens(input: TokenStream) -> TokenStream {
 
     let output = quote! {
         #init
-        #connect
         #assign
+        #connect
         {
             #error
         }

--- a/relm4-macros/src/widget_template.rs
+++ b/relm4-macros/src/widget_template.rs
@@ -44,8 +44,8 @@ pub(crate) fn generate_tokens(vis: Option<Visibility>, mut item_impl: ItemImpl) 
 
                     let view_output = quote! {
                         #init
-                        #connect
                         #assign
+                        #connect
                         {
                             #error
                         }

--- a/relm4-macros/src/widgets/gen/assign/mod.rs
+++ b/relm4-macros/src/widgets/gen/assign/mod.rs
@@ -12,7 +12,7 @@ impl Property {
     fn assign_stream(&self, stream: &mut TokenStream2, w_name: &Ident, is_conditional: bool) {
         match &self.ty {
             PropertyType::Assign(assign) => {
-                assign.conditional_assign_stream(stream, &self.name, w_name, is_conditional);
+                assign.conditional_assign_stream(stream, &self.name, w_name, is_conditional, true);
             }
             PropertyType::Widget(widget) => {
                 widget.assign_stream(stream, &self.name, w_name, is_conditional);

--- a/relm4-macros/src/widgets/gen/conditional_init.rs
+++ b/relm4-macros/src/widgets/gen/conditional_init.rs
@@ -165,11 +165,11 @@ impl AssignProperty {
             match &self.attr {
                 AssignPropertyAttr::None => (),
                 AssignPropertyAttr::Watch => {
-                    self.assign_stream(stream, p_name, w_name);
+                    self.assign_stream(stream, p_name, w_name, true);
                 }
                 AssignPropertyAttr::Track((track_stream, paste_model)) => {
                     let mut assign_stream = TokenStream2::new();
-                    self.assign_stream(&mut assign_stream, p_name, w_name);
+                    self.assign_stream(&mut assign_stream, p_name, w_name, true);
                     let model = paste_model.then(|| model_name);
 
                     stream.extend(quote_spanned! {

--- a/relm4-macros/src/widgets/gen/update_view.rs
+++ b/relm4-macros/src/widgets/gen/update_view.rs
@@ -158,11 +158,11 @@ impl AssignProperty {
         match &self.attr {
             AssignPropertyAttr::None => (),
             AssignPropertyAttr::Watch => {
-                self.assign_stream(stream, p_name, w_name);
+                self.assign_stream(stream, p_name, w_name, false);
             }
             AssignPropertyAttr::Track((track_stream, paste_model)) => {
                 let mut assign_stream = TokenStream2::new();
-                self.assign_stream(&mut assign_stream, p_name, w_name);
+                self.assign_stream(&mut assign_stream, p_name, w_name, false);
                 let model = paste_model.then(|| model_name);
                 let page_switch = conditional_branch.then(|| {
                     quote_spanned! {


### PR DESCRIPTION
#### Summary

Fixes #418

0.5 brings a new feature with the macro to block signal handlers when assigning properties. This was made possible by generating the signal handlers first and then at each property update with a `#[block_handler(handler_name)]`, the signal handler would be temporarily blocked. 

However, this is not great for initializing properties because even on initialization a signal it fired sometimes unless you use the `block_handler` attribute. With this PR, the old order of code generation is restored: First assign properties, then generate signal handlers. The `block_handler` attribute now only affects property updates done with either `#[watch]` or `#[track]` because initialization won't cause any events anyway.

@imsamuka can you test your code against this branch? I think this should fix it.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
