### PR TITLE
Run cargo clippy check in a parallel CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,29 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+
+      - name: "test"
+        run: xvfb-run --auto-servernum cargo test
+
+      - uses: bcomnes/cleanup-xvfb@v1.0.9
+
+  clippy:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/relm4/relm4/docs:latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - "1.70.0"
+    env:
+      DISPLAY: ":99.0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
           components: clippy
 
       - name: "clippy all targets"
@@ -35,16 +58,11 @@ jobs:
       - name: "clippy all features"
         run: cargo clippy --features "all" -- --deny warnings
 
-      - name: "test"
-        run: xvfb-run --auto-servernum cargo test
-
-      - name: "check examples"
+      - name: "clippy check examples"
         run: cargo clippy --examples -- --deny warnings
-          
-      - name: "check libadwaita examples"
-        run: cd examples/libadwaita && cargo clippy --examples -- --deny warnings
 
-      - uses: bcomnes/cleanup-xvfb@v1.0.9
+      - name: "clippy check libadwaita examples"
+        run: cd examples/libadwaita && cargo clippy --examples -- --deny warnings
 
   fmt:
     name: rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,19 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/relm4/relm4/docs:latest
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - nightly
-          - "1.70.0"
     env:
         DISPLAY: ":99.0"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
 
       - name: "test"
         run: xvfb-run --auto-servernum cargo test


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Parallelize the `cargo clippy` check by running it in its own GH Actions job.

This will speed up the build, and also allow `cargo test` to execute even if Clippy fails, allowing us to see any test errors in addition to Clippy errors.

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
