### PR TITLE
Increase flexibility of `Alert` component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 + core: Move internal initialization to `gtk::Application::startup` signal handler
 + core: Remove deprecated RelmApp methods
++ components: Increase flexibility of `Alert` component
 
 ### Fixed
 

--- a/relm4-components/examples/alert.rs
+++ b/relm4-components/examples/alert.rs
@@ -108,8 +108,8 @@ impl SimpleComponent for App {
                 .launch(AlertSettings {
                     text: String::from("Do you want to quit without saving? (First alert)"),
                     secondary_text: Some(String::from("Your counter hasn't reached 42 yet")),
-                    confirm_label: String::from("Close without saving"),
-                    cancel_label: String::from("Cancel"),
+                    confirm_label: Some(String::from("Close without saving")),
+                    cancel_label: Some(String::from("Cancel")),
                     option_label: Some(String::from("Save")),
                     is_modal: true,
                     destructive_accept: true,
@@ -120,8 +120,8 @@ impl SimpleComponent for App {
                 .launch(AlertSettings {
                     text: String::from("Do you want to quit without saving? (Second alert)"),
                     secondary_text: Some(String::from("Your counter hasn't reached 42 yet")),
-                    confirm_label: String::from("Close without saving"),
-                    cancel_label: String::from("Cancel"),
+                    confirm_label: Some(String::from("Close without saving")),
+                    cancel_label: Some(String::from("Cancel")),
                     option_label: Some(String::from("Save")),
                     is_modal: true,
                     destructive_accept: true,


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary
The `Alert` component from `relm4_components` previously didn't have the flexibility I needed for certain uses cases (as discussed in #575). This PR adds those changes.

I also added a `Default` implementation to aid in quickly creating new instances of `Alert` when a ton of configuration isn't desired (i.e. a title and single button, and then `..Default::default()` can be called instead of specifying everything else manually). I added documentation on how the `Default` implementation behaves as I currently don't have it using the `Default` values for all the struct's fields.

As part of my testing I also noticed that hitting the `Esc` key while an `Alert` dialog is open will make it unable to be shown again. I'm not sure what the best approach to fixing that is, but I thought I'd mention it (I can make an issue if it should be tackled outside of this PR).

I also wasn't able to add the extra custom widget functionality mentioned in #575, as there wasn't a clean way to do it while still preserving the ability to modify the struct's settings. `adw::MessageDialog` has some utilities to do such, but that would make the widget require libadwaita and I wasn't sure if y'all wanted that (I would definitely prefer it, any thoughts?).

Closes #575.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
