### PR TITLE
macros: Improve codegen to prevent incorrect lints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,7 @@
 
 ### Fixed
 
++ macros: Improve spans in code generation to prevent false positive lints
 + macros: Fix track attribute for template children
 + macros: Allow trailing commas in the last match arm
 

--- a/examples/macro_reference.rs
+++ b/examples/macro_reference.rs
@@ -1,3 +1,14 @@
+// Catch potential problems with clippy and the macro
+#![warn(
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub,
+    unused_qualifications,
+    clippy::cargo,
+    clippy::must_use_candidate,
+    clippy::used_underscore_binding
+)]
+
 use gtk::prelude::{
     BoxExt, ButtonExt, GridExt, GtkWindowExt, ObjectExt, OrientableExt, ToggleButtonExt, WidgetExt,
 };

--- a/relm4-macros/src/menu/gen.rs
+++ b/relm4-macros/src/menu/gen.rs
@@ -72,7 +72,7 @@ impl MenuItem {
 
 impl SubMenu {
     fn submenu_stream(&self, parent_ident: &Ident) -> TokenStream2 {
-        let name = Ident::new(&format!("_{parent_ident}"), Span2::call_site());
+        let name = Ident::new(&format!("_{parent_ident}"), Span2::mixed_site());
         let gtk_import = crate::gtk_import();
         let expr = &self.expr;
 

--- a/relm4-macros/src/menu/parse.rs
+++ b/relm4-macros/src/menu/parse.rs
@@ -99,5 +99,5 @@ fn section_name() -> Ident {
 
     let value = COUNTER.fetch_add(1, Ordering::Relaxed);
 
-    Ident::new(&format!("_section_{value}"), Span2::call_site())
+    Ident::new(&format!("_section_{value}"), Span2::mixed_site())
 }

--- a/relm4-macros/src/util.rs
+++ b/relm4-macros/src/util.rs
@@ -56,7 +56,7 @@ pub(super) fn strings_to_path(strings: &[&str]) -> Path {
         .iter()
         .map(|string| -> PathSegment {
             PathSegment {
-                ident: Ident::new(string, Span2::call_site()),
+                ident: Ident::new(string, Span2::mixed_site()),
                 arguments: PathArguments::None,
             }
         })
@@ -98,7 +98,7 @@ pub(super) fn verbatim_impl_item_fn(
             unsafety: None,
             abi: None,
             fn_token: syn::token::Fn::default(),
-            ident: Ident::new(name, Span2::call_site()),
+            ident: Ident::new(name, Span2::mixed_site()),
             generics: syn::Generics {
                 lt_token: None,
                 params: Punctuated::default(),

--- a/relm4-macros/src/view.rs
+++ b/relm4-macros/src/view.rs
@@ -17,7 +17,7 @@ pub(super) fn generate_tokens(input: TokenStream) -> TokenStream {
     } = view_widgets.generate_streams(
         &TraitImplDetails {
             vis: None,
-            model_name: Ident::new("_", Span2::call_site()),
+            model_name: Ident::new("_", Span2::mixed_site()),
             sender_name: Ident::new("sender", Span2::call_site()),
             root_name: None,
         },

--- a/relm4-macros/src/widget_template.rs
+++ b/relm4-macros/src/widget_template.rs
@@ -91,7 +91,7 @@ fn try_generate_tokens(
         } = view_widgets.generate_streams(
             &TraitImplDetails {
                 vis: vis.clone(),
-                model_name: Ident::new("_", Span2::call_site()),
+                model_name: Ident::new("_", Span2::mixed_site()),
                 sender_name: Ident::new("sender", Span2::call_site()),
                 root_name: None,
             },

--- a/relm4-macros/src/widgets/gen/assign/assign_property.rs
+++ b/relm4-macros/src/widgets/gen/assign/assign_property.rs
@@ -100,31 +100,30 @@ impl AssignProperty {
                     }
                 }
                 (true, false) => {
-                    quote_spanned! {
-                        span => if let Some(__p_assign) = #assign {
+                    quote! {
+                        if let Some(assign) = #assign {
                             #block_stream
-                            #assign_fn(#self_assign_args __p_assign #args) #chain;
+                            #assign_fn(#self_assign_args assign #args) #chain;
                             #unblock_stream
                         }
                     }
                 }
                 (false, true) => {
-                    quote_spanned! {
-                        span =>
-                            #block_stream
-                            for __elem in #assign {
-                                #assign_fn(#self_assign_args __elem #args) #chain;
-                            }
-                            #unblock_stream
+                    quote! {
+                        #block_stream
+                        for elem in #assign {
+                            #assign_fn(#self_assign_args elem #args) #chain;
+                        }
+                        #unblock_stream
                     }
                 }
                 (true, true) => {
                     quote_spanned! {
                         span =>
                             #block_stream
-                            for __elem in #assign {
-                                if let Some(__p_assign) = __elem {
-                                    #assign_fn(#self_assign_args __p_assign #args) #chain;
+                            for elem in #assign {
+                                if let Some(assign) = elem {
+                                    #assign_fn(#self_assign_args assign #args) #chain;
                                 }
                             }
                             #unblock_stream

--- a/relm4-macros/src/widgets/gen/conditional_init.rs
+++ b/relm4-macros/src/widgets/gen/conditional_init.rs
@@ -134,7 +134,7 @@ impl ConditionalWidget {
 
         let w_name = &self.name;
         stream.extend(quote! {
-            let __current_page = "";
+            let current_page = "";
             #w_name.set_visible_child_name(#brach_stream);
         });
     }

--- a/relm4-macros/src/widgets/gen/update_view.rs
+++ b/relm4-macros/src/widgets/gen/update_view.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{quote, quote_spanned};
+use quote::quote;
 use syn::{punctuated::Punctuated, token, Ident};
 
 use crate::widgets::{
@@ -142,7 +142,7 @@ impl ConditionalWidget {
                     let index = index.to_string();
                     inner_tokens.extend(quote! {
                         #pattern #guard_if #guard_expr #arrow {
-                            let __page_active: bool = (__current_page == #index);
+                            let page_active: bool = (current_page == #index);
                             #inner_update_stream
                             #index
                         },
@@ -157,9 +157,8 @@ impl ConditionalWidget {
         };
 
         let w_name = &self.name;
-        stream.extend(quote_spanned! {
-            w_name.span() =>
-            let __current_page = #w_name.visible_child_name().map_or("".to_string(), |s| s.as_str().to_string());
+        stream.extend(quote! {
+            let current_page = #w_name.visible_child_name().map_or("".to_string(), |s| s.as_str().to_string());
             #w_name.set_visible_child_name(#brach_stream);
         });
     }
@@ -214,9 +213,8 @@ impl AssignProperty {
                 self.assign_stream(&mut info, p_name, false);
                 let model = paste_model.then(|| model_name);
                 let page_switch = conditional_branch.then(|| {
-                    quote_spanned! {
-                        p_name.span() =>
-                            !__page_active ||
+                    quote! {
+                        !page_active ||
                     }
                 });
 

--- a/relm4-macros/src/widgets/gen/util/if_branch.rs
+++ b/relm4-macros/src/widgets/gen/util/if_branch.rs
@@ -24,7 +24,7 @@ impl IfBranch {
         });
         stream.extend(quote! {
             {
-                let __page_active: bool = (__current_page == #index);
+                let page_active: bool = (current_page == #index);
                 #inner_update_tokens
                 #index
             }

--- a/relm4-macros/src/widgets/parse/conditional_widget.rs
+++ b/relm4-macros/src/widgets/parse/conditional_widget.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span as Span2, TokenStream as TokenStream2};
 use syn::parse::ParseStream;
 use syn::{Error, Expr, Ident, Path, Token};
 
@@ -54,7 +54,7 @@ impl ConditionalWidget {
         } else {
             parse_util::idents_to_snake_case(
                 [Ident::new("conditional_widget", input.span())].iter(),
-                input.span(),
+                Span2::call_site(),
             )
         };
 

--- a/relm4-macros/src/widgets/parse/conditional_widget.rs
+++ b/relm4-macros/src/widgets/parse/conditional_widget.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Span as Span2, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use syn::parse::ParseStream;
 use syn::{Error, Expr, Ident, Path, Token};
 
@@ -52,10 +52,7 @@ impl ConditionalWidget {
         } else if let Some(name) = attr_name {
             name
         } else {
-            parse_util::idents_to_snake_case(
-                [Ident::new("conditional_widget", input.span())].iter(),
-                Span2::call_site(),
-            )
+            parse_util::unique_ident_from_parts(["conditional_widget"])
         };
 
         if input.peek(Token![if]) {

--- a/relm4-macros/src/widgets/parse/if_branch.rs
+++ b/relm4-macros/src/widgets/parse/if_branch.rs
@@ -17,7 +17,7 @@ impl IfBranch {
         let args = args_from_index(index, input.span());
         let mut widget = Widget::parse(&braced, attributes, Some(args))?;
         widget.ref_token = Some(And {
-            spans: [Span2::call_site()],
+            spans: [Span2::mixed_site()],
         });
 
         Ok(Self { cond, widget })

--- a/relm4-macros/src/widgets/parse/returned_widget.rs
+++ b/relm4-macros/src/widgets/parse/returned_widget.rs
@@ -1,5 +1,4 @@
 use syn::parse::{Parse, ParseStream};
-use syn::spanned::Spanned;
 use syn::{braced, Ident, Result, Token};
 
 use crate::widgets::{parse_util, Properties, ReturnedWidget};
@@ -29,12 +28,7 @@ impl Parse for ReturnedWidget {
             (None, None)
         };
 
-        let name = name.unwrap_or_else(|| {
-            parse_util::idents_to_snake_case(
-                [Ident::new("_returned_widget", input.span())].iter(),
-                ty.span(),
-            )
-        });
+        let name = name.unwrap_or_else(|| parse_util::unique_ident_from_parts(["returned_widget"]));
 
         let inner;
         let _token = braced!(inner in input);

--- a/relm4-macros/src/widgets/parse_util.rs
+++ b/relm4-macros/src/widgets/parse_util.rs
@@ -58,7 +58,7 @@ impl WidgetFunc {
     pub(super) fn snake_case_name(&self) -> Ident {
         idents_to_snake_case(
             self.path.segments.iter().map(|seg| &seg.ident),
-            self.path.span(),
+            Span2::call_site(),
         )
     }
 }
@@ -86,8 +86,8 @@ impl PartialEq for AssignPropertyAttr {
 
 pub(crate) fn string_to_snake_case(string: &str) -> Ident {
     idents_to_snake_case(
-        [Ident::new(string, Span2::call_site())].iter(),
-        Span2::call_site(),
+        [Ident::new(string, Span2::mixed_site())].iter(),
+        Span2::mixed_site(),
     )
 }
 

--- a/relm4/src/binding/bindings.rs
+++ b/relm4/src/binding/bindings.rs
@@ -41,6 +41,7 @@ macro_rules! binding {
         }
 
         #[allow(missing_docs)]
+        #[allow(clippy::must_use_candidate)]
         mod $mod {
             use std::cell::RefCell;
 

--- a/relm4/src/binding/bindings.rs
+++ b/relm4/src/binding/bindings.rs
@@ -41,7 +41,6 @@ macro_rules! binding {
         }
 
         #[allow(missing_docs)]
-        #[allow(clippy::must_use_candidate)]
         mod $mod {
             use std::cell::RefCell;
 

--- a/relm4/src/factory/sync/collections/hashmap.rs
+++ b/relm4/src/factory/sync/collections/hashmap.rs
@@ -53,8 +53,8 @@ where
 /// A builder-pattern struct for building a [`FactoryHashMap`].
 pub struct FactoryHashMapBuilder<K, C: FactoryComponent, S = RandomState> {
     hasher: S,
-    _component: PhantomData<C>,
-    _key: PhantomData<K>,
+    component: PhantomData<C>,
+    key: PhantomData<K>,
 }
 
 impl<K, C> Default for FactoryHashMapBuilder<K, C>
@@ -87,28 +87,26 @@ where
     pub fn new() -> Self {
         Self {
             hasher: RandomState::default(),
-            _component: PhantomData,
-            _key: PhantomData,
+            component: PhantomData,
+            key: PhantomData,
         }
     }
 
     /// Sets a different hasher.
     pub fn hasher<H: Hasher>(self, hasher: H) -> FactoryHashMapBuilder<K, C, H> {
-        let Self {
-            _component, _key, ..
-        } = self;
+        let Self { component, key, .. } = self;
 
         FactoryHashMapBuilder {
             hasher,
-            _component,
-            _key,
+            component,
+            key,
         }
     }
 
     /// Launch the factory.
     /// This is similar to [`Connector::launch`](crate::component::ComponentBuilder::launch).
     pub fn launch(self, widget: C::ParentWidget) -> FactoryHashMapConnector<K, C> {
-        let Self { hasher, _key, .. } = self;
+        let Self { hasher, key, .. } = self;
 
         let (output_sender, output_receiver) = crate::channel();
 
@@ -117,7 +115,7 @@ where
             output_sender,
             output_receiver,
             hasher,
-            _key,
+            _key: key,
         }
     }
 }

--- a/relm4/src/factory/widgets/libadwaita.rs
+++ b/relm4/src/factory/widgets/libadwaita.rs
@@ -79,18 +79,18 @@ impl FactoryView for adw::PreferencesPage {
     fn factory_prepend(
         &self,
         widget: impl AsRef<Self::Children>,
-        _position: &(),
+        position: &(),
     ) -> Self::ReturnedWidget {
-        self.factory_append(widget, _position)
+        self.factory_append(widget, position)
     }
 
     fn factory_insert_after(
         &self,
         widget: impl AsRef<Self::Children>,
-        _position: &(),
+        position: &(),
         _other: &Self::ReturnedWidget,
     ) -> Self::ReturnedWidget {
-        self.factory_append(widget, _position)
+        self.factory_append(widget, position)
     }
 
     fn returned_widget_to_child(root_child: &Self::ReturnedWidget) -> Self::Children {

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -23,7 +23,8 @@
     unreachable_pub,
     unused_qualifications,
     clippy::cargo,
-    clippy::must_use_candidate
+    clippy::must_use_candidate,
+    clippy::used_underscore_binding
 )]
 #![allow(clippy::multiple_crate_versions)]
 // Configuration for doc builds on the nightly toolchain.


### PR DESCRIPTION
#### Summary

Fixes #532

@PJungkamp it seems like `mixed_site` would have been more correct in some cases, but it didn't cause the problem. The actual cause was that the span of the type (like `gtk::Box`) was used for the automatically generated ident (like `_gtk_box_1`), so it looked to clippy like it was added by the user. This behavior was initially added because I thought it might help with error reporting, but in the end it can only cause problems if the macro does something wrong.

Can you test if this fixes the problem for you?

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
