### PR TITLE
Fix spawn_oneshot_command description

### DIFF
--- a/relm4/src/channel/component.rs
+++ b/relm4/src/channel/component.rs
@@ -117,7 +117,7 @@ where
         });
     }
 
-    /// Spawns a synchronous command that will be dropped as soon as the factory component is shut down.
+    /// Spawns a synchronous command.
     ///
     /// Essentially, this is a simpler version of [`Self::spawn_command()`].
     fn spawn_oneshot_command<Cmd>(&self, cmd: Cmd)


### PR DESCRIPTION
#### Summary

It is not possible to cancel synchronous commands.

#### Checklist

- [ ] cargo fmt
- [ ] cargo clippy
- [ ] cargo test
- [ ] updated CHANGES.md
