### PR TITLE
core: Add builder pattern for async factories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,19 @@
 
 ## Unreleased
 
+### Added
+
++ core: Add builder for initializing async factories
++ core: Add `launch_default()` method to factory builders for launching with default parent widget
+
 ### Changed
 
 + core: Return `Result` from `FactorySender#output` method (so that errors are not silently unwrapped)
++ core: Move parameters from `builder()` to `launch()` in factories for more consistency
+
+### Fixed
+
++ core: Properly re-export factory builder types and document them
 
 ## 0.7.0-beta.1 - 2023-9-23
 

--- a/examples/entry.rs
+++ b/examples/entry.rs
@@ -32,7 +32,7 @@ impl FactoryComponent for Counter {
             #[watch]
             set_label: &self.value.to_string(),
             connect_clicked[index] => move |_| {
-                sender.output(AppMsg::Clicked(index.clone()));
+                sender.output(AppMsg::Clicked(index.clone())).unwrap();
             },
         }
     }
@@ -81,8 +81,8 @@ impl SimpleComponent for App {
     ) -> ComponentParts<Self> {
         let factory_box = gtk::Box::default();
 
-        let counters = FactoryVecDeque::builder(factory_box.clone())
-            .launch()
+        let counters = FactoryVecDeque::builder()
+            .launch(factory_box.clone())
             .forward(sender.input_sender(), |output| output);
 
         let model = App {

--- a/examples/factory.rs
+++ b/examples/factory.rs
@@ -57,7 +57,7 @@ impl FactoryComponent for Counter {
             gtk::Button {
                 set_label: "Up",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::MoveUp(index.clone()));
+                    sender.output(CounterOutput::MoveUp(index.clone())).unwrap();
                 }
             },
 
@@ -65,7 +65,7 @@ impl FactoryComponent for Counter {
             gtk::Button {
                 set_label: "Down",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::MoveDown(index.clone()));
+                    sender.output(CounterOutput::MoveDown(index.clone())).unwrap();
                 }
             },
 
@@ -73,14 +73,14 @@ impl FactoryComponent for Counter {
             gtk::Button {
                 set_label: "To Start",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::SendFront(index.clone()));
+                    sender.output(CounterOutput::SendFront(index.clone())).unwrap();
                 }
             },
 
             gtk::Button {
                 set_label: "Remove",
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(CounterOutput::Remove(index.clone()));
+                    sender.output(CounterOutput::Remove(index.clone())).unwrap();
                 }
             }
         }
@@ -161,14 +161,15 @@ impl SimpleComponent for App {
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let counters = FactoryVecDeque::builder(gtk::Box::default())
-            .launch()
-            .forward(sender.input_sender(), |msg| match msg {
-                CounterOutput::SendFront(index) => AppMsg::SendFront(index),
-                CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),
-                CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
-                CounterOutput::Remove(index) => AppMsg::Remove(index),
-            });
+        let counters =
+            FactoryVecDeque::builder()
+                .launch_default()
+                .forward(sender.input_sender(), |msg| match msg {
+                    CounterOutput::SendFront(index) => AppMsg::SendFront(index),
+                    CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),
+                    CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
+                    CounterOutput::Remove(index) => AppMsg::Remove(index),
+                });
 
         let model = App {
             created_widgets: counter,

--- a/examples/factory_hash_map.rs
+++ b/examples/factory_hash_map.rs
@@ -146,9 +146,7 @@ impl SimpleComponent for App {
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let counters = FactoryHashMap::builder(gtk::Stack::default())
-            .launch()
-            .detach();
+        let counters = FactoryHashMap::builder().launch_default().detach();
 
         let model = App {
             created_widgets: counter,

--- a/examples/grid_factory.rs
+++ b/examples/grid_factory.rs
@@ -92,21 +92,21 @@ impl FactoryComponent for Counter {
                 gtk::Button {
                     set_label: "Up",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::MoveUp(index.clone()));
+                        sender.output(CounterOutput::MoveUp(index.clone())).unwrap();
                     }
                 },
 
                 gtk::Button {
                     set_label: "Down",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::MoveDown(index.clone()));
+                        sender.output(CounterOutput::MoveDown(index.clone())).unwrap();
                     }
                 },
 
                 gtk::Button {
                     set_label: "To Start",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::SendFront(index.clone()));
+                        sender.output(CounterOutput::SendFront(index.clone())).unwrap();
                     }
                 }
             }
