### PR TITLE
Ignore sending error if async component was dropped quickly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 ### Fixed
+
 + components: Don't panic in `get_active_elem()` when calling on `SimpleComboBox` with empty variants
+* core: Ignore sending error if async component was dropped quickly
 
 ## 0.9.0 - 2024-7-12
 

--- a/relm4/src/factory/async/builder.rs
+++ b/relm4/src/factory/async/builder.rs
@@ -91,7 +91,7 @@ where
                 let data = C::init_model(init, &index, component_sender).await;
                 drop(loading_widgets);
                 let data_guard = future_data.start_runtime(data);
-                future_sender.send(data_guard).unwrap();
+                let _ = future_sender.send(data_guard);
             });
             future_receiver
         };


### PR DESCRIPTION
#### Summary

As discussed on Matrix, this may cause panic if factory element is dropped too quickly

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
