### PR TITLE
Add adw::Toast example

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
++ examples: Add libadwaita `Toast` example
+
 ## 0.7.0-beta.2 - 2023-10-14
 
 ### Added

--- a/examples/libadwaita/Cargo.toml
+++ b/examples/libadwaita/Cargo.toml
@@ -20,3 +20,8 @@ path = "tab_factory.rs"
 [[example]]
 name = "tab_game"
 path = "tab_game.rs"
+
+[[example]]
+name = "toast"
+path = "toast.rs"
+required-features = ["relm4/gnome_43"]

--- a/examples/libadwaita/toast.rs
+++ b/examples/libadwaita/toast.rs
@@ -1,0 +1,109 @@
+use gtk::prelude::*;
+use relm4::prelude::*;
+use std::cell::Cell;
+
+struct App {
+    activated: &'static str,
+    toast: Cell<Option<adw::Toast>>,
+}
+
+#[derive(Debug)]
+enum Msg {
+    Activate,
+    Cancel,
+}
+
+#[relm4::component]
+impl SimpleComponent for App {
+    type Init = ();
+    type Input = Msg;
+    type Output = ();
+
+    view! {
+        adw::Window {
+            set_title: Some("Simple app"),
+            set_default_size: (300, 200),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+
+                adw::HeaderBar {
+                    #[wrap(Some)]
+                    set_title_widget = &adw::WindowTitle {
+                        set_title: "Toast",
+                    }
+                },
+
+                #[name = "toast_overlay"]
+                adw::ToastOverlay {
+                    set_vexpand: true,
+                    gtk::Box {
+                        set_orientation: gtk::Orientation::Vertical,
+                        set_spacing: 5,
+                        set_margin_all: 5,
+                        set_valign: gtk::Align::Center,
+
+                        gtk::Button {
+                            set_hexpand: false,
+                            set_vexpand: false,
+                            set_label: "Activate",
+                            connect_clicked => Msg::Activate,
+                        },
+                        gtk::Button {
+                            set_hexpand: false,
+                            set_vexpand: false,
+                            set_label: "Cancel",
+                            connect_clicked => Msg::Cancel,
+                        },
+                        gtk::Text {
+                            #[watch]
+                            set_text: model.activated,
+                        },
+                    },
+
+                    #[watch]
+                    add_toast?: model.toast.take(),
+                }
+            }
+
+        }
+    }
+
+    // Initialize the component.
+    fn init(
+        _: Self::Init,
+        root: &Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = App {
+            activated: "Idle",
+            toast: Cell::new(None),
+        };
+        // Insert the code generation of the view! macro here
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>) {
+        match msg {
+            Msg::Activate => {
+                self.activated = "Active";
+                let toast = adw::Toast::new("Activated");
+                toast.set_button_label(Some("Cancel"));
+                toast.set_timeout(0);
+                toast.connect_button_clicked(move |this| {
+                    this.dismiss();
+                    sender.input(Msg::Cancel);
+                });
+                self.toast.set(Some(toast));
+            }
+            Msg::Cancel => self.activated = "Idle",
+        }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.toast");
+    app.run::<App>(());
+}


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

This PR adds an example for using an `adw::Toast`.

The current example looks pretty bad since I'm just figuring it out (which is why I wished there was already such an example and want to add my own). This PR is a much a PR to improve the examples as it is me asking for help to figure it out.

#### To solve

- [x] I couldn't find a way to make the button work without having to create the `ActionGroup`. Is that really necessary? It feels really weird as an API and I don't understand what it brings (I am not at all familiar with `gio` and `Gtk` overall).
- [x] I don't understand how to access the `toast_overlay` from the `update` method. By naming it I can get it from the widgets, but I don't see how to get the widgets from `update`, so I instead put it in the model, but that again feels out of place (plus it's weird since the model needs to be created before the widgets).

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
