### PR TITLE
Column resize/expand functionality

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Added
 
++ core: Add resizeable/expandable column functionality to `RelmColumn` and `LabelColum`
 + core: Add `visible_on_activate()` to `RelmApp` to prevent the app window from being visible immediately
 + core: Make `into_stream()` method on `Receiver` public
 + examples: Add libadwaita `Toast` example

--- a/examples/typed_column_view.rs
+++ b/examples/typed_column_view.rs
@@ -33,6 +33,7 @@ impl LabelColumn for Label1Column {
     const COLUMN_NAME: &'static str = "label";
 
     const ENABLE_SORT: bool = true;
+    const ENABLE_RESIZE: bool = true;
 
     fn get_cell_value(item: &Self::Item) -> Self::Value {
         item.value
@@ -73,6 +74,7 @@ impl RelmColumn for ButtonColumn {
     type Item = MyListItem;
 
     const COLUMN_NAME: &'static str = "button";
+    const ENABLE_EXPAND: bool = true;
 
     fn setup(_item: &gtk::ListItem) -> (Self::Root, Self::Widgets) {
         (gtk::CheckButton::new(), ())

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -26,6 +26,10 @@ pub trait RelmColumn: Any {
 
     /// The columns created for this list item.
     const COLUMN_NAME: &'static str;
+    /// Whether to enable resizing for this column
+    const ENABLE_RESIZE: bool = false;
+    /// Whether to enable automatic expanding for this column
+    const ENABLE_EXPAND: bool = false;
 
     /// Construct the widgets.
     fn setup(list_item: &gtk::ListItem) -> (Self::Root, Self::Widgets);
@@ -57,6 +61,10 @@ pub trait LabelColumn: 'static {
     const COLUMN_NAME: &'static str;
     /// Whether to enable the sorting for this column
     const ENABLE_SORT: bool;
+    /// Whether to enable resizing for this column
+    const ENABLE_RESIZE: bool = false;
+    /// Whether to enable automatic expanding for this column
+    const ENABLE_EXPAND: bool = false;
 
     /// Get the value that this column represents.
     fn get_cell_value(item: &Self::Item) -> Self::Value;
@@ -75,6 +83,8 @@ where
     type Item = C::Item;
 
     const COLUMN_NAME: &'static str = C::COLUMN_NAME;
+    const ENABLE_RESIZE: bool = C::ENABLE_RESIZE;
+    const ENABLE_EXPAND: bool = C::ENABLE_EXPAND;
 
     fn setup(_: &gtk::ListItem) -> (Self::Root, Self::Widgets) {
         (gtk::Label::new(None), ())
@@ -238,6 +248,9 @@ where
         let sort_fn = C::sort_fn();
 
         let c = gtk::ColumnViewColumn::new(Some(C::COLUMN_NAME), Some(factory));
+        c.set_resizable(C::ENABLE_RESIZE);
+        c.set_expand(C::ENABLE_EXPAND);
+        c.set_resizable(C::ENABLE_RESIZE);
 
         if let Some(sort_fn) = sort_fn {
             c.set_sorter(Some(&gtk::CustomSorter::new(move |first, second| {

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -250,7 +250,6 @@ where
         let c = gtk::ColumnViewColumn::new(Some(C::COLUMN_NAME), Some(factory));
         c.set_resizable(C::ENABLE_RESIZE);
         c.set_expand(C::ENABLE_EXPAND);
-        c.set_resizable(C::ENABLE_RESIZE);
 
         if let Some(sort_fn) = sort_fn {
             c.set_sorter(Some(&gtk::CustomSorter::new(move |first, second| {


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Adds `const bool`s to [`RelmColumn`](https://docs.rs/relm4/0.7.0-beta.2/relm4/typed_view/column/trait.RelmColumn.html) (and [`LabelColumn`](https://docs.rs/relm4/0.7.0-beta.2/relm4/typed_list_view/trait.LabelColumn.html)) that allow for setting the created columns to be resizeable, or to automatically expand.

Fixes #588 

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
