### PR TITLE
Implement TypedColumnView

### DIFF
--- a/examples/typed_column_view.rs
+++ b/examples/typed_column_view.rs
@@ -1,0 +1,209 @@
+use gtk::prelude::*;
+use relm4::{
+    binding::{Binding, U8Binding},
+    prelude::*,
+    typed_list_view::{ColumnSortFn, LabelColumn, RelmColumn, TypedColumnView},
+    RelmObjectExt,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+struct MyListItem {
+    value: u8,
+    binding: U8Binding,
+}
+
+impl MyListItem {
+    fn new(value: u8) -> Self {
+        Self {
+            value,
+            binding: U8Binding::new(0),
+        }
+    }
+}
+
+struct Label1Column;
+
+impl LabelColumn for Label1Column {
+    type Item = MyListItem;
+    type Value = u8;
+
+    const COLUMN_NAME: &'static str = "label";
+
+    const ENABLE_SORT: bool = true;
+
+    fn get_cell_value(item: &Self::Item) -> Self::Value {
+        item.value
+    }
+
+    fn format_cell_value(value: &Self::Value) -> String {
+        format!("Value: {} ", value)
+    }
+}
+
+struct Label2Column;
+
+impl RelmColumn for Label2Column {
+    type Root = gtk::Box;
+    type Widgets = gtk::Label;
+    type Item = MyListItem;
+
+    const COLUMN_NAME: &'static str = "label2";
+
+    fn setup(_item: &gtk::ListItem) -> (gtk::Box, gtk::Label) {
+        relm4::view! {
+            root = gtk::Box {
+                #[name = "widget"]
+                gtk::Label,
+            }
+        }
+
+        (root, widget)
+    }
+
+    fn bind(item: &mut Self::Item, widget: &mut Self::Widgets, _root: &mut Self::Root) {
+        widget.add_write_only_binding(&item.binding, "label");
+    }
+
+    fn sort_fn() -> Option<ColumnSortFn<Self::Item>> {
+        Some(Box::new(|a, b| a.value.cmp(&b.value)))
+    }
+}
+
+struct ButtonColumn;
+
+impl RelmColumn for ButtonColumn {
+    type Root = gtk::Box;
+    type Widgets = gtk::CheckButton;
+    type Item = MyListItem;
+
+    const COLUMN_NAME: &'static str = "button";
+
+    fn setup(_item: &gtk::ListItem) -> (gtk::Box, gtk::CheckButton) {
+        relm4::view! {
+            root = gtk::Box {
+                #[name = "widget"]
+                gtk::CheckButton,
+            }
+        }
+
+        (root, widget)
+    }
+
+    fn bind(item: &mut Self::Item, widget: &mut Self::Widgets, _root: &mut Self::Root) {
+        widget.set_active(item.value % 2 == 0);
+    }
+}
+
+struct App {
+    counter: u8,
+    view_wrapper: TypedColumnView<MyListItem, gtk::SingleSelection>,
+}
+
+#[derive(Debug)]
+enum Msg {
+    Append,
+    Remove,
+    OnlyShowEven(bool),
+}
+
+#[relm4::component]
+impl SimpleComponent for App {
+    type Init = u8;
+    type Input = Msg;
+    type Output = ();
+
+    view! {
+        gtk::Window {
+            set_title: Some("Actually idiomatic view possible?"),
+            set_default_size: (300, 100),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_spacing: 5,
+                set_margin_all: 5,
+
+                gtk::Button {
+                    set_label: "Append 10 items",
+                    connect_clicked => Msg::Append,
+                },
+
+                gtk::Button {
+                    set_label: "Remove second item",
+                    connect_clicked => Msg::Remove,
+                },
+
+                gtk::ToggleButton {
+                    set_label: "Only show even numbers",
+                    connect_clicked[sender] => move |btn| {
+                        sender.input(Msg::OnlyShowEven(btn.is_active()));
+                    }
+                },
+
+                gtk::ScrolledWindow {
+                    set_vexpand: true,
+
+                    #[local_ref]
+                    my_view -> gtk::ColumnView {}
+                }
+            }
+        }
+    }
+
+    fn init(
+        counter: Self::Init,
+        root: &Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        // Initialize the ListView wrapper
+        let mut view_wrapper = TypedColumnView::<MyListItem, gtk::SingleSelection>::new();
+        view_wrapper.append_column::<Label1Column>();
+        view_wrapper.append_column::<Label2Column>();
+        view_wrapper.append_column::<ButtonColumn>();
+
+        // Add a filter and disable it
+        view_wrapper.add_filter(|item| item.value % 2 == 0);
+        view_wrapper.set_filter_status(0, false);
+
+        let model = App {
+            counter,
+            view_wrapper,
+        };
+
+        let my_view = &model.view_wrapper.view;
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>) {
+        match msg {
+            Msg::Append => {
+                // Add 10 items
+                for _ in 0..10 {
+                    self.counter = self.counter.wrapping_add(1);
+                    self.view_wrapper.append(MyListItem::new(self.counter));
+                }
+
+                // Count up the first item
+                let first_item = self.view_wrapper.get(0).unwrap();
+                let first_binding = &mut first_item.borrow_mut().binding;
+                let mut guard = first_binding.guard();
+                *guard += 1;
+            }
+            Msg::Remove => {
+                // Remove the second item
+                self.view_wrapper.remove(1);
+            }
+            Msg::OnlyShowEven(show_only_even) => {
+                // Disable or enable the first filter
+                self.view_wrapper.set_filter_status(0, show_only_even);
+            }
+        }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.typed-column-view");
+    app.run::<App>(0);
+}

--- a/examples/typed_column_view.rs
+++ b/examples/typed_column_view.rs
@@ -43,25 +43,18 @@ impl LabelColumn for Label1Column {
 struct Label2Column;
 
 impl RelmColumn for Label2Column {
-    type Root = gtk::Box;
-    type Widgets = gtk::Label;
+    type Root = gtk::Label;
+    type Widgets = ();
     type Item = MyListItem;
 
     const COLUMN_NAME: &'static str = "label2";
 
-    fn setup(_item: &gtk::ListItem) -> (gtk::Box, gtk::Label) {
-        relm4::view! {
-            root = gtk::Box {
-                #[name = "widget"]
-                gtk::Label,
-            }
-        }
-
-        (root, widget)
+    fn setup(_item: &gtk::ListItem) -> (Self::Root, Self::Widgets) {
+        (gtk::Label::new(None), ())
     }
 
-    fn bind(item: &mut Self::Item, widget: &mut Self::Widgets, _root: &mut Self::Root) {
-        widget.add_write_only_binding(&item.binding, "label");
+    fn bind(item: &mut Self::Item, _: &mut Self::Widgets, label: &mut Self::Root) {
+        label.add_write_only_binding(&item.binding, "label");
     }
 
     fn sort_fn() -> Option<ColumnSortFn<Self::Item>> {
@@ -72,25 +65,18 @@ impl RelmColumn for Label2Column {
 struct ButtonColumn;
 
 impl RelmColumn for ButtonColumn {
-    type Root = gtk::Box;
-    type Widgets = gtk::CheckButton;
+    type Root = gtk::CheckButton;
+    type Widgets = ();
     type Item = MyListItem;
 
     const COLUMN_NAME: &'static str = "button";
 
-    fn setup(_item: &gtk::ListItem) -> (gtk::Box, gtk::CheckButton) {
-        relm4::view! {
-            root = gtk::Box {
-                #[name = "widget"]
-                gtk::CheckButton,
-            }
-        }
-
-        (root, widget)
+    fn setup(_item: &gtk::ListItem) -> (Self::Root, Self::Widgets) {
+        (gtk::CheckButton::new(), ())
     }
 
-    fn bind(item: &mut Self::Item, widget: &mut Self::Widgets, _root: &mut Self::Root) {
-        widget.set_active(item.value % 2 == 0);
+    fn bind(item: &mut Self::Item, _: &mut Self::Widgets, button: &mut Self::Root) {
+        button.set_active(item.value % 2 == 0);
     }
 }
 

--- a/relm4/src/typed_list_view/column_view.rs
+++ b/relm4/src/typed_list_view/column_view.rs
@@ -1,66 +1,119 @@
-//! Idiomatic and high-level abstraction over [`gtk::ListView`].
-
-mod column_view;
-mod relm_selection_ext;
-
-use std::{
-    any::Any,
-    cell::{Ref, RefMut},
-    cmp::Ordering,
-    marker::PhantomData,
-};
-
+use super::*;
 use gtk::{
     gio, glib,
     prelude::{Cast, CastNone, IsA, ListModelExt, ObjectExt, StaticType},
 };
+use std::{
+    any::Any,
+    cmp::Ordering,
+    collections::HashMap,
+    fmt::{Debug, Display},
+    marker::PhantomData,
+};
 
-use relm_selection_ext::RelmSelectionExt;
+/// Sort function for a column.
+pub type ColumnSortFn<T> = Box<dyn Fn(&T, &T) -> Ordering + 'static>;
 
-pub use column_view::{ColumnSortFn, LabelColumn, RelmColumn, TypedColumnView};
-
-pub(crate) fn get_value<T: 'static>(obj: &glib::Object) -> Ref<'_, T> {
-    let wrapper = obj.downcast_ref::<glib::BoxedAnyObject>().unwrap();
-    wrapper.borrow()
-}
-
-pub(crate) fn get_mut_value<T: 'static>(obj: &glib::Object) -> RefMut<'_, T> {
-    let wrapper = obj.downcast_ref::<glib::BoxedAnyObject>().unwrap();
-    wrapper.borrow_mut()
-}
-
-/// An item of a [`TypedListView`].
-pub trait RelmListItem: Any {
+/// An item of a [`TypedColumnView`].
+pub trait RelmColumn: Any {
     /// The top-level widget for the list item.
     type Root: IsA<gtk::Widget>;
 
     /// The widgets created for the list item.
     type Widgets;
 
+    /// Item whose data is shown in this column.
+    type Item: Any;
+
+    /// The columns created for this list item.
+    const COLUMN_NAME: &'static str;
+
     /// Construct the widgets.
     fn setup(list_item: &gtk::ListItem) -> (Self::Root, Self::Widgets);
 
     /// Bind the widgets to match the data of the list item.
-    fn bind(&mut self, _widgets: &mut Self::Widgets, _root: &mut Self::Root) {}
+    fn bind(_item: &mut Self::Item, _widgets: &mut Self::Widgets, _root: &mut Self::Root) {}
 
-    /// Undo the steps of [`RelmListItem::bind()`] if necessary.
-    fn unbind(&mut self, _widgets: &mut Self::Widgets, _root: &mut Self::Root) {}
+    /// Undo the steps of [`RelmColumn::bind()`] if necessary.
+    fn unbind(_item: &mut Self::Item, _widgets: &mut Self::Widgets, _root: &mut Self::Root) {}
 
-    /// Undo the steps of [`RelmListItem::setup()`] if necessary.
+    /// Undo the steps of [`RelmColumn::setup()`] if necessary.
     fn teardown(_list_item: &gtk::ListItem) {}
+
+    /// Sorter for column.
+    #[must_use]
+    fn sort_fn() -> Option<ColumnSortFn<Self::Item>> {
+        None
+    }
+}
+
+/// Simplified trait for creating columns with only one `gtk::Label` widget per-entry (i.e. a text cell)
+pub trait LabelColumn: 'static {
+    /// Item of the model
+    type Item: Any;
+    /// Value of the column
+    type Value: PartialOrd + Display;
+
+    /// Name of the column
+    const COLUMN_NAME: &'static str;
+    /// Whether to enable the sorting for this column
+    const ENABLE_SORT: bool;
+
+    /// Get the value that this column represents.
+    fn get_cell_value(item: &Self::Item) -> Self::Value;
+    /// Format the value for presentation in the text cell.
+    fn format_cell_value(value: &Self::Value) -> String {
+        value.to_string()
+    }
+}
+
+impl<C> RelmColumn for C
+where
+    C: LabelColumn,
+{
+    type Root = gtk::Box;
+    type Widgets = gtk::Label;
+    type Item = C::Item;
+
+    const COLUMN_NAME: &'static str = C::COLUMN_NAME;
+
+    fn setup(_: &gtk::ListItem) -> (Self::Root, Self::Widgets) {
+        let root = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        let widget = gtk::Label::new(None);
+        crate::RelmContainerExt::container_add(&root, &widget);
+
+        (root, widget)
+    }
+
+    fn bind(item: &mut Self::Item, label: &mut Self::Widgets, _: &mut Self::Root) {
+        label.set_label(&C::format_cell_value(&C::get_cell_value(item)));
+    }
+
+    fn sort_fn() -> Option<ColumnSortFn<Self::Item>> {
+        if C::ENABLE_SORT {
+            Some(Box::new(|a, b| {
+                let a = C::get_cell_value(a);
+                let b = C::get_cell_value(b);
+                a.partial_cmp(&b).unwrap_or(Ordering::Equal)
+            }))
+        } else {
+            None
+        }
+    }
 }
 
 /// A high-level wrapper around [`gio::ListStore`],
-/// [`gtk::SignalListItemFactory`] and [`gtk::ListView`].
+/// [`gtk::SignalListItemFactory`] and [`gtk::ColumnView`].
 ///
-/// [`TypedListView`] aims at keeping nearly the same functionality and
+/// [`TypedColumnView`] aims at keeping nearly the same functionality and
 /// flexibility of the raw bindings while introducing a more idiomatic
 /// and type-safe interface.
-pub struct TypedListView<T, S> {
+pub struct TypedColumnView<T, S> {
     /// The internal list view.
-    pub view: gtk::ListView,
+    pub view: gtk::ColumnView,
     /// The internal selection model.
     pub selection_model: S,
+    columns: HashMap<&'static str, gtk::ColumnViewColumn>,
     store: gio::ListStore,
     filters: Vec<Filter>,
     active_model: gio::ListModel,
@@ -68,9 +121,13 @@ pub struct TypedListView<T, S> {
     _ty: PhantomData<*const T>,
 }
 
-impl<T: std::fmt::Debug, S: std::fmt::Debug> std::fmt::Debug for TypedListView<T, S> {
+impl<T, S> Debug for TypedColumnView<T, S>
+where
+    T: Debug,
+    S: Debug,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TypedListView")
+        f.debug_struct("TypedColumnView")
             .field("store", &self.store)
             .field("view", &self.view)
             .field("filters", &"<Vec<gtk::Filter>>")
@@ -81,29 +138,9 @@ impl<T: std::fmt::Debug, S: std::fmt::Debug> std::fmt::Debug for TypedListView<T
     }
 }
 
-impl<T, S> TypedListView<T, S>
+impl<T, S> Default for TypedColumnView<T, S>
 where
-    T: RelmListItem + Ord,
-    S: RelmSelectionExt,
-{
-    /// Create a new [`TypedListView`] that sorts the items
-    /// based on the [`Ord`] trait.
-    #[must_use]
-    pub fn with_sorting() -> Self {
-        Self::init(Some(Box::new(T::cmp)))
-    }
-}
-
-struct Filter {
-    filter: gtk::CustomFilter,
-    model: gtk::FilterListModel,
-}
-
-type OrdFn<T> = Option<Box<dyn Fn(&T, &T) -> Ordering>>;
-
-impl<T, S> Default for TypedListView<T, S>
-where
-    T: RelmListItem,
+    T: Any,
     S: RelmSelectionExt,
 {
     fn default() -> Self {
@@ -111,32 +148,62 @@ where
     }
 }
 
-impl<T, S> TypedListView<T, S>
+impl<T, S> TypedColumnView<T, S>
 where
-    T: RelmListItem,
+    T: Any,
     S: RelmSelectionExt,
 {
-    /// Create a new, empty [`TypedListView`].
+    /// Create a new, empty [`TypedColumnView`].
     #[must_use]
     pub fn new() -> Self {
-        Self::init(None)
-    }
-
-    fn init(sort_fn: OrdFn<T>) -> Self {
         let store = gio::ListStore::new(glib::BoxedAnyObject::static_type());
 
+        let model: gio::ListModel = store.clone().upcast();
+
+        let b = gtk::SortListModel::new(Some(model), None::<gtk::Sorter>);
+
+        let base_model: gio::ListModel = b.clone().upcast();
+
+        let selection_model = S::new_model(base_model.clone());
+        let view = gtk::ColumnView::new(Some(selection_model.clone()));
+        b.set_sorter(view.sorter().as_ref());
+
+        Self {
+            store,
+            view,
+            columns: HashMap::new(),
+            filters: Vec::new(),
+            active_model: base_model.clone(),
+            base_model,
+            _ty: PhantomData,
+            selection_model,
+        }
+    }
+
+    /// Append column to this typed view
+    pub fn append_column<C>(&mut self)
+    where
+        C: RelmColumn<Item = T>,
+    {
         let factory = gtk::SignalListItemFactory::new();
         factory.connect_setup(move |_, list_item| {
             let list_item = list_item
                 .downcast_ref::<gtk::ListItem>()
                 .expect("Needs to be ListItem");
 
-            let (root, widgets) = T::setup(list_item);
+            let (root, widgets) = C::setup(list_item);
             unsafe { root.set_data("widgets", widgets) };
             list_item.set_child(Some(&root));
         });
 
-        factory.connect_bind(move |_, list_item| {
+        #[inline]
+        fn modify_widgets<T, C>(
+            list_item: &glib::Object,
+            f: impl FnOnce(&mut T, &mut C::Widgets, &mut C::Root),
+        ) where
+            T: Any,
+            C: RelmColumn<Item = T>,
+        {
             let list_item = list_item
                 .downcast_ref::<gtk::ListItem>()
                 .expect("Needs to be ListItem");
@@ -149,31 +216,23 @@ where
             let obj = list_item.item().unwrap();
             let mut obj = get_mut_value::<T>(&obj);
 
-            let mut root = widget.and_downcast::<T::Root>().unwrap();
+            let mut root = widget.and_downcast::<C::Root>().unwrap();
 
             let mut widgets = unsafe { root.steal_data("widgets") }.unwrap();
-            obj.bind(&mut widgets, &mut root);
+            (f)(&mut *obj, &mut widgets, &mut root);
             unsafe { root.set_data("widgets", widgets) };
+        }
+
+        factory.connect_bind(move |_, list_item| {
+            modify_widgets::<T, C>(list_item, |obj, widgets, root| {
+                C::bind(obj, widgets, root);
+            });
         });
 
         factory.connect_unbind(move |_, list_item| {
-            let list_item = list_item
-                .downcast_ref::<gtk::ListItem>()
-                .expect("Needs to be ListItem");
-
-            let widget = list_item
-                .downcast_ref::<gtk::ListItem>()
-                .expect("Needs to be ListItem")
-                .child();
-
-            let obj = list_item.item().unwrap();
-            let mut obj = get_mut_value::<T>(&obj);
-
-            let mut root = widget.and_downcast::<T::Root>().unwrap();
-
-            let mut widgets = unsafe { root.steal_data("widgets") }.unwrap();
-            obj.unbind(&mut widgets, &mut root);
-            unsafe { root.set_data("widgets", widgets) };
+            modify_widgets::<T, C>(list_item, |obj, widgets, root| {
+                C::unbind(obj, widgets, root);
+            });
         });
 
         factory.connect_teardown(move |_, list_item| {
@@ -181,39 +240,24 @@ where
                 .downcast_ref::<gtk::ListItem>()
                 .expect("Needs to be ListItem");
 
-            T::teardown(list_item);
+            C::teardown(list_item);
         });
 
-        let model: gio::ListModel = store.clone().upcast();
+        let sort_fn = C::sort_fn();
 
-        let base_model = if let Some(sort_fn) = sort_fn {
-            let sorter = gtk::CustomSorter::new(move |first, second| {
+        let c = gtk::ColumnViewColumn::new(Some(C::COLUMN_NAME), Some(factory));
+
+        if let Some(sort_fn) = sort_fn {
+            c.set_sorter(Some(&gtk::CustomSorter::new(move |first, second| {
                 let first = get_value::<T>(first);
                 let second = get_value::<T>(second);
-                match sort_fn(&first, &second) {
-                    Ordering::Less => gtk::Ordering::Smaller,
-                    Ordering::Equal => gtk::Ordering::Equal,
-                    Ordering::Greater => gtk::Ordering::Larger,
-                }
-            });
 
-            gtk::SortListModel::new(Some(model), Some(sorter)).upcast()
-        } else {
-            model
-        };
-
-        let selection_model = S::new_model(base_model.clone());
-        let view = gtk::ListView::new(Some(selection_model.clone()), Some(factory));
-
-        Self {
-            store,
-            view,
-            filters: Vec::new(),
-            active_model: base_model.clone(),
-            base_model,
-            _ty: PhantomData,
-            selection_model,
+                sort_fn(&first, &second).into()
+            })))
         }
+
+        self.view.append_column(&c);
+        self.columns.insert(C::COLUMN_NAME, c);
     }
 
     /// Add a function to filter the stored items.
@@ -233,6 +277,11 @@ where
             filter,
             model: filter_model,
         });
+    }
+
+    /// Get columns currently associated with this view.
+    pub fn get_columns(&self) -> &HashMap<&'static str, gtk::ColumnViewColumn> {
+        &self.columns
     }
 
     /// Returns the amount of filters that were added.
@@ -335,11 +384,10 @@ where
 
     /// Insert an item into the list and calculate its position from
     /// a sorting function.
-    pub fn insert_sorted<F: FnMut(&T, &T) -> Ordering>(
-        &self,
-        value: T,
-        mut compare_func: F,
-    ) -> u32 {
+    pub fn insert_sorted<F>(&self, value: T, mut compare_func: F) -> u32
+    where
+        F: FnMut(&T, &T) -> Ordering,
+    {
         let item = glib::BoxedAnyObject::new(value);
 
         let compare = move |first: &glib::Object, second: &glib::Object| -> Ordering {
@@ -359,86 +407,5 @@ where
     /// Remove all items.
     pub fn clear(&mut self) {
         self.store.remove_all();
-    }
-}
-
-/// And item of a [`TypedListView`].
-///
-/// The interface is very similar to [`std::cell::RefCell`].
-/// Ownership is calculated at runtime, so you have to borrow the
-/// value explicitly which might panic if done incorrectly.
-#[derive(Debug, Clone)]
-pub struct TypedListItem<T> {
-    inner: glib::BoxedAnyObject,
-    _ty: PhantomData<*const T>,
-}
-
-impl<T: 'static> TypedListItem<T> {
-    fn new(inner: glib::BoxedAnyObject) -> Self {
-        Self {
-            inner,
-            _ty: PhantomData,
-        }
-    }
-
-    /*
-    // rustdoc-stripper-ignore-next
-    /// Immutably borrows the wrapped value, returning an error if the value is currently mutably
-    /// borrowed or if it's not of type `T`.
-    ///
-    /// The borrow lasts until the returned `Ref` exits scope. Multiple immutable borrows can be
-    /// taken out at the same time.
-    ///
-    /// This is the non-panicking variant of [`borrow`](#method.borrow).
-    pub fn try_borrow(&self) -> Result<Ref<'_, T>, BorrowError> {
-        self.inner.try_borrow()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Mutably borrows the wrapped value, returning an error if the value is currently borrowed.
-    /// or if it's not of type `T`.
-    ///
-    /// The borrow lasts until the returned `RefMut` or all `RefMut`s derived
-    /// from it exit scope. The value cannot be borrowed while this borrow is
-    /// active.
-    ///
-    /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
-    pub fn try_borrow_mut(&mut self) -> Result<RefMut<'_, T>, BorrowMutError> {
-        self.inner.try_borrow_mut()
-    } */
-
-    // rustdoc-stripper-ignore-next
-    /// Immutably borrows the wrapped value.
-    ///
-    /// The borrow lasts until the returned `Ref` exits scope. Multiple
-    /// immutable borrows can be taken out at the same time.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is currently mutably borrowed.
-    ///
-    /// For a non-panicking variant, use
-    /// [`try_borrow`](#method.try_borrow).
-    #[must_use]
-    pub fn borrow(&self) -> Ref<'_, T> {
-        self.inner.borrow()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Mutably borrows the wrapped value.
-    ///
-    /// The borrow lasts until the returned `RefMut` or all `RefMut`s derived
-    /// from it exit scope. The value cannot be borrowed while this borrow is
-    /// active.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is currently borrowed.
-    ///
-    /// For a non-panicking variant, use
-    /// [`try_borrow_mut`](#method.try_borrow_mut).
-    #[must_use]
-    pub fn borrow_mut(&self) -> RefMut<'_, T> {
-        self.inner.borrow_mut()
     }
 }

--- a/relm4/src/typed_list_view/column_view.rs
+++ b/relm4/src/typed_list_view/column_view.rs
@@ -71,21 +71,17 @@ impl<C> RelmColumn for C
 where
     C: LabelColumn,
 {
-    type Root = gtk::Box;
-    type Widgets = gtk::Label;
+    type Root = gtk::Label;
+    type Widgets = ();
     type Item = C::Item;
 
     const COLUMN_NAME: &'static str = C::COLUMN_NAME;
 
     fn setup(_: &gtk::ListItem) -> (Self::Root, Self::Widgets) {
-        let root = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        let widget = gtk::Label::new(None);
-        crate::RelmContainerExt::container_add(&root, &widget);
-
-        (root, widget)
+        (gtk::Label::new(None), ())
     }
 
-    fn bind(item: &mut Self::Item, label: &mut Self::Widgets, _: &mut Self::Root) {
+    fn bind(item: &mut Self::Item, _: &mut Self::Widgets, label: &mut Self::Root) {
         label.set_label(&C::format_cell_value(&C::get_cell_value(item)));
     }
 


### PR DESCRIPTION
YOLO implementation of typed wrapper for gtk::ColumnView. Largely based on TypedListView, but modified to have per-column factories as required by ColumnView API.