### PR TITLE
Replace deprecated `from_pixbuf` function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+* components: Replace deprecated `from_pixbuf()` usage
 + components: Don't panic in `get_active_elem()` when calling on `SimpleComboBox` with empty variants
 * core: Ignore sending error if async component was dropped quickly
 

--- a/relm4-components/src/web_image.rs
+++ b/relm4-components/src/web_image.rs
@@ -132,7 +132,8 @@ impl WebImage {
 
     fn generate_image(data: VecDeque<u8>) -> Option<gtk::Image> {
         let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_read(data).ok()?;
-        Some(gtk::Image::from_pixbuf(Some(&pixbuf)))
+        let texture = gtk::gdk::Texture::for_pixbuf(&pixbuf);
+        Some(gtk::Image::from_paintable(Some(&texture)))
     }
 
     async fn get_img_data(id: usize, url: String) -> Option<(usize, VecDeque<u8>)> {


### PR DESCRIPTION
#### Summary
`Image.new_from_pixbuf` was deprecated in 4.12: https://docs.gtk.org/gtk4/ctor.Image.new_from_pixbuf.html, this replaces it with `Texture::for_pixbuf` and `Image::from_paintable`

#### Checklist
- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
