### PR TITLE
Increase flexibility of `Alert` component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 + core: Rewrite `Alert` component from stratch to work with both GTK4 and Adwaita
 + css: Add Adwaita style classes and colors
 + core: Migrate codebase over to using `relm4-css`
++ components: Increase flexibility of `Alert` component
++ components: Make `Alert` component match styling of Adwaita's `MessageDialog` better
 
 ### Changed
 

--- a/relm4-components/examples/alert.rs
+++ b/relm4-components/examples/alert.rs
@@ -106,25 +106,31 @@ impl SimpleComponent for App {
             dialog: Alert::builder()
                 .transient_for(&root)
                 .launch(AlertSettings {
-                    text: String::from("Do you want to quit without saving? (First alert)"),
+                    text: Some(String::from(
+                        "Do you want to quit without saving? (First alert)",
+                    )),
                     secondary_text: Some(String::from("Your counter hasn't reached 42 yet")),
                     confirm_label: Some(String::from("Close without saving")),
                     cancel_label: Some(String::from("Cancel")),
                     option_label: Some(String::from("Save")),
                     is_modal: true,
                     destructive_accept: true,
+                    extra_child: Some(gtk::Button::with_label("Button in Alert").into()),
                 })
                 .forward(sender.input_sender(), convert_alert_response),
             second_dialog: Alert::builder()
                 .transient_for(&root)
                 .launch(AlertSettings {
-                    text: String::from("Do you want to quit without saving? (Second alert)"),
+                    text: Some(String::from(
+                        "Do you want to quit without saving? (Second alert)",
+                    )),
                     secondary_text: Some(String::from("Your counter hasn't reached 42 yet")),
                     confirm_label: Some(String::from("Close without saving")),
                     cancel_label: Some(String::from("Cancel")),
                     option_label: Some(String::from("Save")),
                     is_modal: true,
                     destructive_accept: true,
+                    extra_child: None,
                 })
                 .forward(sender.input_sender(), convert_alert_response),
         };

--- a/relm4-components/src/alert/style.css
+++ b/relm4-components/src/alert/style.css
@@ -3,7 +3,11 @@
     border-bottom-right-radius: 13px;
 }
 
-.relm4-alert button {
+.relm4-alert .message-area {
+    padding: 24px 30px;
+}
+
+.relm4-alert .response-buttons button {
     padding: 10px 14px;
     border-radius: 0px;
     border-width: 0px;


### PR DESCRIPTION
#### Summary
This increases the flexibility of the `Alert` component to allow:

- The title bar to be optional
- An extra widget to be passed in, for use below the Alert's text (like done with Adwaita's [`MessageDialog::set_extra_child`](https://world.pages.gitlab.gnome.org/Rust/libadwaita-rs/stable/latest/docs/libadwaita/prelude/trait.MessageDialogExt.html#method.set_extra_child)).

I had previously done this when implementing the [Adwaita-based `Alert` component](https://github.com/hwittenborn/Relm4/commit/887d03fd06eb7eab34e7ed5fcba1386533e14c40), but it never got added since a custom component was written instead. This PR incorporates the additions originally created there.

I also made some minor adjustments to the spacing in the widget, in order to more closely align with how Adwaita's `MessageDialog` looks. There were some particular spots that were overlooked in the PR for the custom widget's implementation, but comparing the two side by side revealed some issues. You can see such changes in the below screenshot (the `Alert` component is on the left, Adwaita's `MessageDialog` is on the right):

Previous:
![image](https://github.com/Relm4/Relm4/assets/74838472/3f69ad51-c665-4878-8aeb-ff60713be190)

New:
![image](https://github.com/Relm4/Relm4/assets/74838472/336605a7-7e14-460e-bd7e-89a389900f0a)

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
