### PR TITLE
core: Fix scaling of drawing coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Added
 
++ core: Add `size()` method to `DrawHandler` for easier access of width and height
 + core: Add method to set `RelmAction` enabled or disabled
 + core: Add method to get the inner `gio::SimpleAction` used by `RelmAction`
 + core: Add resizeable/expandable column functionality to `RelmColumn` and `LabelColum`
@@ -23,6 +24,7 @@
 
 ### Fixed
 
++ core: Report the correct dimensions in DrawingHandler when a scaling factor is set
 + core: Setting the visibility of the main window isn't overridden by `RelmApp` anymore
 
 ## 0.7.0-beta.2 - 2023-10-14

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -9,7 +9,7 @@ use relm4::{gtk, Component, ComponentParts, ComponentSender, RelmApp, RelmWidget
 enum Msg {
     AddPoint((f64, f64)),
     Reset,
-    Resize((i32, i32)),
+    Resize,
 }
 
 #[derive(Debug)]
@@ -58,8 +58,8 @@ impl Component for App {
                 }
               }
             },
-            connect_resize[sender] => move |_, x, y| {
-                sender.input(Msg::Resize((x, y)));
+            connect_resize[sender] => move |_, _, _| {
+                sender.input(Msg::Resize);
             }
           },
         }
@@ -73,9 +73,9 @@ impl Component for App {
             Msg::AddPoint((x, y)) => {
                 self.points.push(Point::new(x, y));
             }
-            Msg::Resize((x, y)) => {
-                self.width = x as f64;
-                self.height = y as f64;
+            Msg::Resize => {
+                self.width = self.handler.width() as f64;
+                self.height = self.handler.height() as f64;
             }
             Msg::Reset => {
                 cx.set_operator(Operator::Clear);

--- a/relm4/src/drawing.rs
+++ b/relm4/src/drawing.rs
@@ -141,15 +141,45 @@ impl DrawHandler {
         DrawContext::new(&self.draw_surface, &self.edit_surface, &self.drawing_area)
     }
 
-    /// Get the height of the [`DrawHandler`].
+    /// Get the width and height of the [`DrawHandler`] in pixels.
+    #[must_use]
+    pub fn size(&self) -> (i32, i32) {
+        let scale = self.drawing_area.scale_factor();
+        (
+            self.edit_surface.width() / scale,
+            self.edit_surface.height() / scale,
+        )
+    }
+
+    /// Get the height of the [`DrawHandler`] in pixels.
     #[must_use]
     pub fn height(&self) -> i32 {
+        let scale = self.drawing_area.scale_factor();
+        self.edit_surface.height() / scale
+    }
+
+    /// Get the width of the [`DrawHandler`] in pixels.
+    #[must_use]
+    pub fn width(&self) -> i32 {
+        let scale = self.drawing_area.scale_factor();
+        self.edit_surface.width() / scale
+    }
+
+    /// Get the height of the inner [`ImageSurface`].
+    ///
+    /// **NOTE:** Depending on the monitor scaling this is not necessarily
+    /// the height in pixels.
+    #[must_use]
+    pub fn surface_height(&self) -> i32 {
         self.edit_surface.height()
     }
 
-    /// Get the width of the [`DrawHandler`].
+    /// Get the width of the inner [`ImageSurface`].
+    ///
+    /// **NOTE:** Depending on the monitor scaling this is not necessarily
+    /// the width in pixels.
     #[must_use]
-    pub fn width(&self) -> i32 {
+    pub fn surface_width(&self) -> i32 {
         self.edit_surface.width()
     }
 


### PR DESCRIPTION
#### Summary

The dimensions reported by `width` and `height` on `DrawingHandler` were not scaled before. For those using those dimensions as size of the canvas, those numbers would be too large if a scaling factor other than 1 was used (for example for high DPI monitors). This is now fixed and two new methods are added that implement the old behavior.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
