### PR TITLE
improve init parameter error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
++ macros: Improve error messages for non-identifier parameter patterns
+
 ## 0.6.0-beta.1 - 2023-4-19
 
 ### Added
@@ -15,7 +19,6 @@
 + core: Add `set_tooltip` method to `RelmWidgetExt`
 + core: Add `main_adw_application` method to retrieve the `adw::Application` when the libadwaita feature is enabled
 + macros: Add `skip_macro` option for watch and track attributes to skip their initialization 
-+ macros: Improve error messages for non-identifier parameter patterns
 + examples: Example for using relm4-icons 
 
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 + core: Add `set_tooltip` method to `RelmWidgetExt`
 + core: Add `main_adw_application` method to retrieve the `adw::Application` when the libadwaita feature is enabled
 + macros: Add `skip_macro` option for watch and track attributes to skip their initialization 
++ macros: Improve error messages for non-identifier parameter patterns
 + examples: Example for using relm4-icons 
 
 ### Changed

--- a/relm4-macros/src/util.rs
+++ b/relm4-macros/src/util.rs
@@ -116,3 +116,20 @@ pub(super) fn verbatim_impl_item_method(
         },
     })
 }
+
+/// Returns the identifier for a parameter if it is a binding with an identifier pattern.
+pub(super) fn extract_arg_ident(arg: &FnArg) -> syn::Result<&Ident> {
+    match arg {
+        syn::FnArg::Typed(pat_type) => match &*pat_type.pat {
+            syn::Pat::Ident(ident) => Ok(&ident.ident),
+            pat => Err(syn::Error::new_spanned(
+                pat,
+                "parameter binding must be an identifier",
+            )),
+        },
+        syn::FnArg::Receiver(_) => Err(syn::Error::new_spanned(
+            arg,
+            "parameter binding must be an identifier",
+        )),
+    }
+}

--- a/relm4-macros/src/visitors.rs
+++ b/relm4-macros/src/visitors.rs
@@ -7,6 +7,7 @@ use syn::visit_mut::{self, VisitMut};
 
 use crate::additional_fields::AdditionalFields;
 use crate::menu::Menus;
+use crate::util;
 use crate::widgets::ViewWidgets;
 
 #[derive(Debug)]
