### PR TITLE
core: Add `Init` type to `WidgetTemplate`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
++ core: Add `Init` type to the `WidgetTemplate` trait to allow passing data to `init()` 
 + core: Just require `AsRef<gtk::Window>` in `RelmApp::run`
 + core: Add `AsRef<Root>` as requirement to the `WidgetTemplate` trait
 

--- a/relm4-macros/src/widget_template.rs
+++ b/relm4-macros/src/widget_template.rs
@@ -7,95 +7,146 @@ use crate::{
     widgets::ViewWidgets,
 };
 
-pub(crate) fn generate_tokens(vis: Option<Visibility>, mut item_impl: ItemImpl) -> TokenStream2 {
-    if item_impl.items.len() != 1 {
-        return Error::new(
-            item_impl.span(),
-            "Expected only one view macro and nothing else",
-        )
-        .into_compile_error();
-    }
+pub(crate) fn generate_tokens(vis: Option<Visibility>, item_impl: ItemImpl) -> TokenStream2 {
+    let self_ty = item_impl.self_ty.clone();
+    match try_generate_tokens(vis, item_impl) {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            let err = err.to_compile_error();
+            quote! {
+                #[derive(Debug, Clone)]
+                pub struct #self_ty;
 
-    let item = item_impl.items.pop().unwrap();
-
-    if let ImplItem::Macro(mac) = item {
-        if Some("view") == mac.mac.path.get_ident().map(|i| i.to_string()).as_deref() {
-            match syn::parse::<ViewWidgets>(mac.mac.tokens.into()) {
-                Ok(mut view_widgets) => {
-                    view_widgets.mark_root_as_used();
-
-                    let TokenStreams {
-                        error,
-                        init,
-                        assign,
-                        struct_fields,
-                        return_fields,
-                        ..
-                    } = view_widgets.generate_streams(
-                        &TraitImplDetails {
-                            vis: vis.clone(),
-                            model_name: Ident::new("_", Span2::call_site()),
-                            sender_name: Ident::new("sender", Span2::call_site()),
-                            root_name: None,
-                        },
-                        true,
-                    );
-
-                    let view_output = quote! {
-                        #init
-                        #assign
-                        {
-                            #error
-                        }
-                    };
-
-                    let root_widget_type = view_widgets.root_type();
-                    item_impl.items.push(ImplItem::Verbatim(quote! {
-                        type Root = #root_widget_type;
-                    }));
-
-                    let root_name = view_widgets.root_name();
-
-                    item_impl.items.push(ImplItem::Verbatim(quote! {
-                        fn init() -> Self {
-                            #view_output
-                            Self {
-                                #return_fields
-                            }
-                        }
-                    }));
-
-                    let type_name = &item_impl.self_ty;
-
-                    quote! {
-                        #[derive(Debug, Clone)]
-                        #vis struct #type_name {
-                            #struct_fields
-                        }
-
-                        impl ::std::convert::AsRef<#root_widget_type> for #type_name {
-                            fn as_ref(&self) -> &#root_widget_type {
-                                &self.#root_name
-                            }
-                        }
-
-                        impl ::std::ops::Deref for #type_name {
-                            type Target = #root_widget_type;
-
-                            fn deref(&self) -> &Self::Target {
-                                &self.#root_name
-                            }
-                        }
-
-                        #item_impl
+                impl ::std::convert::AsRef<()> for #self_ty {
+                    fn as_ref(&self) -> &() {
+                        todo!()
                     }
                 }
-                Err(err) => err.to_compile_error(),
+
+                impl ::std::ops::Deref for #self_ty {
+                    type Target = ();
+
+                    fn deref(&self) -> &Self::Target {
+                        &()
+                    }
+                }
+
+                impl WidgetTemplate for #self_ty {
+                    type Root = ();
+                    type Init = ();
+
+                    fn init(Self::Init) -> Self {
+                        todo!()
+                    }
+                }
+                #err
             }
-        } else {
-            Error::new(mac.mac.path.span(), "Expected a view macro").into_compile_error()
         }
