### PR TITLE
Display "identical" background if initial icons are the same.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 + core: Add method `FactoryVecDeque::extend` to append multiple components efficiently.
 
+### Fixed
+
++ example "tracker": Display identical background when initial icons are in fact identical.
+
 ## 0.9.1 - 2024-10-11
 
 ### Added

--- a/examples/tracker.rs
+++ b/examples/tracker.rs
@@ -107,12 +107,14 @@ impl SimpleComponent for AppModel {
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let model = AppModel {
+        let mut model = AppModel {
             first_icon: random_icon_name(),
             second_icon: random_icon_name(),
             identical: false,
             tracker: 0,
         };
+
+        model.identical = model.first_icon == model.second_icon;
 
         let widgets = view_output!();
 


### PR DESCRIPTION
#### Summary

The "tracker" example does not display the green "identical" background if the 2 randomly-chosen icons happen to be identical when the app is first initialized.    

Repro:
1. `$ cargo run --example tracker`
2. Visually compare the displayed icons.  If they are not identical:
    a. exit the app
    b. go to step 1.

Expect (when the initially displayed icons are identical):
-- the app window background should be green, indicating identical

Observe:
-- the app window background is not green

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