@@ -252,49 +253,19 @@ struct InitFnVisitor {
 
 impl<'ast> Visit<'ast> for InitFnVisitor {
     fn visit_impl_item_method(&mut self, func: &'ast syn::ImplItemMethod) {
-        let root_name = match func.sig.inputs.iter().nth(1) {
-            Some(syn::FnArg::Typed(pat_type)) => match &*pat_type.pat {
-                syn::Pat::Ident(ident) => Ok(ident.ident.clone()),
-                _ => Err(syn::Error::new_spanned(
-                    pat_type,
-                    "unable to determine root name",
-                )),
-            },
-            Some(arg) => Err(syn::Error::new_spanned(
-                arg,
-                "unable to determine root name",
-            )),
-            None => Err(syn::Error::new_spanned(
-                &func.sig,
-                "unable to determine root name",
-            )),
-        };
+        let Some(root_arg) = func.sig.inputs.iter().nth(1) else { return };
+        let root_name = util::extract_arg_ident(root_arg);
 
         match root_name {
-            Ok(root_name) => self.root_name = Some(root_name),
+            Ok(root_name) => self.root_name = Some(root_name.clone()),
             Err(e) => self.errors.push(e),
         }
 
-        let sender_name = match func.sig.inputs.iter().nth(2) {
-            Some(syn::FnArg::Typed(pat_type)) => match &*pat_type.pat {
-                syn::Pat::Ident(ident) => Ok(ident.ident.clone()),
-                _ => Err(syn::Error::new_spanned(
-                    pat_type,
-                    "unable to determine sender name",
-                )),
-            },
-            Some(arg) => Err(syn::Error::new_spanned(
-                arg,
-                "unable to determine sender name",
-            )),
-            None => Err(syn::Error::new_spanned(
-                &func.sig,
-                "unable to determine sender name",
-            )),
-        };
+        let Some(sender_arg) = func.sig.inputs.iter().nth(2) else { return };
+        let sender_name = util::extract_arg_ident(sender_arg);
 
         match sender_name {
-            Ok(sender_name) => self.sender_name = Some(sender_name),
+            Ok(sender_name) => self.sender_name = Some(sender_name.clone()),
             Err(e) => self.errors.push(e),
         }
 
@@ -348,26 +319,12 @@ struct InitWidgetsFnVisitor {
 
 impl<'ast> Visit<'ast> for InitWidgetsFnVisitor {
     fn visit_impl_item_method(&mut self, func: &'ast syn::ImplItemMethod) {
-        let root_name = match func.sig.inputs.iter().nth(2) {
-            Some(syn::FnArg::Typed(pat_type)) => match &*pat_type.pat {
-                syn::Pat::Ident(ident) => Ok(ident.ident.clone()),
-                _ => Err(syn::Error::new_spanned(
-                    pat_type,
-                    "unable to determine root name",
-                )),
-            },
-            Some(arg) => Err(syn::Error::new_spanned(
-                arg,
-                "unable to determine root name",
-            )),
-            None => Err(syn::Error::new_spanned(
-                &func.sig,
-                "unable to determine root name",
-            )),
-        };
+        let Some(root_arg) = func.sig.inputs.iter().nth(2) else { return };
+
+        let root_name = util::extract_arg_ident(root_arg);
 
         match root_name {
-            Ok(root_name) => self.root_name = Some(root_name),
+            Ok(root_name) => self.root_name = Some(root_name.clone()),
             Err(e) => self.errors.push(e),
         }
 

--- a/relm4-macros/tests/ui/compile-fail/init-identifers.rs
+++ b/relm4-macros/tests/ui/compile-fail/init-identifers.rs
@@ -1,0 +1,51 @@
+use relm4::prelude::*;
+
+struct ComponentInitBadIdentifiers;
+
+#[relm4_macros::component]
+impl SimpleComponent for ComponentInitBadIdentifiers {
+    type Init = ();
+    type Input = ();
+    type Output = ();
+    type Root = (i32, i32);
+
+    view! {
+        gtk::Window {}
+    }
+
+    fn init(
+        _: Self::Init,
+        (a, b): &Self::Root,
+        _: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        todo!();
+    }
+
+    fn init_root() -> Self::Root {
+        todo!();
+    }
+}
+
+struct ComponentInitNoArgs;
+
+#[relm4_macros::component]
+impl SimpleComponent for ComponentInitNoArgs {
+    type Init = ();
+    type Input = ();
+    type Output = ();
+    type Root = ();
+
+    view! {
+        gtk::Window {}
+    }
+
+    fn init() -> ComponentParts<Self> {
+        todo!();
+    }
+
+    fn init_root() -> Self::Root {
+        todo!();
+    }
+}
+
+fn main() {}

--- a/relm4-macros/tests/ui/compile-fail/init-identifers.stderr
+++ b/relm4-macros/tests/ui/compile-fail/init-identifers.stderr
@@ -1,0 +1,19 @@
+error: parameter binding must be an identifier
+  --> tests/ui/compile-fail/init-identifers.rs:18:9
+   |
+18 |         (a, b): &Self::Root,
+   |         ^^^^^^
+
+error: parameter binding must be an identifier
+  --> tests/ui/compile-fail/init-identifers.rs:19:9
+   |
+19 |         _: ComponentSender<Self>,
+   |         ^
+
+error[E0050]: method `init` has 0 parameters but the declaration in trait `relm4::SimpleComponent::init` has 3
+  --> tests/ui/compile-fail/init-identifers.rs:42:5
+   |
+42 |     fn init() -> ComponentParts<Self> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters, found 0
+   |
+   = note: `init` from trait: `fn(<Self as relm4::SimpleComponent>::Init, &<Self as relm4::SimpleComponent>::Root, relm4::ComponentSender<Self>) -> relm4::ComponentParts<Self>`


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary
 
This PR improves the error messages when attempting to use a non-identifier pattern for certain init function arguments. It also removes some duplication of that error handling.

Previous:

```
error: unable to determine root name
  --> tests/ui/compile-fail/init-identifers.rs:18:9
   |
18 |         (a, b): &Self::Root,
   |         ^^^^^^^^^^^^^^^^^^^

error: unable to determine sender name
  --> tests/ui/compile-fail/init-identifers.rs:19:9
   |
19 |         _: ComponentSender<Self>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^

error: unable to determine root name
  --> tests/ui/compile-fail/init-identifers.rs:42:5
   |
42 |     fn init() -> ComponentParts<Self> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: unable to determine sender name
  --> tests/ui/compile-fail/init-identifers.rs:42:5
   |
42 |     fn init() -> ComponentParts<Self> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0050]: method `init` has 0 parameters but the declaration in trait `relm4::SimpleComponent::init` has 3
  --> tests/ui/compile-fail/init-identifers.rs:42:5
   |
42 |     fn init() -> ComponentParts<Self> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters, found 0
   |
   = note: `init` from trait: `fn(<Self as relm4::SimpleComponent>::Init, &<Self as relm4::SimpleComponent>::Root, relm4::ComponentSender<Self>) -> relm4::ComponentParts<Self>`
```

New:

```
error: parameter binding must be an identifier
  --> tests/ui/compile-fail/init-identifers.rs:18:9
   |
18 |         (a, b): &Self::Root,
   |         ^^^^^^

error: parameter binding must be an identifier
  --> tests/ui/compile-fail/init-identifers.rs:19:9
   |
19 |         _: ComponentSender<Self>,
   |         ^

error[E0050]: method `init` has 0 parameters but the declaration in trait `relm4::SimpleComponent::init` has 3
  --> tests/ui/compile-fail/init-identifers.rs:42:5
   |
42 |     fn init() -> ComponentParts<Self> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters, found 0
   |
   = note: `init` from trait: `fn(<Self as relm4::SimpleComponent>::Init, &<Self as relm4::SimpleComponent>::Root, relm4::ComponentSender<Self>) -> relm4::ComponentParts<Self>`
```

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
