### PR TITLE
Accept clippy fixes

### DIFF
--- a/relm4/src/factory/async/collections/vec_deque.rs
+++ b/relm4/src/factory/async/collections/vec_deque.rs
@@ -32,7 +32,7 @@ where
     inner: &'a mut AsyncFactoryVecDeque<C>,
 }
 
-impl<'a, C: AsyncFactoryComponent> Drop for AsyncFactoryVecDequeGuard<'a, C>
+impl<C: AsyncFactoryComponent> Drop for AsyncFactoryVecDequeGuard<'_, C>
 where
     <C::ParentWidget as FactoryView>::ReturnedWidget: Clone,
 {
@@ -378,7 +378,7 @@ where
     }
 }
 
-impl<'a, C: AsyncFactoryComponent> Deref for AsyncFactoryVecDequeGuard<'a, C>
+impl<C: AsyncFactoryComponent> Deref for AsyncFactoryVecDequeGuard<'_, C>
 where
     <C::ParentWidget as FactoryView>::ReturnedWidget: Clone,
 {

--- a/relm4/src/factory/sync/collections/hashmap.rs
+++ b/relm4/src/factory/sync/collections/hashmap.rs
@@ -22,7 +22,7 @@ where
     inner: &'a mut FactoryHandle<C>,
 }
 
-impl<'a, C> ops::Deref for FactoryElementGuard<'a, C>
+impl<C> ops::Deref for FactoryElementGuard<'_, C>
 where
     C: FactoryComponent,
 {
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<'a, C> ops::DerefMut for FactoryElementGuard<'a, C>
+impl<C> ops::DerefMut for FactoryElementGuard<'_, C>
 where
     C: FactoryComponent,
 {
@@ -42,7 +42,7 @@ where
     }
 }
 
-impl<'a, C> Drop for FactoryElementGuard<'a, C>
+impl<C> Drop for FactoryElementGuard<'_, C>
 where
     C: FactoryComponent,
 {

--- a/relm4/src/factory/sync/collections/vec_deque.rs
+++ b/relm4/src/factory/sync/collections/vec_deque.rs
@@ -33,7 +33,7 @@ where
     inner: &'a mut FactoryVecDeque<C>,
 }
 
-impl<'a, C> Drop for FactoryVecDequeGuard<'a, C>
+impl<C> Drop for FactoryVecDequeGuard<'_, C>
 where
     C: FactoryComponent<Index = DynamicIndex>,
 {
@@ -355,7 +355,7 @@ where
     }
 }
 
-impl<'a, C> Deref for FactoryVecDequeGuard<'a, C>
+impl<C> Deref for FactoryVecDequeGuard<'_, C>
 where
     C: FactoryComponent<Index = DynamicIndex>,
 {
@@ -366,7 +366,7 @@ where
     }
 }
 
-impl<'a, C> Index<usize> for FactoryVecDequeGuard<'a, C>
+impl<C> Index<usize> for FactoryVecDequeGuard<'_, C>
 where
     C: FactoryComponent<Index = DynamicIndex>,
 {
@@ -377,7 +377,7 @@ where
     }
 }
 
-impl<'a, C> IndexMut<usize> for FactoryVecDequeGuard<'a, C>
+impl<C> IndexMut<usize> for FactoryVecDequeGuard<'_, C>
 where
     C: FactoryComponent<Index = DynamicIndex>,
 {

--- a/relm4/src/runtime_util.rs
+++ b/relm4/src/runtime_util.rs
@@ -171,7 +171,7 @@ where
     sender_dropped: bool,
 }
 
-impl<'a, T> GuardedReceiver<'a, T>
+impl<T> GuardedReceiver<'_, T>
 where
     T: 'static,
 {
@@ -183,7 +183,7 @@ where
     }
 }
 
-impl<'a, T> Future for GuardedReceiver<'a, T>
+impl<T> Future for GuardedReceiver<'_, T>
 where
     T: 'static,
 {
@@ -211,7 +211,7 @@ where
     }
 }
 
-impl<'a, T> FusedFuture for GuardedReceiver<'a, T> {
+impl<T> FusedFuture for GuardedReceiver<'_, T> {
     fn is_terminated(&self) -> bool {
         self.sender_dropped
     }

--- a/relm4/src/shared_state/state.rs
+++ b/relm4/src/shared_state/state.rs
@@ -273,7 +273,7 @@ pub struct SharedStateReadGuard<'a, Data> {
     inner: RwLockReadGuard<'a, Data>,
 }
 
-impl<'a, Data> Deref for SharedStateReadGuard<'a, Data> {
+impl<Data> Deref for SharedStateReadGuard<'_, Data> {
     type Target = Data;
 
     fn deref(&self) -> &Self::Target {
@@ -288,7 +288,7 @@ pub struct SharedStateWriteGuard<'a, Data> {
     subscribers: RwLockWriteGuard<'a, Vec<SubscriberFn<Data>>>,
 }
 
-impl<'a, Data: std::fmt::Debug> std::fmt::Debug for SharedStateWriteGuard<'a, Data> {
+impl<Data: std::fmt::Debug> std::fmt::Debug for SharedStateWriteGuard<'_, Data> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SharedStateWriteGuard")
             .field("data", &self.data)
@@ -297,7 +297,7 @@ impl<'a, Data: std::fmt::Debug> std::fmt::Debug for SharedStateWriteGuard<'a, Da
     }
 }
 
-impl<'a, Data> Deref for SharedStateWriteGuard<'a, Data> {
+impl<Data> Deref for SharedStateWriteGuard<'_, Data> {
     type Target = Data;
 
     fn deref(&self) -> &Self::Target {
@@ -305,13 +305,13 @@ impl<'a, Data> Deref for SharedStateWriteGuard<'a, Data> {
     }
 }
 
-impl<'a, Data> DerefMut for SharedStateWriteGuard<'a, Data> {
+impl<Data> DerefMut for SharedStateWriteGuard<'_, Data> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.data
     }
 }
 
-impl<'a, Data> Drop for SharedStateWriteGuard<'a, Data> {
+impl<Data> Drop for SharedStateWriteGuard<'_, Data> {
     // Notify subscribers
     fn drop(&mut self) {
         let data = &*self.data;


### PR DESCRIPTION
#### Summary
`cargo clippy` complaining about explicit lifetimes in code I haven't touched.
Happens both with current nightly (rustc 1.85.0-nightly (426d17342 2024-12-21))
and with current stable (rustc 1.83.0 (90b35a623 2024-11-26).

I'm also seeing some test failures as well, but only with stable.  So I don't expect this PR to pass CI.
#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test -- failures in stable, but not nightly
- [x] updated CHANGES.md -- n/a
