### PR TITLE
core: Add `allow_multiple_instances()` to `RelmApp`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
++ core: Add `allow_multiple_instances()` to `RelmApp` to allow multiple concurrent instances of the same application
+
 ### Fixed
 
 + core: Don't require `Clone` and `Debug` for the generic action name parameter in `RelmAction`

--- a/relm4/src/app.rs
+++ b/relm4/src/app.rs
@@ -84,6 +84,22 @@ impl<M: Debug + 'static> RelmApp<M> {
         self
     }
 
+    /// If `true`, allow multiple concurrent instances of the application
+    /// by setting the [`gtk::gio::ApplicationFlags::NON_UNIQUE`] flag.
+    ///
+    /// By default, this flag is not set.
+    /// When the flag is not set, the application will not be
+    /// started if another instance is already running.
+    pub fn allow_multiple_instances(&self, allow: bool) {
+        let mut flags = self.app.flags();
+        if allow {
+            flags |= gtk::gio::ApplicationFlags::NON_UNIQUE;
+        } else {
+            flags &= !gtk::gio::ApplicationFlags::NON_UNIQUE;
+        }
+        self.app.set_flags(flags);
+    }
+
     /// Sets a custom global stylesheet.
     pub fn set_global_css(&self, style_data: &str) {
         let display = gtk::gdk::Display::default().unwrap();


### PR DESCRIPTION
#### Summary
Usually, starting an already-running application again causes nothing to happen. However, with `allow_multiple_instances(true)`, the `NON_UNIQUE` flag is set, which makes it possible to run multiple instances of the application to run at the same time.
This should fix #396.

#### Checklist

- [X] cargo fmt
- [X] cargo clippy
- [X] cargo test
- [X] updated CHANGES.md
