### PR TITLE
Implement traits to make working with the new adwaita NavigationView easier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
++ core: Implement `RelmContainerExt` for libadwaita 1.4's `NavigationView`
++ core: Implement `RelmSetChildExt` for libadwaita 1.4's `NavigationPage`
+
 ### Changed
 
 + core: Return `Result` from `FactorySender#output` method (so that errors are not silently unwrapped)
@@ -12,8 +16,6 @@
 
 + core: Add `AsyncComponentStream` to supports streams for async components as well
 + core: Builder pattern for initializing factories similar to regular components
-+ core: Implement `RelmContainerExt` for libadwaita 1.4's `NavigationView`
-+ core: Implement `RelmSetChildExt` for libadwaita 1.4's `NavigationPage`
 + components: Add `SimpleComboRow` helper for libadwaita's `ComboRow`, analogous to `SimpleComboBox`
 + components: Add an example for `SimpleComboRow`
 + components: Add an example how to use `SimpleComboBox`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 + core: Add `AsyncComponentStream` to supports streams for async components as well
 + core: Builder pattern for initializing factories similar to regular components
++ core: Implement `RelmContainerExt` for libadwaita 1.4's `NavigationView`
++ core: Implement `RelmSetChildExt` for libadwaita 1.4's `NavigationPage`
 + components: Add `SimpleComboRow` helper for libadwaita's `ComboRow`, analogous to `SimpleComboBox`
 + components: Add an example for `SimpleComboRow`
 + components: Add an example how to use `SimpleComboBox`

--- a/relm4/src/extensions/container.rs
+++ b/relm4/src/extensions/container.rs
@@ -72,7 +72,12 @@ mod libadwaita {
     impl RelmContainerExt for adw::NavigationView {
         fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
             use gtk::prelude::Cast;
-            self.add(widget.as_ref().downcast_ref::<adw::NavigationPage>().expect("Not a adw::NavigationPage."));
+            self.add(
+                widget
+                    .as_ref()
+                    .downcast_ref::<adw::NavigationPage>()
+                    .expect("Not a adw::NavigationPage."),
+            );
         }
     }
 }

--- a/relm4/src/extensions/container.rs
+++ b/relm4/src/extensions/container.rs
@@ -67,4 +67,12 @@ mod libadwaita {
             self.add(widget.as_ref());
         }
     }
+
+    #[cfg(feature = "gnome_45")]
+    impl RelmContainerExt for adw::NavigationView {
+        fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
+            use gtk::prelude::Cast;
+            self.add(widget.as_ref().downcast_ref::<adw::NavigationPage>().expect("Not a adw::NavigationPage."));
+        }
+    }
 }

--- a/relm4/src/extensions/container.rs
+++ b/relm4/src/extensions/container.rs
@@ -68,7 +68,7 @@ mod libadwaita {
         }
     }
 
-    #[cfg(feature = "gnome_45")]
+    #[cfg(all(feature = "libadwaita", feature = "gnome_45"))]
     impl RelmContainerExt for adw::NavigationView {
         fn container_add(&self, widget: &impl AsRef<gtk::Widget>) {
             use gtk::prelude::Cast;

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -202,4 +202,7 @@ mod libadwaita {
         adw::ToastOverlay,
         adw::ExpanderRow
     }
+
+    #[cfg(feature = "gnome_45")]
+    container_child_impl! { adw::NavigationPage }
 }

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -203,6 +203,6 @@ mod libadwaita {
         adw::ExpanderRow
     }
 
-    #[cfg(feature = "gnome_45")]
+    #[cfg(all(feature = "libadwaita", feature = "gnome_45"))]
     container_child_impl! { adw::NavigationPage }
 }

--- a/relm4/src/extensions/set_child.rs
+++ b/relm4/src/extensions/set_child.rs
@@ -77,7 +77,7 @@ mod libadwaita {
         adw::ToastOverlay
     );
 
-    #[cfg(feature = "gnome_45")]
+    #[cfg(all(feature = "libadwaita", feature = "gnome_45"))]
     mod gnome_45 {
         use super::RelmSetChildExt;
         use adw::prelude::NavigationPageExt;

--- a/relm4/src/extensions/set_child.rs
+++ b/relm4/src/extensions/set_child.rs
@@ -76,4 +76,12 @@ mod libadwaita {
         adw::StatusPage,
         adw::ToastOverlay
     );
+
+    #[cfg(feature = "gnome_45")]
+    mod gnome_45 {
+        use super::RelmSetChildExt;
+        use adw::prelude::NavigationPageExt;
+
+        set_child_impl!(adw::NavigationPage);
+    }
 }


### PR DESCRIPTION
#### Summary

Implement Relm traits for `NavigationView` and `NavigationPage` introduced in libadwaita v1.4.
(I did not touch `NavigationSplitView`)

This doesn't close any issue, as far as I know, but makes working with the new widgets easier. I've almost opened an issue but decided to try to fix the problem myself instead. This is my first time working with this code base so please let me know if there are any issues. I tried out the changes in a small test application and didn't encounter any issues.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
