### PR TITLE
all: Ignore most GTK 4.10 deprecations

### DIFF
--- a/examples/components.rs
+++ b/examples/components.rs
@@ -1,3 +1,7 @@
+// Don't show GTK 4.10 deprecations.
+// We can't replace them without raising the GTK requirement to 4.10.
+#![allow(deprecated)]
+
 use std::convert::identity;
 
 use gtk::prelude::*;

--- a/examples/factory_hash_map.rs
+++ b/examples/factory_hash_map.rs
@@ -1,5 +1,6 @@
-use gtk::prelude::{BoxExt, ButtonExt, EntryBufferExtManual, GtkWindowExt, OrientableExt};
-use gtk::traits::{EntryExt, WidgetExt};
+use gtk::prelude::{
+    BoxExt, ButtonExt, EntryBufferExtManual, EntryExt, GtkWindowExt, OrientableExt, WidgetExt,
+};
 use relm4::factory::{FactoryComponent, FactoryHashMap, FactorySender};
 use relm4::{gtk, ComponentParts, ComponentSender, RelmApp, RelmWidgetExt, SimpleComponent};
 

--- a/examples/macro_reference.rs
+++ b/examples/macro_reference.rs
@@ -156,8 +156,9 @@ impl SimpleComponent for App {
             set_title: Some("Another window"),
             set_default_size: (300, 100),
             set_transient_for: Some(&main_window),
+            set_visible: false,
             // Empty args
-            hide: (),
+            grab_focus: (),
 
             #[watch]
             set_visible: counter.value == 42,

--- a/examples/message_broker.rs
+++ b/examples/message_broker.rs
@@ -1,3 +1,7 @@
+// Don't show GTK 4.10 deprecations.
+// We can't replace them without raising the GTK requirement to 4.10.
+#![allow(deprecated)]
+
 use std::convert::identity;
 
 use gtk::prelude::{BoxExt, ButtonExt, DialogExt, GtkWindowExt, ToggleButtonExt, WidgetExt};

--- a/examples/message_stream.rs
+++ b/examples/message_stream.rs
@@ -1,3 +1,7 @@
+// Don't show GTK 4.10 deprecations.
+// We can't replace them without raising the GTK requirement to 4.10.
+#![allow(deprecated)]
+
 use gtk::prelude::*;
 use relm4::{prelude::*, Sender};
 
@@ -28,7 +32,7 @@ impl SimpleComponent for Dialog {
             present: (),
 
             connect_response[sender] => move |dialog, resp| {
-                dialog.hide();
+                dialog.set_visible(false);
                 sender.input(if resp == gtk::ResponseType::Accept {
                     DialogMsg::Accept
                 } else {

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -164,11 +164,11 @@ impl Component for App {
             match progress {
                 CmdOut::Progress(p) => {
                     widgets.label.set_label("Searching for the answer...");
-                    widgets.progress.show();
+                    widgets.progress.set_visible(true);
                     widgets.progress.set_fraction(*p as f64);
                 }
                 CmdOut::Finished(result) => {
-                    widgets.progress.hide();
+                    widgets.progress.set_visible(false);
                     widgets
                         .label
                         .set_label(&format!("The answer to life is: {result:?}"));

--- a/examples/transient_dialog.rs
+++ b/examples/transient_dialog.rs
@@ -1,3 +1,7 @@
+// Don't show GTK 4.10 deprecations.
+// We can't replace them without raising the GTK requirement to 4.10.
+#![allow(deprecated)]
+
 use std::convert::identity;
 
 use gtk::prelude::{ButtonExt, GtkWindowExt, WidgetExt};

--- a/relm4-components/examples/file_dialogs.rs
+++ b/relm4-components/examples/file_dialogs.rs
@@ -83,7 +83,7 @@ impl SimpleComponent for App {
                 .buttons(gtk::ButtonsType::Ok)
                 .build();
             dialog.connect_response(|dialog, _| dialog.destroy());
-            dialog.show();
+            dialog.set_visible(true);
             sender.input(Input::ResetMessage);
         }
     }

--- a/relm4-components/src/lib.rs
+++ b/relm4-components/src/lib.rs
@@ -27,6 +27,10 @@
 )]
 // Configuration for doc builds on the nightly toolchain.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Ignore GTK 4.10 deprecations.
+// Most deprecated features can only be replaced with new 4.10 APIs and
+// we don't want to lift the minimum requirement GTK4 version for Relm4 yet.
+#![allow(deprecated)]
 
 pub mod alert;
 pub mod open_button;

--- a/relm4-components/src/web_image.rs
+++ b/relm4-components/src/web_image.rs
@@ -3,10 +3,8 @@
 use std::collections::VecDeque;
 use std::fmt::Debug;
 
-use relm4::gtk::prelude::Cast;
-use relm4::gtk::traits::{BoxExt, WidgetExt};
-use relm4::{gtk, ComponentSender};
-use relm4::{Component, ComponentParts};
+use relm4::gtk::prelude::{BoxExt, Cast, WidgetExt};
+use relm4::{gtk, Component, ComponentParts, ComponentSender};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Reusable component for loading images from the web.

--- a/relm4/src/actions/mod.rs
+++ b/relm4/src/actions/mod.rs
@@ -2,8 +2,7 @@
 
 use gtk::gio;
 use gtk::glib::FromVariant;
-use gtk::prelude::{ActionExt, ActionMapExt, StaticVariantType, ToVariant};
-use gtk::traits::WidgetExt;
+use gtk::prelude::{ActionExt, ActionMapExt, StaticVariantType, ToVariant, WidgetExt};
 
 use std::marker::PhantomData;
 

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -97,7 +97,7 @@ impl<M: Debug + 'static> RelmApp<M> {
                 controller.detach_runtime();
 
                 app.add_window(window.as_ref());
-                window.show();
+                window.set_visible(true);
             }
         });
 
@@ -154,7 +154,7 @@ impl<M: Debug + 'static> RelmApp<M> {
                 controller.detach_runtime();
 
                 app.add_window(window.as_ref());
-                window.show();
+                window.set_visible(true);
             }
         });
 

