### PR TITLE
Improvements to ExpanderRow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Implemented `RelmRemoveExt` for `adw::ExpanderRow`. 
+- Implemented `ContainerChild` for `adw::ExpanderRow`.
+- `adw::ExpanderRow` can now be loaded asynchronously.
 
 ### Added
 

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -194,6 +194,7 @@ mod libadwaita {
         adw::SplitButton,
         adw::StatusPage,
         adw::PreferencesGroup,
-        adw::ToastOverlay
+        adw::ToastOverlay,
+        adw::ExpanderRow
     }
 }

--- a/relm4/src/extensions/remove.rs
+++ b/relm4/src/extensions/remove.rs
@@ -44,6 +44,15 @@ impl RelmRemoveExt for adw::PreferencesGroup {
     }
 }
 
+#[cfg(feature = "libadwaita")]
+#[cfg_attr(docsrs, doc(cfg(feature = "libadwaita")))]
+impl RelmRemoveExt for adw::ExpanderRow {
+    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
+        let child = widget.as_ref();
+        self.remove(child);
+    }
+}
+
 macro_rules! remove_impl {
     ($($type:ty),+) => {
         $(
@@ -113,6 +122,24 @@ impl RelmRemoveAllExt for gtk::ListBox {
             let row = child
                 .downcast::<gtk::ListBoxRow>()
                 .expect("The child of `ListBox` is not a `ListBoxRow`.");
+            row.set_child(None::<&gtk::Widget>);
+            self.remove(&row);
+        }
+    }
+}
+
+#[cfg(feature = "libadwaita")]
+#[cfg_attr(docsrs, doc(cfg(feature = "libadwaita")))]
+use adw::traits::ExpanderRowExt;
+
+#[cfg(feature = "libadwaita")]
+#[cfg_attr(docsrs, doc(cfg(feature = "libadwaita")))]
+impl RelmRemoveAllExt for adw::ExpanderRow {
+    fn remove_all(&self) {
+        while let Some(child) = self.last_child() {
+            let row = child
+                .downcast::<gtk::ListBoxRow>()
+                .expect("The child of `ExpanderRow` is not a `ListBoxRow`.");
             row.set_child(None::<&gtk::Widget>);
             self.remove(&row);
         }


### PR DESCRIPTION
#### Summary

- Implemented `RelmRemoveExt` for `adw::ExpanderRow`. 
- Implemented `ContainerChild` for `adw::ExpanderRow`.
- `adw::ExpanderRow` can now be loaded asynchronously.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
