### PR TITLE
macros: Allow trailing commas in the last match arm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 + macros: Fix track attribute for template children
++ macros: Allow trailing commas in the last match arm
 
 ## 0.7.0-alpha.1 - 2023-8-28
 

--- a/examples/macro_reference.rs
+++ b/examples/macro_reference.rs
@@ -90,7 +90,7 @@ impl SimpleComponent for App {
                         gtk::Label {
                             set_label: "Value is higher than 2",
                         }
-                    }
+                    },
                 },
 
                 append = &gtk::Label,

--- a/relm4-macros/src/widgets/parse/match_arm.rs
+++ b/relm4-macros/src/widgets/parse/match_arm.rs
@@ -7,10 +7,6 @@ use crate::widgets::{parse_util, MatchArm, ParseError, Widget};
 
 impl MatchArm {
     pub(super) fn parse(input: ParseStream<'_>, index: usize) -> Result<Self, ParseError> {
-        if input.peek(Token![,]) {
-            let _comma: Token![,] = input.parse()?;
-        }
-
         let pattern = syn::Pat::parse_multi_with_leading_vert(input)?;
         let guard = if input.peek(token::FatArrow) {
             None
@@ -34,6 +30,11 @@ impl MatchArm {
         let ref_span = input.span();
         let mut widget = Widget::parse(inner_tokens, attributes, Some(args))?;
         widget.ref_token = Some(And { spans: [ref_span] });
+
+        // Parse trailing commas
+        if input.peek(Token![,]) {
+            let _comma: Token![,] = input.parse()?;
+        }
 
         Ok(Self {
             pattern,


### PR DESCRIPTION
#### Summary

Fixes #506

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