@@ -186,13 +186,14 @@ impl SimpleComponent for App {
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let counters = FactoryVecDeque::builder(gtk::Grid::default())
-            .launch()
-            .forward(sender.input_sender(), |msg| match msg {
-                CounterOutput::SendFront(index) => AppMsg::SendFront(index),
-                CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),
-                CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
-            });
+        let counters =
+            FactoryVecDeque::builder()
+                .launch_default()
+                .forward(sender.input_sender(), |msg| match msg {
+                    CounterOutput::SendFront(index) => AppMsg::SendFront(index),
+                    CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),
+                    CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
+                });
 
         let model = App {
             created_widgets: counter,

--- a/examples/to_do.rs
+++ b/examples/to_do.rs
@@ -51,7 +51,7 @@ impl FactoryComponent for Task {
                 set_margin_all: 12,
 
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(TaskOutput::Delete(index.clone()));
+                    sender.output(TaskOutput::Delete(index.clone())).unwrap();
                 }
             }
         }
@@ -134,11 +134,12 @@ impl SimpleComponent for App {
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let tasks = FactoryVecDeque::builder(gtk::ListBox::default())
-            .launch()
-            .forward(sender.input_sender(), |output| match output {
-                TaskOutput::Delete(index) => AppMsg::DeleteEntry(index),
-            });
+        let tasks =
+            FactoryVecDeque::builder()
+                .launch_default()
+                .forward(sender.input_sender(), |output| match output {
+                    TaskOutput::Delete(index) => AppMsg::DeleteEntry(index),
+                });
 
         let model = App { tasks };
 

--- a/relm4-components/src/open_button/factory.rs
+++ b/relm4-components/src/open_button/factory.rs
@@ -25,7 +25,7 @@ impl FactoryComponent for FileListItem {
                 set_label: self.path.iter().last().expect("Empty path").to_str().unwrap(),
                 set_margin_all: 0,
                 connect_clicked[sender, index] => move |_| {
-                    sender.output(OpenButtonMsg::OpenRecent(index.clone()));
+                    sender.output(OpenButtonMsg::OpenRecent(index.clone())).unwrap();
                 }
             }
         }