--- a/relm4/src/extensions/container.rs
+++ b/relm4/src/extensions/container.rs
@@ -14,6 +14,7 @@ impl<T: RelmSetChildExt> RelmContainerExt for T {
     }
 }
 
+#[allow(deprecated)]
 impl RelmContainerExt for gtk::Dialog {
     fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
         self.content_area().append(widget.as_ref());
@@ -35,6 +36,7 @@ macro_rules! append_impl {
 macro_rules! add_child_impl {
     ($($type:ty),+) => {
         $(
+            #[allow(deprecated)]
             impl RelmContainerExt for $type {
                 fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
                     self.add_child(widget.as_ref());

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -68,7 +68,7 @@ impl ApplicationBuilderExt for gtk::builders::ApplicationBuilder {
 
             init(app.clone(), window.clone());
 
-            window.show();
+            window.set_visible(true);
         });
 
         app.run();
@@ -139,6 +139,7 @@ macro_rules! container_child_impl {
     };
     ($($type:ty), +) => {
         $(
+            #[allow(deprecated)]
             impl ContainerChild for $type {
                 type Child = gtk::Widget;
             }

--- a/relm4/src/extensions/remove.rs
+++ b/relm4/src/extensions/remove.rs
@@ -59,6 +59,7 @@ macro_rules! remove_impl {
 macro_rules! remove_child_impl {
     ($($type:ty),+) => {
         $(
+            #[allow(deprecated)]
             impl RelmRemoveExt for $type {
                 fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
                     self.remove_child(widget.as_ref());

--- a/relm4/src/extensions/widget_ext.rs
+++ b/relm4/src/extensions/widget_ext.rs
@@ -1,7 +1,4 @@
-use gtk::{
-    prelude::{Cast, StaticType, WidgetExt},
-    traits::StyleContextExt,
-};
+use gtk::prelude::{Cast, StaticType, WidgetExt};
 
 /// Trait that extends [`gtk::prelude::WidgetExt`].
 ///
@@ -64,7 +61,10 @@ impl<T: gtk::glib::IsA<gtk::Widget>> RelmWidgetExt for T {
         }
     }
 
+    #[allow(deprecated)]
     fn inline_css(&self, style: &str) {
+        use gtk::prelude::StyleContextExt;
+
         let context = self.style_context();
         let provider = gtk::CssProvider::new();
 

--- a/relm4/src/factory/sync/collections/hashmap.rs
+++ b/relm4/src/factory/sync/collections/hashmap.rs
@@ -226,7 +226,7 @@ where
             &key,
             returned_widget,
             &self.parent_sender,
-            C::output_to_parent_input,
+            C::forward_to_parent,
         );
 
         assert!(self.inner.insert(key, component).is_none());

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -161,6 +161,8 @@ pub fn set_global_css(style_data: &str) {
     let display = gtk::gdk::Display::default().unwrap();
     let provider = gtk::CssProvider::new();
     provider.load_from_data(style_data);
+
+    #[allow(deprecated)]
     gtk::StyleContext::add_provider_for_display(
         &display,
         &provider,


### PR DESCRIPTION
#### Summary

There are three categories of deprecation:

1. Easy to fix: Simple things like `show()` -> `set_visible(true)`, apply changes immediately
2. Trait impls: We shouldn't remove trait impls for deprecated types because some might still use those types
3. Only 4.10 replacements available: Ignore those entirely, we don't want Relm4 to lift its GTK4 requirement to the recent 4.10 release (which might take years to land in some distros).

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] ~updated CHANGES.md~ no changes for users