### PR TITLE
Move internal initialization to startup signal handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
++ core: Move internal inititalization to `gtk::Application::startup` signal handler
 + examples: Add libadwaita `Toast` example
 
 ## 0.7.0-beta.2 - 2023-10-14
@@ -34,7 +35,7 @@
 
 ### Changed
 
-+ core: Add `Init` type to the `WidgetTemplate` trait to allow passing data to `init()` 
++ core: Add `Init` type to the `WidgetTemplate` trait to allow passing data to `init()`
 + core: Just require `AsRef<gtk::Window>` in `RelmApp::run`
 + core: Add `AsRef<Root>` as requirement to the `WidgetTemplate` trait
 + core: Removed `forward_to_parent` from `FactoryComponent`
@@ -87,7 +88,7 @@
 
 ### Added
 
-+ core: Implemented `RelmRemoveExt` for `adw::ExpanderRow`. 
++ core: Implemented `RelmRemoveExt` for `adw::ExpanderRow`.
 + core: Implemented `ContainerChild` for `adw::ExpanderRow`.
 + core: Add `TypedListView` as idiomatic wrapper over `gtk::ListView`
 
@@ -106,9 +107,9 @@
 + core: Documentation and better support for data bindings
 + core: Add `set_tooltip` method to `RelmWidgetExt`
 + core: Add `main_adw_application` method to retrieve the `adw::Application` when the libadwaita feature is enabled
-+ macros: Add `skip_init` option for watch and track attributes to skip their initialization 
++ macros: Add `skip_init` option for watch and track attributes to skip their initialization
 + examples: Introduce setting and action safeties
-+ examples: Example for using relm4-icons 
++ examples: Example for using relm4-icons
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-+ core: Move internal inititalization to `gtk::Application::startup` signal handler
++ core: Move internal initialization to `gtk::Application::startup` signal handler
 + examples: Add libadwaita `Toast` example
 
 ## 0.7.0-beta.2 - 2023-10-14

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -75,13 +75,8 @@ impl<M: Debug + 'static> RelmApp<M> {
 
         let payload = Cell::new(Some(payload));
 
-        app.connect_activate(move |app| {
+        app.connect_startup(move |app| {
             if let Some(payload) = payload.take() {
-                assert!(
-                    app.is_registered(),
-                    "App should be already registered when activated"
-                );
-
                 let builder = ComponentBuilder::<C>::default();
                 let connector = match broker {
                     Some(broker) => builder.launch_with_broker(payload, broker),
@@ -96,8 +91,12 @@ impl<M: Debug + 'static> RelmApp<M> {
 
                 controller.detach_runtime();
 
-                let window = window.as_ref();
-                app.add_window(window);
+                app.add_window(window.as_ref());
+            }
+        });
+
+        app.connect_activate(move |app| {
+            if let Some(window) = app.active_window() {
                 window.set_visible(true);
             }
         });
@@ -137,13 +136,8 @@ impl<M: Debug + 'static> RelmApp<M> {
 
         let payload = Cell::new(Some(payload));
 
-        app.connect_activate(move |app| {
+        app.connect_startup(move |app| {
             if let Some(payload) = payload.take() {
-                assert!(
-                    app.is_registered(),
-                    "App should be already registered when activated"
-                );
-
                 let builder = AsyncComponentBuilder::<C>::default();
                 let connector = match broker {
                     Some(broker) => builder.launch_with_broker(payload, broker),
@@ -158,8 +152,12 @@ impl<M: Debug + 'static> RelmApp<M> {
 
                 controller.detach_runtime();
 
-                let window = window.as_ref();
-                app.add_window(window);
+                app.add_window(window.as_ref());
+            }
+        });
+
+        app.connect_activate(move |app| {
+            if let Some(window) = app.active_window() {
                 window.set_visible(true);
             }
         });


### PR DESCRIPTION
#### Summary

Currently `RelmApp` does full components initialization in `gtk::Application::activate` signal handler. This is problematic for apps that needs to be able to run in the background, because they use `activate` signal to switch back to foreground. This PR moves the initialization to `startup` signal handler, and uses `activate` signal only for setting the main window visible.

This shouldn't change the behavior of any existing apps unless they used `gtk::Application::connect_startup` directly.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
