### PR TITLE
Add a separator to the leaflet example

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 + core: Fix an issue with using `connect_open` on `gtk::Application`
 + macros: Allow trailing commas in view!
 
+### Changed
+
++ examples: Add a separator to the libadwaita leaflet example.
+
 ## 0.6.0 - 2023-5-31
 
 ### Added

--- a/examples/libadwaita/leaflet_sidebar.rs
+++ b/examples/libadwaita/leaflet_sidebar.rs
@@ -58,9 +58,10 @@ impl SimpleComponent for App {
                     }
                 },
 
-                #[name = "separator"]
-                gtk::Separator {
+                append = &gtk::Separator {
                     set_orientation: gtk::Orientation::Vertical,
+                } -> {
+                    set_navigatable: false,
                 },
 
                 gtk::Box {
@@ -123,10 +124,6 @@ impl SimpleComponent for App {
             .bind_property("folded", &widgets.back_button, "visible")
             .flags(glib::BindingFlags::SYNC_CREATE)
             .build();
-        widgets
-            .leaflet
-            .page(&widgets.separator)
-            .set_navigatable(false);
 
         ComponentParts { model, widgets }
     }

--- a/examples/libadwaita/leaflet_sidebar.rs
+++ b/examples/libadwaita/leaflet_sidebar.rs
@@ -58,6 +58,11 @@ impl SimpleComponent for App {
                     }
                 },
 
+                #[name = "separator"]
+                gtk::Separator {
+                    set_orientation: gtk::Orientation::Vertical,
+                },
+
                 gtk::Box {
                     set_orientation: gtk::Orientation::Vertical,
                     set_hexpand: true,
@@ -118,6 +123,10 @@ impl SimpleComponent for App {
             .bind_property("folded", &widgets.back_button, "visible")
             .flags(glib::BindingFlags::SYNC_CREATE)
             .build();
+        widgets
+            .leaflet
+            .page(&widgets.separator)
+            .set_navigatable(false);
 
         ComponentParts { model, widgets }
     }


### PR DESCRIPTION
#### Summary

The libadwaita sidebar/leaflet example did not include a separator, while most sidebar will want one.
There is however a subtlety when it comes to adding a separator, as it needs to be wrapped in a `LeafletPage` with the `navigatable` property set to false. However `LeafletPage` is created automatically by the leaflet and cannot be created manually.
There is therefore a bit of a subtlety is required to get access to the generated `LeafletPage` and set it to not navigatable.

It took me some time and some help from the GTK-RS channel to get how to do it, I think having it in the example will help. 

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
