### PR TITLE
[feat:] implement extend method to add multiple components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ### Added
 
 + core: Add gnome_47 feature flag for GNOME 47
++ core: Add method `FactoryVecDeque::extend` to append multiple components efficiently.
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### Added
+
++ core: Add method `FactoryVecDeque::extend` to append multiple components efficiently.
+
 ## 0.9.1 - 2024-10-11
 
 ### Added
 
 + core: Add gnome_47 feature flag for GNOME 47
-+ core: Add method `FactoryVecDeque::extend` to append multiple components efficiently.
 
 ### Changed
 

--- a/relm4/src/factory/sync/collections/vec_deque.rs
+++ b/relm4/src/factory/sync/collections/vec_deque.rs
@@ -730,6 +730,19 @@ where
         }
         output
     }
+    /// Adds multiple components to the back of the [`FactoryVecDeque`].
+    /// 
+    /// This method takes an iterator over components and adds each one
+    /// to the deque, rendering them efficiently.
+    pub fn extend(&mut self, component_iter: impl IntoIterator<Item = C::Init>) {
+        // Acquire the guard to make changes
+        let mut edit = self.guard();
+
+        // Iterate over the incoming components and push each one
+        for component in component_iter {
+            edit.push_back(component);
+        }
+    }
 }
 
 ///Implements the Clone Trait for `FactoryVecDeque<C>` where C is Cloneable

--- a/relm4/src/factory/sync/collections/vec_deque.rs
+++ b/relm4/src/factory/sync/collections/vec_deque.rs
@@ -731,7 +731,7 @@ where
         output
     }
     /// Adds multiple components to the back of the [`FactoryVecDeque`].
-    /// 
+    ///
     /// This method takes an iterator over components and adds each one
     /// to the deque, rendering them efficiently.
     pub fn extend(&mut self, component_iter: impl IntoIterator<Item = C::Init>) {


### PR DESCRIPTION

This PR addresses **Issue #600** by introducing a new `extend` method to the `FactoryVecDeque` struct. The method allows multiple components to be added efficiently in one call, improving the usability and performance when adding multiple elements to the deque.

### **Key Changes**

- **New `extend` method**: The method takes an iterator of components and adds each component to the deque. It batches the changes within a `FactoryVecDequeGuard`, ensuring efficient rendering by accumulating all changes before they are processed.
### **Closes Issue**

Closes #600.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
