### PR TITLE
Replace `FactoryVecDeque`'s associated function `from_vec` with `from_iter`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 ### Changed
 
++ core: Replace `FactoryVecDeque`'s associated function `from_vec` with `from_iter`
 + core: Added `Index` type to the `FactoryComponent` trait
 + core: Rename factory component traits `output_to_parent_input` method to `forward_to_parent`
 + core: Improved `RelmActionGroup` API

--- a/relm4/src/factory/sync/collections/vec_deque.rs
+++ b/relm4/src/factory/sync/collections/vec_deque.rs
@@ -605,16 +605,16 @@ where
         self.components.iter().map(ComponentStorage::get)
     }
 
-    /// Creates a FactoryVecDeque from a Vec
-    pub fn from_vec(
-        component_vec: Vec<C::Init>,
+    /// Creates a FactoryVecDeque from any IntoIterator
+    pub fn from_iter(
+        component_iter: impl IntoIterator<Item = C::Init>,
         widget: C::ParentWidget,
         parent_sender: &Sender<C::ParentInput>,
     ) -> Self {
         let mut output = Self::new(widget, parent_sender);
         {
             let mut edit = output.guard();
-            for component in component_vec {
+            for component in component_iter {
                 edit.push_back(component);
             }
             edit.drop();


### PR DESCRIPTION
#### Summary

This PR replaces `FactoryVecDeque`'s associated function `from_vec` which creates a `FactoryVecDeque` from a `Vec` with a more universal `from_iter` which creates a `FactoryVecDeque` from any type implementing `IntoIterator`

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
