### PR TITLE
Hotfix: make factory and grid_factory examples work again

### DIFF
--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -57,7 +57,7 @@ impl FactoryComponent for Counter {
             gtk::Button {
                 set_label: "Up",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::MoveUp(index.clone()))
+                    sender.output(CounterOutput::MoveUp(index.clone()));
                 }
             },
 
@@ -65,7 +65,7 @@ impl FactoryComponent for Counter {
             gtk::Button {
                 set_label: "Down",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::MoveDown(index.clone()))
+                    sender.output(CounterOutput::MoveDown(index.clone()));
                 }
             },
 
@@ -73,14 +73,14 @@ impl FactoryComponent for Counter {
             gtk::Button {
                 set_label: "To Start",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::SendFront(index.clone()))
+                    sender.output(CounterOutput::SendFront(index.clone()));
                 }
             },
 
             gtk::Button {
                 set_label: "Remove",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::Remove(index.clone()))
+                    sender.output(CounterOutput::Remove(index.clone()));
                 }
             }
         }

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -92,21 +92,21 @@ impl FactoryComponent for Counter {
                 gtk::Button {
                     set_label: "Up",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::MoveUp(index.clone()))
+                        sender.output(CounterOutput::MoveUp(index.clone()));
                     }
                 },
 
                 gtk::Button {
                     set_label: "Down",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::MoveDown(index.clone()))
+                        sender.output(CounterOutput::MoveDown(index.clone()));
                     }
                 },
 
                 gtk::Button {
                     set_label: "To Start",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::SendFront(index.clone()))
+                        sender.output(CounterOutput::SendFront(index.clone()));
                     }
                 }
             }

--- a/relm4-macros/src/lib.rs
+++ b/relm4-macros/src/lib.rs
@@ -263,7 +263,7 @@ pub fn component(attributes: TokenStream, input: TokenStream) -> TokenStream {
 ///             gtk::Button {
 ///                 set_label: "To start",
 ///                 connect_clicked[sender, index] => move |_| {
-///                     sender.output(CounterOutput::SendFront(index.clone()))
+///                     sender.output(CounterOutput::SendFront(index.clone()));
 ///                 }
 ///             }
 ///         }


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

I noticed a couple of the examples stopped compiling with the latest change in 828c940. This hotfix should make the build work again.

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
