### PR TITLE
Remove unnecessary explicit call to `.into_iter()`

### DIFF
--- a/relm4-macros/src/util.rs
+++ b/relm4-macros/src/util.rs
@@ -106,7 +106,7 @@ pub(super) fn verbatim_impl_item_fn(
                 where_clause: None,
             },
             paren_token: syn::token::Paren::default(),
-            inputs: Punctuated::from_iter(args.into_iter()),
+            inputs: Punctuated::from_iter(args),
             variadic: None,
             output: syn::ReturnType::Type(syn::token::RArrow::default(), Box::new(ty)),
         },


### PR DESCRIPTION
#### Summary
Make clippy happy. This causes the `build (beta)` check to fail, cancelling the rest of the builds in https://github.com/Relm4/Relm4/pull/490.

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
