### PR TITLE
macros: Add support for accessing nested template children

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
++ macros: Add support for accessing nested template children
+
+## 0.6.1 - 2023-8-9
+
 ### Added
 
 + core: Add `TypedColumnView` as a typed wrapper for `gtk::ColumnView`

--- a/relm4-macros/src/widgets/gen/assign/conditional_widget.rs
+++ b/relm4-macros/src/widgets/gen/assign/conditional_widget.rs
@@ -36,7 +36,7 @@ impl ConditionalWidget {
         let mut info = AssignInfo {
             stream: info.stream,
             widget_name: &self.name,
-            template_name: None,
+            template_path: None,
             is_conditional: true,
         };
         match &self.branches {

--- a/relm4-macros/src/widgets/gen/assign/mod.rs
+++ b/relm4-macros/src/widgets/gen/assign/mod.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
-use syn::Ident;
+use syn::{punctuated::Punctuated, token, Ident};
 
 use crate::widgets::{Property, PropertyType};
 
@@ -12,7 +12,7 @@ mod widgets;
 pub(crate) struct AssignInfo<'a> {
     pub(crate) stream: &'a mut TokenStream2,
     pub(crate) widget_name: &'a Ident,
-    pub(crate) template_name: Option<&'a Ident>,
+    pub(crate) template_path: Option<Punctuated<Ident, token::Dot>>,
     pub(crate) is_conditional: bool,
 }
 

--- a/relm4-macros/src/widgets/gen/assign/widgets.rs
+++ b/relm4-macros/src/widgets/gen/assign/widgets.rs
@@ -33,7 +33,7 @@ impl Widget {
         let mut info = AssignInfo {
             stream,
             widget_name: w_name,
-            template_name: None,
+            template_path: None,
             is_conditional: false,
         };
         self.properties.assign_stream(&mut info, sender_name);
@@ -47,12 +47,13 @@ impl Widget {
     ) {
         // Recursively generate code for properties
         {
-            let template_name = (self.template_attr == WidgetTemplateAttr::TemplateChild)
-                .then_some(info.widget_name);
+            let template_path = (self.template_attr == WidgetTemplateAttr::TemplateChild)
+                .then_some(self.func.widget_template_path(info.widget_name, &self.name));
+
             let mut info = AssignInfo {
                 stream: info.stream,
                 widget_name: &self.name,
-                template_name,
+                template_path,
                 is_conditional: info.is_conditional,
             };
             self.properties.assign_stream(&mut info, sender_name);
@@ -88,7 +89,7 @@ impl Widget {
             let mut info = AssignInfo {
                 stream: info.stream,
                 widget_name: &returned_widget.name,
-                template_name: None,
+                template_path: None,
                 is_conditional: info.is_conditional,
             };
             returned_widget

--- a/relm4-macros/src/widgets/gen/conditional_init.rs
+++ b/relm4-macros/src/widgets/gen/conditional_init.rs
@@ -171,7 +171,7 @@ impl AssignProperty {
                         let mut info = AssignInfo {
                             stream,
                             widget_name,
-                            template_name: None,
+                            template_path: None,
                             is_conditional,
                         };
                         self.assign_stream(&mut info, p_name, true);
@@ -187,7 +187,7 @@ impl AssignProperty {
                         let mut info = AssignInfo {
                             stream: &mut assign_stream,
                             widget_name,
-                            template_name: None,
+                            template_path: None,
                             is_conditional,
                         };
 

--- a/relm4-macros/src/widgets/gen/util/property_name.rs
+++ b/relm4-macros/src/widgets/gen/util/property_name.rs
@@ -8,11 +8,11 @@ impl PropertyName {
     pub(crate) fn assign_fn_stream(&self, info: &mut AssignInfo<'_>) -> TokenStream2 {
         let AssignInfo {
             widget_name,
-            template_name,
+            template_path,
             ..
         } = info;
-        let widget_name = if let Some(template_name) = template_name {
-            quote! { #template_name.#widget_name }
+        let widget_name = if let Some(template_path) = template_path {
+            quote! { #template_path }
         } else {
             quote! { #widget_name }
         };

--- a/relm4-macros/src/widgets/gen/util/widget_func.rs
+++ b/relm4-macros/src/widgets/gen/util/widget_func.rs
@@ -1,7 +1,8 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned, ToTokens};
-use syn::spanned::Spanned;
-use syn::Error;
+use syn::punctuated::Punctuated;
+use syn::{spanned::Spanned, Ident};
+use syn::{token, Error};
 
 use crate::widgets::{Widget, WidgetFunc};
 
@@ -85,5 +86,27 @@ impl WidgetFunc {
         }
 
         stream
+    }
+
+    pub(crate) fn widget_template_path(
+        &self,
+        template_widget_name: &Ident,
+        widget_name: &Ident,
+    ) -> Punctuated<Ident, token::Dot> {
+        let mut template_path = Punctuated::new();
+        template_path.push(template_widget_name.clone());
+        template_path.push(widget_name.clone());
+        if let Some(chain) = &self.method_chain {
+            for method in chain {
+                if method.turbofish.is_some() || method.args.is_some() {
+                    break;
+                } else {
+                    template_path.push(method.ident.clone());
+                }
+            }
+            template_path
+        } else {
+            template_path
+        }
     }
 }

--- a/relm4-macros/tests/widget_template_nested_child.rs
+++ b/relm4-macros/tests/widget_template_nested_child.rs
@@ -1,0 +1,81 @@
+use gtk::prelude::{BoxExt, GtkWindowExt, OrientableExt};
+use relm4::{gtk, ComponentParts, ComponentSender, RelmWidgetExt, SimpleComponent, WidgetTemplate};
+
+#[relm4_macros::widget_template]
+impl WidgetTemplate for CustomBox {
+    view! {
+        gtk::Box {
+            set_margin_all: 5,
+            set_spacing: 5,
+
+            #[name = "label"]
+            gtk::Label {
+                set_label: "Is it working?",
+            }
+        }
+    }
+}
+
+#[relm4_macros::widget_template]
+impl WidgetTemplate for CustomWindow {
+    view! {
+        gtk::Window {
+            set_title: Some("Simple app"),
+            set_default_width: 300,
+            set_default_height: 100,
+
+            #[template]
+            #[name = "custom_box"]
+            CustomBox {
+                set_orientation: gtk::Orientation::Vertical,
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct App {
+    counter: u8,
+}
+
+#[derive(Debug)]
+enum AppMsg {}
+
+#[relm4_macros::component]
+impl SimpleComponent for App {
+    type Init = u8;
+    type Input = AppMsg;
+    type Output = ();
+
+    view! {
+        #[template]
+        CustomWindow {
+            set_title: Some("Simple app"),
+            set_default_width: 300,
+            set_default_height: 100,
+
+            // Nested template child
+            #[template_child]
+            custom_box.label {
+                #[watch]
+                set_label: "It works!",
+            },
+        }
+    }
+
+    fn init(
+        counter: Self::Init,
+        root: &Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = Self { counter };
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, _msg: AppMsg, _sender: ComponentSender<Self>) {
+        self.counter += 1;
+    }
+}


### PR DESCRIPTION
Fixes #505 

#### Summary

Adds support for a macro syntax to access nested template children.
For example, according to #504, you might have a template `SettingsPage` with a button  `btn_dark_mode` and another template `MainWidget` that includes an instance of `SettingsPage` with name `settings_page`.
With this PR, it will be possible to access the `btn_dark_mode` by using it's path `settings_page.btn_dark_mode`.

```rust
adw::Window {
    // ...

    #[template]
    MainWidget {

        // Access MainWidget->SettingsPage->btn_dark_mode like this:
        #[template_child] 
        settings_page.btn_dark_mode {
            connect_clicked => Message::DarkMode,
        },

    },
}
```

@eminfedar could you please test this PR with your code?

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