--- a/relm4-components/src/open_button/mod.rs
+++ b/relm4-components/src/open_button/mod.rs
@@ -174,8 +174,8 @@ impl SimpleComponent for OpenButton {
         let widgets = view_output!();
 
         if let Some(filename) = model.config.recently_opened_files {
-            let mut factory = FactoryVecDeque::builder(widgets.recent_files_list.clone())
-                .launch()
+            let mut factory = FactoryVecDeque::builder()
+                .launch(widgets.recent_files_list.clone())
                 .forward(sender.input_sender(), |msg| msg);
 
             if let Ok(entries) = fs::read_to_string(filename) {

--- a/relm4/src/binding/mod.rs
+++ b/relm4/src/binding/mod.rs
@@ -8,7 +8,7 @@
 //! In any case, the primary property type are always documented.
 //!
 //! To find out which widgets are currently supported and which property is considered as primary,
-//! please look at the list implementors for [`ConnectBinding`].
+//! please look at the list implementers for [`ConnectBinding`].
 //! Contributions to add support for more widgets are always welcome.
 
 mod bindings;

--- a/relm4/src/channel/component.rs
+++ b/relm4/src/channel/component.rs
@@ -186,6 +186,16 @@ macro_rules! sender_impl {
                 self.shared.input(message);
             }
 
+            /// Emit an output to the component.
+            ///
+            /// Returns [`Err`] if all receivers were dropped,
+            /// for example by [`detach`].
+            ///
+            /// [`detach`]: crate::component::Connector::detach
+            pub fn output(&self, message: C::Output) -> Result<(), C::Output> {
+                self.shared.output(message)
+            }
+
             /// Spawns an asynchronous command.
             /// You can bind the the command to the lifetime of the component
             /// by using a [`ShutdownReceiver`].
@@ -243,50 +253,6 @@ macro_rules! sender_impl {
 }
 
 sender_impl!(ComponentSender, Component);
-
-impl<C: Component> ComponentSender<C> {
-    /// Emit an output to the component.
-    ///
-    /// Returns [`Err`] if all receivers were dropped,
-    /// for example by [`detach`].
-    ///
-    /// [`detach`]: crate::component::Connector::detach
-    pub fn output(&self, message: C::Output) -> Result<(), C::Output> {
-        self.shared.output(message)
-    }
-}
-
 sender_impl!(AsyncComponentSender, AsyncComponent);
-
-impl<C: AsyncComponent> AsyncComponentSender<C> {
-    /// Emit an output to the component.
-    ///
-    /// Returns [`Err`] if all receivers were dropped,
-    /// for example by [`detach`].
-    ///
-    /// [`detach`]: crate::component::AsyncConnector::detach
-    pub fn output(&self, message: C::Output) -> Result<(), C::Output> {
-        self.shared.output(message)
-    }
-}
-
 sender_impl!(FactorySender, FactoryComponent);
-
-impl<C: FactoryComponent> FactorySender<C> {
-    /// Emit an output to the component.
-    ///
-    /// Returns [`Err`] if all receivers were dropped,
-    /// for example by the `detach` method.
-    pub fn output(&self, message: C::Output) -> Result<(), C::Output> {
-        self.shared.output(message)
-    }
-}
-
 sender_impl!(AsyncFactorySender, AsyncFactoryComponent);
-
-impl<C: AsyncFactoryComponent> AsyncFactorySender<C> {
-    /// Emit an output to the component.
-    pub fn output(&self, message: C::Output) {
-        self.shared.output(message).unwrap()
-    }
-}

--- a/relm4/src/component/async/connector.rs
+++ b/relm4/src/component/async/connector.rs
@@ -74,7 +74,7 @@ impl<C: AsyncComponent> AsyncConnector<C> {
         }
     }
 
-    /// Ignore outputs from the component and take the handle.
+    /// Ignore outputs from the component and finish the builder.
     pub fn detach(self) -> AsyncController<C> {
         let Self {
             widget,

--- a/relm4/src/component/sync/connector.rs
+++ b/relm4/src/component/sync/connector.rs
@@ -73,7 +73,7 @@ impl<C: Component> Connector<C> {
         }
     }
 
-    /// Ignore outputs from the component and take the handle.
+    /// Ignore outputs from the component and finish the builder.
     pub fn detach(self) -> Controller<C> {
         let Self {
             state,

--- a/relm4/src/component/worker.rs
+++ b/relm4/src/component/worker.rs
@@ -235,7 +235,7 @@ where
         }
     }
 
-    /// Ignore outputs from the component and take the handle.
+    /// Ignore outputs from the component and finish the builder.
     #[must_use]
     pub fn detach(self) -> WorkerController<W> {
         let Self {

--- a/relm4/src/factory/async/collections/mod.rs
+++ b/relm4/src/factory/async/collections/mod.rs
@@ -1,7 +1,10 @@
 //! Containers similar to [`std::collections`] that can be used to store factory data.
 
 mod vec_deque;
-pub use vec_deque::{AsyncFactoryVecDeque, AsyncFactoryVecDequeGuard};
+pub use vec_deque::{
+    AsyncFactoryVecDeque, AsyncFactoryVecDequeBuilder, AsyncFactoryVecDequeConnector,
+    AsyncFactoryVecDequeGuard,
+};
 
 use crate::factory::DynamicIndex;
 

--- a/relm4/src/factory/async/component_storage.rs
+++ b/relm4/src/factory/async/component_storage.rs
@@ -1,5 +1,4 @@
 use crate::factory::{DynamicIndex, FactoryView};
-use crate::Sender;
 
 use super::traits::AsyncFactoryComponent;
 use super::AsyncFactoryBuilder;
@@ -63,15 +62,9 @@ where
         self,
         index: &DynamicIndex,
         returned_widget: <C::ParentWidget as FactoryView>::ReturnedWidget,
-        parent_sender: &Sender<C::ParentInput>,
     ) -> Option<Self> {
         if let Self::Builder(builder) = self {
-            Some(Self::Final(builder.launch(
-                index,
-                returned_widget,
-                parent_sender,
-                C::forward_to_parent,
-            )))
+            Some(Self::Final(builder.launch(index, returned_widget)))
         } else {
             None
         }

--- a/relm4/src/factory/async/mod.rs
+++ b/relm4/src/factory/async/mod.rs
@@ -9,5 +9,8 @@ use builder::AsyncFactoryBuilder;
 use future_data::AsyncData;
 use handle::AsyncFactoryHandle;
 
-pub use collections::{AsyncFactoryVecDeque, AsyncFactoryVecDequeGuard};
+pub use collections::{
+    AsyncFactoryVecDeque, AsyncFactoryVecDequeBuilder, AsyncFactoryVecDequeConnector,
+    AsyncFactoryVecDequeGuard,
+};
 pub use traits::AsyncFactoryComponent;

--- a/relm4/src/factory/async/traits.rs
+++ b/relm4/src/factory/async/traits.rs
@@ -17,9 +17,6 @@ pub trait AsyncFactoryComponent:
     /// Container widget to which all widgets of the factory will be added.
     type ParentWidget: FactoryView + 'static;
 
-    /// Input messages sent to the parent component.
-    type ParentInput: Debug + 'static;
-
     /// Messages which are received from commands executing in the background.
     type CommandOutput: Debug + Send + 'static;
 
@@ -67,15 +64,6 @@ pub trait AsyncFactoryComponent:
         returned_widget: &<Self::ParentWidget as FactoryView>::ReturnedWidget,
         sender: AsyncFactorySender<Self>,
     ) -> Self::Widgets;
-
-    /// Optionally convert an output message from this component to an input message for the
-    /// parent component. By default this method does nothing, you must overwrite it to
-    /// forward messages.
-    ///
-    /// If [`None`] is returned, nothing is forwarded.
-    fn forward_to_parent(_output: Self::Output) -> Option<Self::ParentInput> {
-        None
-    }
 
     /// Processes inputs received by the component.
     #[allow(unused)]

--- a/relm4/src/factory/mod.rs
+++ b/relm4/src/factory/mod.rs
@@ -15,9 +15,13 @@ mod sync;
 mod data_guard;
 use data_guard::DataGuard;
 
-pub use r#async::{AsyncFactoryComponent, AsyncFactoryVecDeque, AsyncFactoryVecDequeGuard};
+pub use r#async::{
+    AsyncFactoryComponent, AsyncFactoryVecDeque, AsyncFactoryVecDequeBuilder,
+    AsyncFactoryVecDequeConnector, AsyncFactoryVecDequeGuard,
+};
 pub use sync::{
-    CloneableFactoryComponent, FactoryComponent, FactoryHashMap, FactoryVecDeque,
+    CloneableFactoryComponent, FactoryComponent, FactoryHashMap, FactoryHashMapBuilder,
+    FactoryHashMapConnector, FactoryVecDeque, FactoryVecDequeBuilder, FactoryVecDequeConnector,
     FactoryVecDequeGuard,
 };
 

--- a/relm4/src/factory/sync/collections/mod.rs
+++ b/relm4/src/factory/sync/collections/mod.rs
@@ -3,8 +3,10 @@
 mod hashmap;
 mod vec_deque;
 
-pub use hashmap::FactoryHashMap;
-pub use vec_deque::{FactoryVecDeque, FactoryVecDequeGuard};
+pub use hashmap::{FactoryHashMap, FactoryHashMapBuilder, FactoryHashMapConnector};
+pub use vec_deque::{
+    FactoryVecDeque, FactoryVecDequeBuilder, FactoryVecDequeConnector, FactoryVecDequeGuard,
+};
 
 use crate::factory::DynamicIndex;
 

--- a/relm4/src/factory/sync/mod.rs
+++ b/relm4/src/factory/sync/mod.rs
@@ -7,5 +7,8 @@ mod traits;
 use builder::FactoryBuilder;
 use handle::FactoryHandle;
 
-pub use collections::{FactoryHashMap, FactoryVecDeque, FactoryVecDequeGuard};
+pub use collections::{
+    FactoryHashMap, FactoryHashMapBuilder, FactoryHashMapConnector, FactoryVecDeque,
+    FactoryVecDequeBuilder, FactoryVecDequeConnector, FactoryVecDequeGuard,
+};
 pub use traits::{CloneableFactoryComponent, FactoryComponent};

--- a/relm4/src/runtime_util.rs
+++ b/relm4/src/runtime_util.rs
@@ -78,7 +78,7 @@ impl<Output, Command> RuntimeSenders<Output, Command> {
         // Notifies the component's child commands that it is being shut down.
         let (shutdown_notifier, shutdown_recipient) = shutdown::channel();
 
-        // Cannel to tell the component to shutdown.
+        // Channel to tell the component to shutdown.
         // Use a capacity of 2 to prevent blocking when the runtime is dropped while app shutdown is running as well.
         // This rare case will emit 2 messages (but certainly not more).
         let (shutdown_event_sender, shutdown_event_receiver) = mpsc::channel(2);


### PR DESCRIPTION
#### Summary

[See changelog](https://github.com/Relm4/Relm4/compare/async-factory-builder?expand=1#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2) + some minor cleanups

I think using `::builder().launch(arg)` is more natural then `::builder(arg).launch()`.

@chriskilding if you have time, can you have a look over the changes?

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
