### PR TITLE
Fix compilation of tab examples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 + core: Fix an issue with using `connect_open` on `gtk::Application`
 + macros: Allow trailing commas in view!
++ examples: Fix libadwaita tab examples
 
 ## 0.6.0 - 2023-5-31
 

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -86,7 +86,7 @@ impl FactoryComponent for Counter {
         }
     }
 
-    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
+    fn forward_to_parent(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::SendFront(index) => AppMsg::SendFront(index),
             CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -48,7 +48,7 @@ impl FactoryComponent for GamePage {
     type ParentInput = AppMsg;
     type ParentWidget = adw::TabView;
 
-    fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
+    fn forward_to_parent(output: Self::Output) -> Option<AppMsg> {
         Some(match output {
             CounterOutput::StartGame(index) => AppMsg::StartGame(index),
             CounterOutput::SelectedGuess(guess) => AppMsg::SelectedGuess(guess),


### PR DESCRIPTION
### Summary

Fix the compilation of the `examples/libadwaita/tab_game.rs` and `examples/libadwaita/tab_factory.rs`.

Maybe their compilation should be added to the CI?

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
