### PR TITLE
WIP: multiple application windows

### DIFF
--- a/examples/application.rs
+++ b/examples/application.rs
@@ -1,0 +1,150 @@
+use std::collections::VecDeque;
+
+use gtk::prelude::*;
+use relm4::*;
+use relm4::factory::FactoryVecDeque;
+use relm4::prelude::*;
+
+struct Window {
+    counter: u8,
+}
+
+#[derive(Debug)]
+enum WindowMsg {
+    Increment,
+    Decrement,
+}
+
+#[relm4::factory]
+impl FactoryComponent for Window {
+    type Init = u8;
+    type Input = WindowMsg;
+    type Output = ();
+    type CommandOutput = ();
+    type ParentWidget = gtk::Application;
+
+    view! {
+        #[root]
+        gtk::ApplicationWindow {
+            set_visible: true,
+            set_title: Some("Simple app"),
+            set_default_size: (300, 100),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_spacing: 5,
+                set_margin_all: 5,
+
+                gtk::Button {
+                    set_label: "Increment",
+                    connect_clicked => WindowMsg::Increment,
+                },
+
+                gtk::Button {
+                    set_label: "Decrement",
+                    connect_clicked => WindowMsg::Decrement,
+                },
+
+                gtk::Label {
+                    #[watch]
+                    set_label: &format!("Counter: {}", &self.counter),
+                    set_margin_all: 5,
+                }
+            }
+        }
+    }
+
+    // Initialize the component.
+    fn init_model(value: Self::Init, _index: &DynamicIndex, _sender: FactorySender<Self>) -> Self {
+        Self { counter: value }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: FactorySender<Self>) {
+        match msg {
+            WindowMsg::Increment => {
+                self.counter = self.counter.wrapping_add(1);
+            }
+            WindowMsg::Decrement => {
+                self.counter = self.counter.wrapping_sub(1);
+            }
+        }
+    }
+}
+
+
+struct App {
+    queued_windows: VecDeque<u8>,
+    windows: FactoryVecDeque<Window>,
+}
+
+#[derive(Debug)]
+enum AppMsg {
+    Activate(u8),
+    Startup,
+}
+
+impl SimpleComponent for App {
+    type Init = u8;
+    type Input = AppMsg;
+    type Output = ();
+    type Root = gtk::Application;
+    type Widgets = ();
+
+    fn init_root() -> Self::Root {
+        let app = main_application();
+        app
+    }
+
+    // Initialize the component.
+    fn init(
+        init: Self::Init,
+        root: &Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = App {
+            queued_windows: VecDeque::new(),
+            windows: FactoryVecDeque::builder()
+                .launch_default()
+                .detach()
+         };
+
+        let csender = sender.clone();
+        root.connect_activate(move |_app| {
+            println!("activate");
+            csender.input(AppMsg::Activate(init))
+        });
+
+        let csender = sender.clone();
+        root.connect_startup(move |_app|{
+            println!("startup {:?}", _app.application_id());
+
+            println!("Startup");
+            csender.input(AppMsg::Startup)
+        });
+
+        ComponentParts { model, widgets: () }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>) {
+        let mut windows_guard = self.windows.guard();
+
+        match msg {
+            AppMsg::Activate(init) => {
+                println!("Add window");
+                // self.queued_windows.push_back(init);
+                           windows_guard.push_back(init);
+
+            }
+            AppMsg::Startup => {
+                while let Some(init) = self.queued_windows.pop_front() {
+                    windows_guard.push_back(init);
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.application");
+    app.run_with_application::<App>(0);
+}

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -2,6 +2,7 @@ use gtk::glib;
 use gtk::prelude::{ApplicationExt, ApplicationExtManual, Cast, GtkApplicationExt, IsA, WidgetExt};
 use tokio::sync::oneshot;
 use std::fmt::Debug;
+use std::thread;
 
 use crate::component::{AsyncComponent, AsyncComponentBuilder, AsyncComponentController};
 use crate::runtime_util::shutdown_all;
@@ -130,12 +131,13 @@ impl<M: Debug + 'static> RelmApp<M> {
 
         let payload = Cell::new(Some(payload));
 
+
         app.connect_activate(move |_app| {
             println!("activate");
         });
 
         app.connect_startup(move |app| {
-            println!("startup {:?}", app.application_id());
+            println!("startup {:?} {:?}", app.application_id(), thread::current().id());
             if let Some(payload) = payload.take() {
                 let builder = ComponentBuilder::<C>::default();
                 println!("startup2 {:?}", app.application_id());
@@ -156,8 +158,9 @@ impl<M: Debug + 'static> RelmApp<M> {
 
         let _guard = RUNTIME.enter();
 
-        // prevent app from shutting down. Workaround until I can get the windows to register at the correct time
-        let _hold_guard = app.hold();
+        // TODO: prevent app from shutting down. Workaround until I can get the windows to register at the correct time
+        // this makes a new process hang
+        // let _hold_guard = app.hold();
         if let Some(args) = args {
             app.run_with_args(&args);
         } else {

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -1,14 +1,13 @@
 use gtk::glib;
 use gtk::prelude::{ApplicationExt, ApplicationExtManual, Cast, GtkApplicationExt, IsA, WidgetExt};
-use tokio::sync::oneshot;
 use std::fmt::Debug;
-use std::thread;
+use std::rc::Rc;
 
 use crate::component::{AsyncComponent, AsyncComponentBuilder, AsyncComponentController};
 use crate::runtime_util::shutdown_all;
 use crate::{Component, ComponentBuilder, ComponentController, MessageBroker, RUNTIME};
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 /// An app that runs the main application.
 #[derive(Debug)]
@@ -117,64 +116,6 @@ impl<M: Debug + 'static> RelmApp<M> {
     }
 
     /// Runs the application, returns once the application is closed.
-    pub fn run_with_application<C>(self, payload: C::Init)
-    where
-        C: Component<Input = M>,
-        C::Root: AsRef<gtk::Application>,
-    {
-        let Self {
-            app,
-            broker,
-            args,
-            ..
-        } = self;
-
-        let payload = Cell::new(Some(payload));
-
-
-        app.connect_activate(move |_app| {
-            println!("activate");
-        });
-
-        app.connect_startup(move |app| {
-            println!("startup {:?} {:?}", app.application_id(), thread::current().id());
-            if let Some(payload) = payload.take() {
-                let builder = ComponentBuilder::<C>::default();
-                println!("startup2 {:?}", app.application_id());
-
-                let connector = match broker {
-                    Some(broker) => builder.launch_with_broker(payload, broker),
-                    None => builder.launch(payload),
-                };
-
-                // Run late initialization for transient windows for example.
-                crate::late_initialization::run_late_init();
-
-                let mut controller = connector.detach();
-                controller.detach_runtime();
-            }
-        });
-
-
-        let _guard = RUNTIME.enter();
-
-        // TODO: prevent app from shutting down. Workaround until I can get the windows to register at the correct time
-        // this makes a new process hang
-        // let _hold_guard = app.hold();
-        if let Some(args) = args {
-            app.run_with_args(&args);
-        } else {
-            println!("run!");
-            app.run();
-        }
-
-        println!("shutdown");
-        // Make sure everything is shut down
-        shutdown_all();
-        glib::MainContext::ref_thread_default().iteration(true);
-    }
-
-    /// Runs the application, returns once the application is closed.
     pub fn run<C>(self, payload: C::Init)
     where
         C: Component<Input = M>,
@@ -230,6 +171,55 @@ impl<M: Debug + 'static> RelmApp<M> {
     }
 
     /// Runs the application, returns once the application is closed.
+    pub fn run_application<C>(self, payload: C::Init)
+    where
+        C: Component<Input = M>,
+        C::Root: AsRef<gtk::Application>,
+    {
+        let Self {
+            app,
+            broker,
+            args,
+            ..
+        } = self;
+
+        let hold_guard = Rc::new(RefCell::new(Some(app.hold())));
+        app.connect_window_added(move |_app, _window| {
+            hold_guard.borrow_mut().take();
+        });
+
+        let payload = Cell::new(Some(payload));
+        app.connect_startup(move |_app| {
+            if let Some(payload) = payload.take() {
+                let builder = ComponentBuilder::<C>::default();
+                let connector = match broker {
+                    Some(broker) => builder.launch_with_broker(payload, broker),
+                    None => builder.launch(payload),
+                };
+
+                // Run late initialization for transient windows for example.
+                crate::late_initialization::run_late_init();
+
+                let mut controller = connector.detach();
+                controller.detach_runtime();
+            }
+        });
+
+
+        let _guard = RUNTIME.enter();
+        if let Some(args) = args {
+            app.run_with_args(&args);
+        } else {
+            app.run();
+        }
+
+        // Make sure everything is shut down
+        shutdown_all();
+        glib::MainContext::ref_thread_default().iteration(true);
+    }
+
+
+    /// Runs the application, returns once the application is closed.
     pub fn run_async<C>(self, payload: C::Init)
     where
         C: AsyncComponent<Input = M>,
@@ -243,7 +233,6 @@ impl<M: Debug + 'static> RelmApp<M> {
         } = self;
 
         let payload = Cell::new(Some(payload));
-
         app.connect_startup(move |app| {
             if let Some(payload) = payload.take() {
                 let builder = AsyncComponentBuilder::<C>::default();
@@ -283,4 +272,54 @@ impl<M: Debug + 'static> RelmApp<M> {
         shutdown_all();
         glib::MainContext::ref_thread_default().iteration(true);
     }
+
+    /// Runs the application, returns once the application is closed.
+    pub fn run_application_async<C>(self, payload: C::Init)
+    where
+        C: AsyncComponent<Input = M>,
+        C::Root: AsRef<gtk::Application>,
+    {
+        let Self {
+            app,
+            broker,
+            args,
+            ..
+        } = self;
+
+        let hold_guard = Rc::new(RefCell::new(Some(app.hold())));
+        app.connect_window_added(move |_app, _window| {
+            hold_guard.borrow_mut().take();
+        });
+
+        let payload = Cell::new(Some(payload));
+        app.connect_startup(move |_app| {
+            if let Some(payload) = payload.take() {
+                let builder = AsyncComponentBuilder::<C>::default();
+                let connector = match broker {
+                    Some(broker) => builder.launch_with_broker(payload, broker),
+                    None => builder.launch(payload),
+                };
+
+                // Run late initialization for transient windows for example.
+                crate::late_initialization::run_late_init();
+
+                let mut controller = connector.detach();
+                controller.detach_runtime();
+            }
+        });
+
+
+        let _guard = RUNTIME.enter();
+        if let Some(args) = args {
+            app.run_with_args(&args);
+        } else {
+            app.run();
+        }
+
+
+        // Make sure everything is shut down
+        shutdown_all();
+        glib::MainContext::ref_thread_default().iteration(true);
+    }
+
 }

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -181,7 +181,8 @@ container_child_impl! {
 
 container_child_impl! {
     gtk::ListBox: gtk::ListBoxRow,
-    gtk::FlowBox: gtk::FlowBoxChild
+    gtk::FlowBox: gtk::FlowBoxChild,
+    gtk::Application: gtk::Window
 }
 
 #[cfg(feature = "libadwaita")]
@@ -201,6 +202,10 @@ mod libadwaita {
         adw::PreferencesGroup,
         adw::ToastOverlay,
         adw::ExpanderRow
+    }
+
+    container_child_impl! {
+        adw::Application: gtk::Window
     }
 
     #[cfg(all(feature = "libadwaita", feature = "gnome_45"))]

--- a/relm4/src/factory/widgets/gtk.rs
+++ b/relm4/src/factory/widgets/gtk.rs
@@ -1,4 +1,4 @@
-use gtk::prelude::{BoxExt, Cast, FlowBoxChildExt, GridExt, ListBoxRowExt, WidgetExt};
+use gtk::prelude::{BoxExt, Cast, FlowBoxChildExt, GridExt, ListBoxRowExt, WidgetExt, GtkApplicationExt};
 
 use crate::factory::{positions, FactoryView};
 
@@ -293,6 +293,54 @@ impl FactoryView for gtk::FlowBox {
         returned_widget
             .child()
             .unwrap_or_else(|| returned_widget.upcast_ref::<gtk::Widget>().clone())
+    }
+}
+
+impl FactoryView for gtk::Application {
+    type Children = gtk::Window;
+    type ReturnedWidget = gtk::Window;
+    type Position = ();
+
+    fn factory_remove(&self, widget: &Self::ReturnedWidget) {
+        self.remove_window(widget)
+    }
+
+    fn factory_append(
+        &self,
+        widget: impl AsRef<Self::Children>,
+        _position: &Self::Position,
+    ) -> Self::ReturnedWidget {
+        self.add_window(widget.as_ref());
+        widget.as_ref().clone()
+    }
+
+    fn factory_prepend(
+        &self,
+        widget: impl AsRef<Self::Children>,
+        _position: &Self::Position,
+    ) -> Self::ReturnedWidget {
+        self.add_window(widget.as_ref());
+        widget.as_ref().clone()
+    }
+
+    fn factory_insert_after(
+        &self,
+        widget: impl AsRef<Self::Children>,
+        _position: &Self::Position,
+        _other: &Self::ReturnedWidget,
+    ) -> Self::ReturnedWidget {
+        self.add_window(widget.as_ref());
+        widget.as_ref().clone()
+    }
+
+    fn returned_widget_to_child(root_child: &Self::ReturnedWidget) -> Self::Children {
+        root_child.clone()
+    }
+
+    fn factory_move_after(&self, _widget: &Self::ReturnedWidget, _other: &Self::ReturnedWidget) {
+    }
+
+    fn factory_move_start(&self, _widget: &Self::ReturnedWidget) {
     }
 }
 

--- a/relm4/src/factory/widgets/libadwaita.rs
+++ b/relm4/src/factory/widgets/libadwaita.rs
@@ -298,3 +298,56 @@ impl FactoryView for adw::Leaflet {
         returned_widget.child()
     }
 }
+
+impl FactoryView for adw::Application {
+    type Children = gtk::Window;
+    type ReturnedWidget = gtk::Window;
+    type Position = ();
+
+    fn factory_remove(&self, widget: &Self::ReturnedWidget) {
+        self.remove_window(widget)
+    }
+
+    fn factory_append(
+        &self,
+        widget: impl AsRef<Self::Children>,
+        _position: &Self::Position,
+    ) -> Self::ReturnedWidget {
+        self.add_window(widget.as_ref());
+        widget.as_ref().set_visible(true);
+        widget.as_ref().clone()
+    }
+
+    fn factory_prepend(
+        &self,
+        widget: impl AsRef<Self::Children>,
+        _position: &Self::Position,
+    ) -> Self::ReturnedWidget {
+        self.add_window(widget.as_ref());
+                widget.as_ref().set_visible(true);
+
+        widget.as_ref().clone()
+    }
+
+    fn factory_insert_after(
+        &self,
+        widget: impl AsRef<Self::Children>,
+        _position: &Self::Position,
+        _other: &Self::ReturnedWidget,
+    ) -> Self::ReturnedWidget {
+        self.add_window(widget.as_ref());
+                widget.as_ref().set_visible(true);
+
+        widget.as_ref().clone()
+    }
+
+    fn returned_widget_to_child(root_child: &Self::ReturnedWidget) -> Self::Children {
+        root_child.clone()
+    }
+
+    fn factory_move_after(&self, _widget: &Self::ReturnedWidget, _other: &Self::ReturnedWidget) {
+    }
+
+    fn factory_move_start(&self, _widget: &Self::ReturnedWidget) {
+    }
+}

--- a/relm4/src/factory/widgets/traits.rs
+++ b/relm4/src/factory/widgets/traits.rs
@@ -1,8 +1,8 @@
-use gtk::prelude::IsA;
+use gtk::{prelude::IsA, glib};
 use std::fmt::Debug;
 
 /// A trait implemented for GTK4 widgets that allows a factory to create and remove widgets.
-pub trait FactoryView: IsA<gtk::Widget> {
+pub trait FactoryView: IsA<glib::Object> {
     /// The widget returned when inserting a widget.
     ///
     /// This doesn't matter on containers like [`gtk::Box`].

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -57,7 +57,7 @@ pub use extensions::*;
 pub use shared_state::{Reducer, Reducible, SharedState};
 pub use shutdown::ShutdownReceiver;
 
-pub use app::RelmApp;
+pub use app::{RelmApp};
 pub use tokio::task::JoinHandle;
 
 use gtk::prelude::{Cast, IsA};


### PR DESCRIPTION
#### Summary

This PR is a draft to allow gtk::Application to be used as root element, paving the way for multiple application windows.

Currently, it is more a POC than anything else. It shuts down instantly and always shows the message:

``` 
(application:296406): Gtk-CRITICAL **: 23:13:26.648: New application windows must be added after the GApplication::startup signal has been emitted.
```

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
