### PR TITLE
Rename factory component traits `output_to_parent_input` method to `forward_to_parent`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
++ core: Rename factory component traits `output_to_parent_input` method to `forward_to_parent`
 + core: Improved `RelmActionGroup` API
 + all: Increase MSRV to 1.65 to match the dependencies
 

--- a/examples/entry.rs
+++ b/examples/entry.rs
@@ -41,7 +41,7 @@ impl FactoryComponent for Counter {
     // You usually wouldn't do this but rather process the click in the factory
     // element itself. However, this demonstrates how easy it is to forward messages
     // to the parent component of the factory.
-    fn output_to_parent_input(output: Self::Output) -> Option<Self::ParentInput> {
+    fn forward_to_parent(output: Self::Output) -> Option<Self::ParentInput> {
         Some(output)
     }
 

--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -87,7 +87,7 @@ impl FactoryComponent for Counter {
         }
     }
 
-    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
+    fn forward_to_parent(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),

--- a/examples/factory_async.rs
+++ b/examples/factory_async.rs
@@ -109,7 +109,7 @@ impl AsyncFactoryComponent for Counter {
         Some(LoadingWidgets::new(root, spinner))
     }
 
-    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
+    fn forward_to_parent(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -48,7 +48,7 @@ impl FactoryComponent for Counter {
     type ParentInput = AppMsg;
     type ParentWidget = gtk::Grid;
 
-    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
+    fn forward_to_parent(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),

--- a/examples/to_do.rs
+++ b/examples/to_do.rs
@@ -64,7 +64,7 @@ impl FactoryComponent for Task {
         widgets.label.set_attributes(Some(&attrs));
     }
 
-    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
+    fn forward_to_parent(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             TaskOutput::Delete(index) => AppMsg::DeleteEntry(index),
         })

--- a/relm4-components/src/open_button/factory.rs
+++ b/relm4-components/src/open_button/factory.rs
@@ -32,7 +32,7 @@ impl FactoryComponent for FileListItem {
         }
     }
 
-    fn output_to_parent_input(output: Self::Output) -> Option<Self::ParentInput> {
+    fn forward_to_parent(output: Self::Output) -> Option<Self::ParentInput> {
         Some(output)
     }
 

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -269,7 +269,7 @@ pub fn component(attributes: TokenStream, input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 ///
-///     fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
+///     fn forward_to_parent(output: Self::Output) -> Option<AppMsg> {
 ///         Some(match output {
 ///             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
 ///         })

--- a/relm4/src/factory/async/component_storage.rs
+++ b/relm4/src/factory/async/component_storage.rs
@@ -70,7 +70,7 @@ where
                 index,
                 returned_widget,
                 parent_sender,
-                C::output_to_parent_input,
+                C::forward_to_parent,
             )))
         } else {
             None

--- a/relm4/src/factory/async/traits.rs
+++ b/relm4/src/factory/async/traits.rs
@@ -73,7 +73,7 @@ pub trait AsyncFactoryComponent:
     /// forward messages.
     ///
     /// If [`None`] is returned, nothing is forwarded.
-    fn output_to_parent_input(_output: Self::Output) -> Option<Self::ParentInput> {
+    fn forward_to_parent(_output: Self::Output) -> Option<Self::ParentInput> {
         None
     }
 

--- a/relm4/src/factory/sync/component_storage.rs
+++ b/relm4/src/factory/sync/component_storage.rs
@@ -62,7 +62,7 @@ impl<C: FactoryComponent> ComponentStorage<C> {
                 index,
                 returned_widget,
                 parent_sender,
-                C::output_to_parent_input,
+                C::forward_to_parent,
             )))
         } else {
             None

--- a/relm4/src/factory/sync/traits.rs
+++ b/relm4/src/factory/sync/traits.rs
@@ -55,7 +55,7 @@ pub trait FactoryComponent:
     /// forward messages.
     ///
     /// If [`None`] is returned, nothing is forwarded.
-    fn output_to_parent_input(_output: Self::Output) -> Option<Self::ParentInput> {
+    fn forward_to_parent(_output: Self::Output) -> Option<Self::ParentInput> {
         None
     }
 


### PR DESCRIPTION
#### Summary

This PR renames `FactoryComponent`'s and `AsyncFactoryComponent`'s method `output_to_parent_input` to a more intuitive expressive name `forward_to_parent`

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
