### PR TITLE
core: Allow widget templates as root of RelmApp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-## 0.7.0-alpha.1 - 2023-9-28
+### Changed
+
++ core: Just require `AsRef<gtk::Window>` in `RelmApp::run`
++ core: Add `AsRef<Root>` as requirement to the `WidgetTemplate` trait
+
+## 0.7.0-alpha.1 - 2023-8-28
 
 ### Added
 
@@ -13,7 +18,7 @@
 + core: Bump version of gtk4 dependency to 0.7
 + core: Bump version of libadwaita dependency to 0.5
 
-## 0.6.2 - 2023-9-27
+## 0.6.2 - 2023-8-27
 
 ### Fixed
 

--- a/examples/widget_template.rs
+++ b/examples/widget_template.rs
@@ -24,6 +24,17 @@ impl WidgetTemplate for MySpinner {
 }
 
 #[relm4::widget_template]
+impl WidgetTemplate for MyWindow {
+    view! {
+        gtk::Window {
+            set_title: Some("Widget template"),
+            set_default_width: 300,
+            set_default_height: 100,
+        }
+    }
+}
+
+#[relm4::widget_template]
 impl WidgetTemplate for CustomBox {
     view! {
         gtk::Box {
@@ -76,11 +87,8 @@ impl SimpleComponent for AppModel {
     type Output = ();
 
     view! {
-        gtk::Window {
-            set_title: Some("Widget template"),
-            set_default_width: 300,
-            set_default_height: 100,
-
+        #[template]
+        MyWindow {
             #[template]
             CustomBox {
                 #[template_child]

--- a/relm4-macros/src/widget_template.rs
+++ b/relm4-macros/src/widget_template.rs
@@ -73,6 +73,12 @@ pub(crate) fn generate_tokens(vis: Option<Visibility>, mut item_impl: ItemImpl) 
                             #struct_fields
                         }
 
+                        impl ::std::convert::AsRef<#root_widget_type> for #type_name {
+                            fn as_ref(&self) -> &#root_widget_type {
+                                &self.#root_name
+                            }
+                        }
+
                         impl ::std::ops::Deref for #type_name {
                             type Target = #root_widget_type;
 

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -69,7 +69,7 @@ impl<M: Debug + 'static> RelmApp<M> {
     pub fn run<C>(self, payload: C::Init)
     where
         C: Component<Input = M>,
-        C::Root: IsA<gtk::Window> + WidgetExt,
+        C::Root: AsRef<gtk::Window>,
     {
         let Self { app, broker, args } = self;
 
@@ -96,7 +96,8 @@ impl<M: Debug + 'static> RelmApp<M> {
 
                 controller.detach_runtime();
 
-                app.add_window(&window);
+                let window = window.as_ref();
+                app.add_window(window);
                 window.set_visible(true);
             }
         });
@@ -119,7 +120,7 @@ impl<M: Debug + 'static> RelmApp<M> {
     pub fn run_with_args<C, S>(self, payload: C::Init, args: &[S])
     where
         C: Component<Input = M>,
-        C::Root: IsA<gtk::Window> + WidgetExt,
+        C::Root: AsRef<gtk::Window>,
         S: AsRef<str>,
     {
         let args = args.iter().map(|a| a.as_ref().to_string()).collect();
@@ -130,7 +131,7 @@ impl<M: Debug + 'static> RelmApp<M> {
     pub fn run_async<C>(self, payload: C::Init)
     where
         C: AsyncComponent<Input = M>,
-        C::Root: IsA<gtk::Window> + WidgetExt,
+        C::Root: AsRef<gtk::Window>,
     {
         let Self { app, broker, args } = self;
 
@@ -157,7 +158,8 @@ impl<M: Debug + 'static> RelmApp<M> {
 
                 controller.detach_runtime();
 
-                app.add_window(&window);
+                let window = window.as_ref();
+                app.add_window(window);
                 window.set_visible(true);
             }
         });
@@ -180,7 +182,7 @@ impl<M: Debug + 'static> RelmApp<M> {
     pub fn run_async_with_args<C, S>(self, payload: C::Init, args: &[S])
     where
         C: AsyncComponent<Input = M>,
-        C::Root: IsA<gtk::Window> + WidgetExt,
+        C::Root: AsRef<gtk::Window>,
         S: AsRef<str>,
     {
         let args = args.iter().map(|a| a.as_ref().to_string()).collect();

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -40,7 +40,9 @@ impl<T: AsRef<gtk::Widget>> WidgetRef for T {
 ///
 /// Widget templates can be created manually by implementing this trait
 /// or by using the [`widget_template`](crate::widget_template) macro.
-pub trait WidgetTemplate: Sized + std::fmt::Debug + std::ops::Deref<Target = Self::Root> {
+pub trait WidgetTemplate:
+    Sized + std::fmt::Debug + AsRef<Self::Root> + std::ops::Deref<Target = Self::Root>
+{
     /// The root of the template.
     type Root;
 


### PR DESCRIPTION
#### Summary

Fixes widget templates as root of the component used in `RelmApp`.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
