### PR TITLE
Add a `SimpleComboRow` helper for `adw::ComboRow`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ### Added
 
 + core: Add `AsyncComponentStream` to supports streams for async components as well
++ components: Add `SimpleComboRow` helper for libadwaita's `ComboRow`, analogous to `SimpleComboBox`
++ components: Add an example for `SimpleComboRow`
 
 ### Changed
 

--- a/relm4-components/Cargo.toml
+++ b/relm4-components/Cargo.toml
@@ -29,9 +29,10 @@ reqwest = { version = "0.11.18", optional = true }
 tracker = "0.2.1"
 
 [features]
-default = []
+default = ["libadwaita"]
 dox = ["web"]
 web = ["reqwest"]
+libadwaita = ["relm4/libadwaita"]
 
 [[example]]
 name = "web_image"

--- a/relm4-components/Cargo.toml
+++ b/relm4-components/Cargo.toml
@@ -37,3 +37,7 @@ libadwaita = ["relm4/libadwaita"]
 [[example]]
 name = "web_image"
 required-features = ["web"]
+
+[[example]]
+name = "adw_combo_row"
+required-features = ["libadwaita"]

--- a/relm4-components/examples/adw_combo_row.rs
+++ b/relm4-components/examples/adw_combo_row.rs
@@ -1,0 +1,87 @@
+use adw::prelude::*;
+use relm4::{
+    adw, gtk, Component, ComponentController, ComponentParts, ComponentSender, Controller, RelmApp,
+    SimpleComponent,
+};
+use relm4_components::simple_adw_combo_row::SimpleComboRow;
+
+#[derive(Debug)]
+enum AppMsg {
+    Selected(usize),
+}
+
+struct App {
+    combo_row: Controller<SimpleComboRow<&'static str>>,
+    selected_variant: usize,
+}
+
+#[relm4::component]
+impl SimpleComponent for App {
+    type Init = ();
+    type Input = AppMsg;
+    type Output = ();
+
+    view! {
+        #[name = "app"]
+        adw::Window {
+            set_default_size: (300, 100),
+            set_title: Some("Libadwaita SimpleComboRow"),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_vexpand: true,
+
+                #[name = "sidebar_header"]
+                adw::HeaderBar {
+                    #[wrap(Some)]
+                    set_title_widget = &adw::WindowTitle {
+                        set_title: "Libadwaita SimpleComboRow",
+                    },
+                    set_show_end_title_buttons: false,
+                },
+
+                adw::PreferencesGroup {
+                    #[local_ref]
+                    combo_row -> adw::ComboRow,
+                },
+
+                gtk::Text {
+                    #[watch]
+                    set_text: &format!("Variant {}", model.selected_variant + 1),
+                }
+            },
+        }
+    }
+
+    fn update(&mut self, msg: Self::Input, _: ComponentSender<Self>) {
+        match msg {
+            AppMsg::Selected(selected) => self.selected_variant = selected,
+        }
+    }
+
+    fn init(
+        _: Self::Init,
+        root: &Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = App {
+            combo_row: SimpleComboRow::builder()
+                .launch(SimpleComboRow {
+                    variants: vec!["Variant 1", "Variant 2"],
+                    active_index: None,
+                })
+                .forward(sender.input_sender(), AppMsg::Selected),
+            selected_variant: 0,
+        };
+
+        let combo_row = model.combo_row.widget();
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.adw_combo_box");
+    app.run::<App>(());
+}

--- a/relm4-components/src/lib.rs
+++ b/relm4-components/src/lib.rs
@@ -36,6 +36,8 @@ pub mod alert;
 pub mod open_button;
 pub mod open_dialog;
 pub mod save_dialog;
+#[cfg(feature = "libadwaita")]
+pub mod simple_adw_combo_row;
 pub mod simple_combo_box;
 
 #[cfg(feature = "web")]