+    }
+}
+
+fn try_generate_tokens(
+    vis: Option<Visibility>,
+    mut item_impl: ItemImpl,
+) -> syn::Result<TokenStream2> {
+    let mut init_type_set = false;
+    let mut view_macro_idx = None;
+    for (idx, item) in item_impl.items.iter().enumerate() {
+        match item {
+            ImplItem::Type(ty) => {
+                if ty.ident == "Init" {
+                    init_type_set = true;
+                }
+            }
+            ImplItem::Macro(mac) => {
+                if mac.mac.path.get_ident().map(|ident| ident == "view") == Some(true) {
+                    view_macro_idx = Some(idx);
+                }
+            }
+            _ => return Err(Error::new(item.span(), "Expected a view macro")),
+        }
+    }
+
+    if !init_type_set {
+        item_impl.items.push(ImplItem::Type(syn::parse_quote! {
+            type Init = ();
+        }));
+    }
+
+    if let Some(view_macro_idx) = view_macro_idx {
+        let ImplItem::Macro(view_macro) = item_impl.items.remove(view_macro_idx) else {
+            unreachable!()
+        };
+
+        let mut view_widgets = syn::parse::<ViewWidgets>(view_macro.mac.tokens.into())?;
+        view_widgets.mark_root_as_used();
+
+        let TokenStreams {
+            error,
+            init,
+            assign,
+            struct_fields,
+            return_fields,
+            ..
+        } = view_widgets.generate_streams(
+            &TraitImplDetails {
+                vis: vis.clone(),
+                model_name: Ident::new("_", Span2::call_site()),
+                sender_name: Ident::new("sender", Span2::call_site()),
+                root_name: None,
+            },
+            true,
+        );
+
+        let view_output = quote! {
+            #init
+            #assign
+            {
+                #error
+            }
+        };
+
+        let root_widget_type = view_widgets.root_type();
+        item_impl.items.push(ImplItem::Verbatim(quote! {
+            type Root = #root_widget_type;
+        }));
+
+        let root_name = view_widgets.root_name();
+
+        item_impl.items.push(ImplItem::Verbatim(quote! {
+            fn init(init: Self::Init) -> Self {
+                #view_output
+                Self {
+                    #return_fields
+                }
+            }
+        }));
+
+        let type_name = &item_impl.self_ty;
+
+        Ok(quote! {
+            #[derive(Debug, Clone)]
+            #vis struct #type_name {
+                #struct_fields
+            }
+
+            impl ::std::convert::AsRef<#root_widget_type> for #type_name {
+                fn as_ref(&self) -> &#root_widget_type {
+                    &self.#root_name
+                }
+            }
+
+            impl ::std::ops::Deref for #type_name {
+                type Target = #root_widget_type;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.#root_name
+                }
+            }
+
+            #item_impl
+        })
     } else {
-        Error::new(item.span(), "Expected a macro").into_compile_error()
+        Err(Error::new(item_impl.span(), "Expected a view macro"))
     }
 }

--- a/relm4-macros/src/widgets/gen/init.rs
+++ b/relm4-macros/src/widgets/gen/init.rs
@@ -44,12 +44,7 @@ impl Widget {
             WidgetTemplateAttr::None | WidgetTemplateAttr::TemplateChild => {
                 self.func.func_token_stream()
             }
-            WidgetTemplateAttr::Template => {
-                let widget_ty = &self.func.path;
-                quote! {
-                    <#widget_ty as relm4::WidgetTemplate>::init()
-                }
-            }
+            WidgetTemplateAttr::Template => self.func.widget_template_init(),
         });
 
         self.other_init_stream(init_stream);
@@ -69,9 +64,9 @@ impl Widget {
                     });
                 }
                 WidgetTemplateAttr::Template => {
-                    let widget_ty = &self.func.path;
+                    let init = self.func.widget_template_init();
                     stream.extend(quote! {
-                        let #mutability #name #ty = <#widget_ty as relm4::WidgetTemplate>::init();
+                        let #mutability #name #ty = #init;
                     });
                 }
                 // Template children are already initialized by their template.

--- a/relm4-macros/tests/widget_template.rs
+++ b/relm4-macros/tests/widget_template.rs
@@ -3,10 +3,11 @@ use relm4::{gtk, ComponentParts, ComponentSender, RelmWidgetExt, SimpleComponent
 
 #[relm4_macros::widget_template]
 impl WidgetTemplate for CustomBox {
+    type Init = i32;
     view! {
         gtk::Box {
             set_orientation: gtk::Orientation::Vertical,
-            set_margin_all: 5,
+            set_margin_all: init,
             set_spacing: 5,
 
             #[name = "child_label"]
@@ -62,7 +63,7 @@ impl SimpleComponent for App {
             },
 
             #[template]
-            CustomBox {
+            CustomBox(5) {
                 gtk::Button {
                     set_label: "Increment",
                     connect_clicked[sender] => move |_| {
@@ -82,7 +83,7 @@ impl SimpleComponent for App {
                     set_label: &format!("Counter: {}", model.counter),
                 },
                 #[template]
-                CustomBox {
+                CustomBox(5) {
                     #[template_child]
                     child_label {
                         set_margin_all: 5,

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -46,8 +46,11 @@ pub trait WidgetTemplate:
     /// The root of the template.
     type Root;
 
+    /// The parameter used to initialize the template.
+    type Init;
+
     /// Initializes the template.
-    fn init() -> Self;
+    fn init(init: Self::Init) -> Self;
 }
 
 /// Additional methods for `gtk::builders::ApplicationBuilder`


### PR DESCRIPTION
#### Summary

Allow passing data to `WidgetTemplate::init()` to make widget templates more flexible.
Due to clever use of the macros, existing code should still compile just fine.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
