### PR TITLE
Add `notify_filter_changed` function to typed views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Changed
 
 + core: Add more async factory types to prelude
++ core: Add `notify_filter_changed` to typed views to allow dynamic filters
 + components: Hide recent button from `OpenButton` component when there is no entries
 
 ### Fixed

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -309,9 +309,14 @@ where
 
     /// Notify that a certain filter has changed.
     /// This causes the filter expression to be re-evaluated.
-    pub fn notify_filter_changed(&self, idx: usize) {
+    ///
+    /// Returns true if a filter was notified.
+    pub fn notify_filter_changed(&self, idx: usize) -> bool {
         if let Some(filter) = self.filters.get(idx) {
             filter.filter.changed(gtk::FilterChange::Different);
+            true
+        } else {
+            false
         }
     }
 

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -307,7 +307,7 @@ where
         }
     }
 
-    /// Notify that a certian filter has changed.
+    /// Notify that a certain filter has changed.
     /// This causes the filter expression to be re-evaluated.
     pub fn notify_filter_changed(&self, idx: usize) {
         if let Some(filter) = self.filters.get(idx) {

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -3,7 +3,7 @@
 use super::{get_mut_value, get_value, Filter, OrdFn, RelmSelectionExt, TypedListItem};
 use gtk::{
     gio, glib,
-    prelude::{Cast, CastNone, IsA, ListItemExt, ListModelExt, ObjectExt},
+    prelude::{Cast, CastNone, FilterExt, IsA, ListItemExt, ListModelExt, ObjectExt},
 };
 use std::{
     any::Any,
@@ -304,6 +304,14 @@ where
             true
         } else {
             false
+        }
+    }
+
+    /// Notify that a certian filter has changed.
+    /// This causes the filter expression to be re-evaluated.
+    pub fn notify_filter_changed(&self, idx: usize) {
+        if let Some(filter) = self.filters.get(idx) {
+            filter.filter.changed(gtk::FilterChange::Different);
         }
     }
 

--- a/relm4/src/typed_view/grid.rs
+++ b/relm4/src/typed_view/grid.rs
@@ -227,9 +227,14 @@ where
 
     /// Notify that a certain filter has changed.
     /// This causes the filter expression to be re-evaluated.
-    pub fn notify_filter_changed(&self, idx: usize) {
+    ///
+    /// Returns true if a filter was notified.
+    pub fn notify_filter_changed(&self, idx: usize) -> bool {
         if let Some(filter) = self.filters.get(idx) {
             filter.filter.changed(gtk::FilterChange::Different);
+            true
+        } else {
+            false
         }
     }
 

--- a/relm4/src/typed_view/grid.rs
+++ b/relm4/src/typed_view/grid.rs
@@ -3,7 +3,7 @@
 use super::{get_mut_value, get_value, Filter, OrdFn, RelmSelectionExt, TypedListItem};
 use gtk::{
     gio, glib,
-    prelude::{Cast, CastNone, IsA, ListItemExt, ListModelExt, ObjectExt},
+    prelude::{Cast, CastNone, FilterExt, IsA, ListItemExt, ListModelExt, ObjectExt},
 };
 use std::{any::Any, cmp::Ordering, marker::PhantomData};
 
@@ -222,6 +222,14 @@ where
             true
         } else {
             false
+        }
+    }
+
+    /// Notify that a certian filter has changed.
+    /// This causes the filter expression to be re-evaluated.
+    pub fn notify_filter_changed(&self, idx: usize) {
+        if let Some(filter) = self.filters.get(idx) {
+            filter.filter.changed(gtk::FilterChange::Different);
         }
     }
 

--- a/relm4/src/typed_view/grid.rs
+++ b/relm4/src/typed_view/grid.rs
@@ -225,7 +225,7 @@ where
         }
     }
 
-    /// Notify that a certian filter has changed.
+    /// Notify that a certain filter has changed.
     /// This causes the filter expression to be re-evaluated.
     pub fn notify_filter_changed(&self, idx: usize) {
         if let Some(filter) = self.filters.get(idx) {

--- a/relm4/src/typed_view/list.rs
+++ b/relm4/src/typed_view/list.rs
@@ -227,9 +227,14 @@ where
 
     /// Notify that a certain filter has changed.
     /// This causes the filter expression to be re-evaluated.
-    pub fn notify_filter_changed(&self, idx: usize) {
+    ///
+    /// Returns true if a filter was notified.
+    pub fn notify_filter_changed(&self, idx: usize) -> bool {
         if let Some(filter) = self.filters.get(idx) {
             filter.filter.changed(gtk::FilterChange::Different);
+            true
+        } else {
+            false
         }
     }
 

--- a/relm4/src/typed_view/list.rs
+++ b/relm4/src/typed_view/list.rs
@@ -3,7 +3,7 @@
 use super::{get_mut_value, get_value, Filter, OrdFn, RelmSelectionExt, TypedListItem};
 use gtk::{
     gio, glib,
-    prelude::{Cast, CastNone, IsA, ListItemExt, ListModelExt, ObjectExt},
+    prelude::{Cast, CastNone, FilterExt, IsA, ListItemExt, ListModelExt, ObjectExt},
 };
 use std::{any::Any, cmp::Ordering, marker::PhantomData};
 
@@ -222,6 +222,14 @@ where
             true
         } else {
             false
+        }
+    }
+
+    /// Notify that a certian filter has changed.
+    /// This causes the filter expression to be re-evaluated.
+    pub fn notify_filter_changed(&self, idx: usize) {
+        if let Some(filter) = self.filters.get(idx) {
+            filter.filter.changed(gtk::FilterChange::Different);
         }
     }
 

--- a/relm4/src/typed_view/list.rs
+++ b/relm4/src/typed_view/list.rs
@@ -225,7 +225,7 @@ where
         }
     }
 
-    /// Notify that a certian filter has changed.
+    /// Notify that a certain filter has changed.
     /// This causes the filter expression to be re-evaluated.
     pub fn notify_filter_changed(&self, idx: usize) {
         if let Some(filter) = self.filters.get(idx) {


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

This PR adds a `notify_filter_changed` function to all of the typed list abstractions. This is useful for making dynamic filters where the result may change between evaluations.

For example, I'm trying to make a text filter for a `TypedListView` where the user can filter items by entering text in a `SearchEntry`.

The filter looks like this:
```rust
        model.list_view.add_filter({
            let search_entry = widgets.search_entry.clone();
            move |item| {
                item
                    .name
                    .to_lowercase()
                    .contains(&search_entry.text().to_lowercase())
            }
        });
```

Currently to force this filter to update, you either have set it to inactive and then active, or completely re-add it to the list view on every input change.

With this function, I can simply notify that the filter has changed:
```rust
            AppMsg::FilterChanged(filter) => {
                if filter.is_empty() {
                    self.list_view.set_filter_status(0, false);
                } else {
                    self.list_view.set_filter_status(0, true);
                    self.list_view.notify_filter_changed(0);
                }
            }
```

#### Checklist

- [X] cargo fmt
- [X] cargo clippy
- [X] cargo test
- [X] updated CHANGES.md