--- a/relm4-components/src/simple_adw_combo_row.rs
+++ b/relm4-components/src/simple_adw_combo_row.rs
@@ -99,14 +99,12 @@ where
     E: ToString,
 {
     fn render(&self, combo_box: &adw::ComboRow) {
-        use std::ops::Deref;
         if combo_box.model().is_some() {
             unreachable!()
         }
 
-        let variants: Vec<String> = self.variants.iter().map(ToString::to_string).collect();
-        let variants: Vec<&str> = variants.iter().map(String::deref).collect();
-        combo_box.set_model(Some(&StringList::new(&variants)));
+        let model: StringList = self.variants.iter().map(ToString::to_string).collect();
+        combo_box.set_model(Some(&model));
 
         if let Some(idx) = self.active_index {
             combo_box.set_selected(idx as u32);

--- a/relm4-components/src/simple_adw_combo_row.rs
+++ b/relm4-components/src/simple_adw_combo_row.rs
@@ -1,0 +1,121 @@
+//! A wrapper around [`adw::ComboRow`] that makes it easier to use
+//! from regular Rust code.
+
+use std::fmt::Debug;
+
+use relm4::{adw, Component, ComponentParts, ComponentSender};
+
+use adw::gtk::StringList;
+use adw::prelude::ComboRowExt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// A simple wrapper around [`adw::ComboRow`].
+///
+/// This can be used with enums, [`String`]s or any custom type you want.
+/// The only requirement is that the inner type implements [`ToString`] and [`Debug`].
+///
+/// To get notified when the selection changed, you can use
+/// [`Connector::forward()`](relm4::component::Connector::forward())
+/// after launching the component.
+pub struct SimpleComboRow<E: ToString> {
+    /// The variants that can be selected.
+    pub variants: Vec<E>,
+    /// The index of the active element or [`None`] is nothing is selected.
+    pub active_index: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// The message type of [`SimpleComboRow`].
+pub enum SimpleComboRowMsg<E: ToString> {
+    /// Overwrite the current values.
+    UpdateData(SimpleComboRow<E>),
+    /// Set the index of the active element.
+    SetActiveIdx(usize),
+    #[doc(hidden)]
+    UpdateIndex(usize),
+}
+
+impl<E> Component for SimpleComboRow<E>
+where
+    E: ToString + 'static + Debug,
+{
+    type CommandOutput = ();
+    type Input = SimpleComboRowMsg<E>;
+    type Output = usize;
+    type Init = Self;
+    type Root = adw::ComboRow;
+    type Widgets = adw::ComboRow;
+
+    fn init_root() -> Self::Root {
+        adw::ComboRow::default()
+    }
+
+    fn init(
+        model: Self::Init,
+        root: &Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let widgets = root.clone();
+
+        model.render(&widgets);
+
+        widgets.connect_selected_notify(move |combo_box| {
+            sender.input(Self::Input::UpdateIndex(combo_box.selected() as _));
+        });
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update_with_view(
+        &mut self,
+        widgets: &mut Self::Widgets,
+        input: Self::Input,
+        sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match input {
+            SimpleComboRowMsg::UpdateIndex(idx) => {
+                // Ignore send errors because the component might
+                // be detached.
+                sender.output(idx).ok();
+                self.active_index = Some(idx);
+            }
+            SimpleComboRowMsg::SetActiveIdx(idx) => {
+                if idx < self.variants.len() {
+                    self.active_index = Some(idx);
+                    widgets.set_selected(idx as u32);
+                }
+            }
+            SimpleComboRowMsg::UpdateData(data) => {
+                *self = data;
+                self.render(widgets);
+            }
+        }
+    }
+}
+
+impl<E> SimpleComboRow<E>
+where
+    E: ToString,
+{
+    fn render(&self, combo_box: &adw::ComboRow) {
+        use std::ops::Deref;
+        if combo_box.model().is_some() {
+            unreachable!()
+        }
+
+        let variants: Vec<String> = self.variants.iter().map(ToString::to_string).collect();
+        let variants: Vec<&str> = variants.iter().map(String::deref).collect();
+        combo_box.set_model(Some(&StringList::new(&variants)));
+
+        if let Some(idx) = self.active_index {
+            combo_box.set_selected(idx as u32);
+        }
+    }
+
+    /// Return the value of the currently selected element or [`None`] if nothing is selected.
+    #[must_use]
+    pub fn get_active_elem(&self) -> Option<&E> {
+        self.active_index.map(|idx| &self.variants[idx])
+    }
+}

--- a/relm4-components/src/simple_adw_combo_row.rs
+++ b/relm4-components/src/simple_adw_combo_row.rs
@@ -99,10 +99,6 @@ where
     E: ToString,
 {
     fn render(&self, combo_box: &adw::ComboRow) {
-        if combo_box.model().is_some() {
-            unreachable!()
-        }
-
         let model: StringList = self.variants.iter().map(ToString::to_string).collect();
         combo_box.set_model(Some(&model));
 


### PR DESCRIPTION
#### Summary

This PR adds:

- A `SimpleComboRow` component, as an easy to use wrapper around `adw::ComboRow`, similar to the existing `SimpleComboBox`
- Examples for `SimpleComboBox` and `SimpleComboRow`

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md

The examples are a bit raw, I can make them a bit prettier if necessary.