### PR TITLE
Added a overwritable function to change the header in RelmColumn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 + core: Add convenience methods for setting the active `StackPage` in `FactoryVecDeque` and `FactoryHashMap`
 + core: Impl `Binding` for `gtk::CheckButton`
++ core: Added a method to change column headers in `RelmColumn`. Useful for translations
 
 ### Added
 

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -31,6 +31,12 @@ pub trait RelmColumn: Any {
     /// Whether to enable automatic expanding for this column
     const ENABLE_EXPAND: bool = false;
 
+    /// Returns the shown title for the column. By default shows [`RelmColumn::COLUMN_NAME`]. Useful for translations
+    #[must_use]
+    fn header_title() -> String {
+        String::from(Self::COLUMN_NAME)
+    }
+
     /// Construct the widgets.
     fn setup(list_item: &gtk::ListItem) -> (Self::Root, Self::Widgets);
 
@@ -247,7 +253,7 @@ where
 
         let sort_fn = C::sort_fn();
 
-        let c = gtk::ColumnViewColumn::new(Some(C::COLUMN_NAME), Some(factory));
+        let c = gtk::ColumnViewColumn::new(Some(&C::header_title()), Some(factory));
         c.set_resizable(C::ENABLE_RESIZE);
         c.set_expand(C::ENABLE_EXPAND);
 


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

I decided to use gettext for translations in my project. It uses a function for changing strings which is incompatible with the way column headers are determined. So i added a overwritable function in RelmColumn and LabelColumn that defaults to COLLUMN_NAME, so it doesn't break old code.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
