### PR TITLE
ci(macros): Add tests for returned widgets without builders

### DIFF
--- a/relm4-macros/tests/returned_widgets.rs
+++ b/relm4-macros/tests/returned_widgets.rs
@@ -1,13 +1,26 @@
 use relm4::gtk;
 
+fn widget() -> gtk::Separator {
+    // Mimic component.widget() call
+    gtk::Separator::default()
+}
+
 fn main() {
+    let local_widget = widget();
     relm4_macros::view! {
         gtk::Stack {
             add_child = &gtk::Separator::default() { }
                 -> { set_needs_attention: false },
-
             add_child = &gtk::Separator::default() { }
                 -> page: gtk::StackPage { set_needs_attention: false },
+            add_child = &widget() {} -> {
+                set_needs_attention: false
+            },
+            add_child: &widget(),
+            #[local_ref]
+            add_child = &local_widget {} -> {
+                set_needs_attention: false
+            },
         }
     }
 }


### PR DESCRIPTION
#### Summary
Hi there, while trying to use returned widgets with a widget generated by a container, I could not find any docs and tried fiddling with the tests (as they are a more up-to date than the docs) to make it work. Maybe they can also work as docs?

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
