### PR TITLE
Return Result from `FactorySender#output` method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
++ core: Return `Result` from `FactorySender#output` method (so that errors are not silently unwrapped)
+
 ## 0.7.0-beta.1 - 2023-9-23
 
 ### Added

--- a/relm4/src/channel/component.rs
+++ b/relm4/src/channel/component.rs
@@ -274,8 +274,11 @@ sender_impl!(FactorySender, FactoryComponent);
 
 impl<C: FactoryComponent> FactorySender<C> {
     /// Emit an output to the component.
-    pub fn output(&self, message: C::Output) {
-        self.shared.output(message).unwrap()
+    ///
+    /// Returns [`Err`] if all receivers were dropped,
+    /// for example by the `detach` method.
+    pub fn output(&self, message: C::Output) -> Result<(), C::Output> {
+        self.shared.output(message)
     }
 }
 


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Return the `Result` object from `FactorySender#output`, instead of silently unwrapping it. This allows app developers to handle the `Result` as they wish (rather than it crashing the app if no handler function is attached).

This brings the signature of this `output` method into line with the `ComponentSender` and `AsyncComponentSender`.

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
