### PR TITLE
fixed panic on empty combo box

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
++ components: Don't panic in `get_active_elem()` when calling on `SimpleComboBox` with empty variants
+
 ## 0.9.0 - 2024-7-12
 
 ### Added

--- a/relm4-components/src/simple_combo_box.rs
+++ b/relm4-components/src/simple_combo_box.rs
@@ -110,6 +110,7 @@ where
     /// Return the value of the currently selected element or [`None`] if nothing is selected.
     #[must_use]
     pub fn get_active_elem(&self) -> Option<&E> {
-        self.active_index.map(|idx| &self.variants[idx])
+        self.active_index.and_then(|idx| self.variants.get(idx))
     }
+
 }

--- a/relm4-components/src/simple_combo_box.rs
+++ b/relm4-components/src/simple_combo_box.rs
@@ -112,5 +112,4 @@ where
     pub fn get_active_elem(&self) -> Option<&E> {
         self.active_index.and_then(|idx| self.variants.get(idx))
     }
-
 }


### PR DESCRIPTION
#### Summary

Fixed panic that happens when calling get_active_elem() method on SimpleComboBox with empty variants.

#### Checklist

- [+] cargo fmt
- [+] cargo clippy
- [+] cargo test
- [+] updated CHANGES.md
