### PR TITLE
fixes for adw::TabView examples

### DIFF
--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -60,21 +60,21 @@ impl FactoryComponent for Counter {
                 gtk::Button {
                     set_label: "Up",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::MoveUp(index.clone()))
+                        sender.output(CounterOutput::MoveUp(index.clone())).unwrap()
                     }
                 },
 
                 gtk::Button {
                     set_label: "Down",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::MoveDown(index.clone()))
+                        sender.output(CounterOutput::MoveDown(index.clone())).unwrap()
                     }
                 },
 
                 gtk::Button {
                     set_label: "To Start",
                     connect_clicked[sender, index] => move |_| {
-                        sender.output(CounterOutput::SendFront(index.clone()))
+                        sender.output(CounterOutput::SendFront(index.clone())).unwrap()
                     }
                 }
             }
@@ -160,8 +160,8 @@ impl SimpleComponent for App {
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let counters = FactoryVecDeque::builder(adw::TabView::default())
-            .launch()
+        let counters = FactoryVecDeque::builder()
+            .launch(adw::TabView::default())
             .forward(sender.input_sender(), |output| {
                 match output {
                     CounterOutput::SendFront(index) => AppMsg::SendFront(index),

--- a/examples/libadwaita/tab_factory.rs
+++ b/examples/libadwaita/tab_factory.rs
@@ -162,12 +162,10 @@ impl SimpleComponent for App {
     ) -> ComponentParts<Self> {
         let counters = FactoryVecDeque::builder()
             .launch(adw::TabView::default())
-            .forward(sender.input_sender(), |output| {
-                match output {
-                    CounterOutput::SendFront(index) => AppMsg::SendFront(index),
-                    CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),
-                    CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
-                }
+            .forward(sender.input_sender(), |output| match output {
+                CounterOutput::SendFront(index) => AppMsg::SendFront(index),
+                CounterOutput::MoveUp(index) => AppMsg::MoveUp(index),
+                CounterOutput::MoveDown(index) => AppMsg::MoveDown(index),
             });
         let model = App {
             created_widgets: counter,

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -222,11 +222,9 @@ impl Component for App {
     ) -> ComponentParts<Self> {
         let counters = FactoryVecDeque::builder()
             .launch(adw::TabView::default())
-            .forward(sender.input_sender(), |output| {
-                match output {
-                    CounterOutput::StartGame(index) => AppMsg::StartGame(index),
-                    CounterOutput::SelectedGuess(guess) => AppMsg::SelectedGuess(guess),
-                }
+            .forward(sender.input_sender(), |output| match output {
+                CounterOutput::StartGame(index) => AppMsg::StartGame(index),
+                CounterOutput::SelectedGuess(guess) => AppMsg::SelectedGuess(guess),
             });
 
         let mut model = App {

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -86,7 +86,7 @@ impl FactoryComponent for GamePage {
                             gtk::Button {
                                 set_label: "Start!",
                                 connect_clicked[sender, index] => move |_| {
-                                    sender.output(CounterOutput::StartGame(index.clone()));
+                                    sender.output(CounterOutput::StartGame(index.clone())).unwrap()
                                 }
                             },
                         }
@@ -97,7 +97,7 @@ impl FactoryComponent for GamePage {
                             set_valign: gtk::Align::Center,
 
                             connect_clicked[sender, index] => move |_| {
-                                sender.output(CounterOutput::SelectedGuess(index.clone()));
+                                sender.output(CounterOutput::SelectedGuess(index.clone())).unwrap()
                             }
                         }
                     }

--- a/examples/libadwaita/tab_game.rs
+++ b/examples/libadwaita/tab_game.rs
@@ -220,8 +220,8 @@ impl Component for App {
         root: &Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let counters = FactoryVecDeque::builder(adw::TabView::default())
-            .launch()
+        let counters = FactoryVecDeque::builder()
+            .launch(adw::TabView::default())
             .forward(sender.input_sender(), |output| {
                 match output {
                     CounterOutput::StartGame(index) => AppMsg::StartGame(index),


### PR DESCRIPTION
#### Summary

Updates the libadwaita examples (specificially `tab_factory` and `tab_game`) to fix compiler errors.

Previously, the aforementioned libadwaita examples failed to compile, this fix allows the examples to work.

#### Checklist

- [ ✓ ] cargo fmt
- [ ✓ ] cargo clippy
- [ ✓ ] cargo test
- [ ✓ ] updated CHANGES.md
