### PR TITLE
core: Improve late init callbacks after startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 
 + core: Report the correct dimensions in DrawingHandler when a scaling factor is set
 + core: Setting the visibility of the main window isn't overridden by `RelmApp` anymore
++ core: Fix timing of `transient_for()` when called after app init
 
 ## 0.7.0-beta.2 - 2023-10-14
 


### PR DESCRIPTION
#### Summary

Should fix #584

@nazar-pc can you try this branch? I'm not entirely sure whether this fixes your specific issue, but this change should be good in general.

With this PR, the following order of operations should start working:

1. Build a component
2. Call `transient_for` with a widget that is not connected yet
4. Add the widget to a window (or any other widget somehow connected to a window)
5. Return (from `init`, `update` or similar)

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
