### PR TITLE
Implement `RelmSetChildExt` for `gtk::AspectFrame`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Added
 
++ core: Implement `RelmSetChildExt` for `gtk::AspectFrame`
 + core: Add `FactoryHashMap` as alternative to `FactoryVecDeque`
 + core: Add gnome_44 feature flag for GNOME 44
 + core: Documentation and better support for data bindings

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -170,7 +170,8 @@ container_child_impl! {
     gtk::Overlay,
     gtk::Revealer,
     gtk::WindowHandle,
-    gtk::Expander
+    gtk::Expander,
+    gtk::AspectFrame
 }
 
 container_child_impl! {

--- a/relm4/src/extensions/set_child.rs
+++ b/relm4/src/extensions/set_child.rs
@@ -41,7 +41,8 @@ set_child_impl!(
     gtk::Overlay,
     gtk::Revealer,
     gtk::WindowHandle,
-    gtk::Expander
+    gtk::Expander,
+    gtk::AspectFrame
 );
 
 #[cfg(feature = "libadwaita")]


### PR DESCRIPTION
#### Summary

This PR adds `RelmSetChildExt` implementation for `gtk::AspectFrame`

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
