### PR TITLE
Fix Stack so that it appears correctly in StackSwitcher, etc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
++ core: Fix to use `StackPageInfo` in the implementation of `Stack`'s `FactoryView`
+
 ## 0.5.0 - 2023-2-17
 
 ### Fixed

--- a/relm4/src/factory/positions.rs
+++ b/relm4/src/factory/positions.rs
@@ -22,3 +22,13 @@ pub struct FixedPosition {
     /// Position on the y-axis.
     pub y: f64,
 }
+
+#[derive(Debug, Default)]
+/// Position (or rather information) for a stack page
+/// inside a factory.
+pub struct StackPageInfo {
+    /// The name of the [`gtk::StackPage`].
+    pub name: Option<String>,
+    /// The title of the [`gtk::StackPage`].
+    pub title: Option<String>,
+}

--- a/relm4/src/factory/widgets/gtk.rs
+++ b/relm4/src/factory/widgets/gtk.rs
@@ -1,6 +1,9 @@
 use gtk::prelude::{BoxExt, Cast, FlowBoxChildExt, GridExt, ListBoxRowExt, WidgetExt};
 
-use crate::factory::{positions, FactoryView};
+use crate::factory::{
+    positions::{self, StackPageInfo},
+    FactoryView,
+};
 
 impl FactoryView for gtk::Box {
     type Children = gtk::Widget;
@@ -110,7 +113,7 @@ impl FactoryView for gtk::Grid {
 impl FactoryView for gtk::Stack {
     type Children = gtk::Widget;
     type ReturnedWidget = gtk::StackPage;
-    type Position = ();
+    type Position = StackPageInfo;
 
     fn factory_remove(&self, widget: &Self::ReturnedWidget) {
         self.remove(&widget.child());
@@ -119,26 +122,38 @@ impl FactoryView for gtk::Stack {
     fn factory_append(
         &self,
         widget: impl AsRef<Self::Children>,
-        _position: &Self::Position,
+        position: &Self::Position,
     ) -> Self::ReturnedWidget {
-        self.add_child(widget.as_ref())
+        if let Some(title) = &position.title {
+            self.add_titled(widget.as_ref(), position.name.as_deref(), title)
+        } else {
+            self.add_named(widget.as_ref(), position.name.as_deref())
+        }
     }
 
     fn factory_prepend(
         &self,
         widget: impl AsRef<Self::Children>,
-        _position: &(),
+        position: &Self::Position,
     ) -> Self::ReturnedWidget {
-        self.add_child(widget.as_ref())
+        if let Some(title) = &position.title {
+            self.add_titled(widget.as_ref(), position.name.as_deref(), title)
+        } else {
+            self.add_named(widget.as_ref(), position.name.as_deref())
+        }
     }
 
     fn factory_insert_after(
         &self,
         widget: impl AsRef<Self::Children>,
-        _position: &(),
+        position: &Self::Position,
         _other: &Self::ReturnedWidget,
     ) -> Self::ReturnedWidget {
-        self.add_child(widget.as_ref())
+        if let Some(title) = &position.title {
+            self.add_titled(widget.as_ref(), position.name.as_deref(), title)
+        } else {
+            self.add_named(widget.as_ref(), position.name.as_deref())
+        }
     }
 
     fn factory_move_after(&self, _widget: &Self::ReturnedWidget, _other: &Self::ReturnedWidget) {}
@@ -307,27 +322,6 @@ impl FactoryView for gtk::FlowBox {
 
 //     fn remove(&self, widget: &gtk::TreeViewColumn) {
 //         self.remove_column(widget);
-//     }
-// }
-
-// impl<Widget> FactoryView<Widget> for gtk::Stack
-// where
-//     Widget: glib::IsA<gtk::Widget>,
-// {
-//     type Position = StackPageInfo;
-//     type Root = Widget;
-
-//     fn add(&self, widget: &Widget, position: &StackPageInfo) -> Widget {
-//         if let Some(title) = &position.title {
-//             self.add_titled(widget, position.name.as_deref(), title);
-//         } else {
-//             self.add_named(widget, position.name.as_deref());
-//         }
-//         widget.clone()
-//     }
-
-//     fn remove(&self, widget: &Widget) {
-//         self.remove(widget);
 //     }
 // }
 

--- a/relm4/src/factory/widgets/tests.rs
+++ b/relm4/src/factory/widgets/tests.rs
@@ -1,5 +1,8 @@
 use crate::{
-    factory::{positions::GridPosition, FactoryView},
+    factory::{
+        positions::{GridPosition, StackPageInfo},
+        FactoryView,
+    },
     gtk, RelmIterChildrenExt, WidgetRef,
 };
 use gtk::prelude::{FlowBoxChildExt, ListBoxRowExt};
@@ -135,9 +138,9 @@ fn stack_factory_view() {
     let widget2 = gtk::Switch::default();
     let widget3 = gtk::Entry::default();
 
-    let page1 = stack.factory_append(&widget1, &());
-    let page2 = stack.factory_append(&widget2, &());
-    let page3 = stack.factory_append(&widget3, &());
+    let page1 = stack.factory_append(&widget1, &StackPageInfo::default());
+    let page2 = stack.factory_append(&widget2, &StackPageInfo::default());
+    let page3 = stack.factory_append(&widget3, &StackPageInfo::default());
 
     assert_eq!(page1.child(), widget1);
     assert_eq!(page2.child(), widget2);


### PR DESCRIPTION
#### Summary

I am currently in the process of migrating from relm 0.4 to 0.5 and `Stack` is not displaying correctly.

This behavior does not seem to be documented in GTK4, but it appears that `StackPage` does not appear in `StackSwitcher` or `StackSidebar` unless the title is specified using the `add_titled` method. Therefore, `StackPageInfo` should be used as in relm 0.4.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md

Since I am a non-English speaker, please make appropriate changes to the wording I have added to CHANGES.md