### PR TITLE
Fix natural children management for ListBox and FlowBox in view macro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 + components: Add `icon` to `IconButton`
 + core: Implement container traits to allow easier usage of libpanel widgets in the view macro
+* core: Support naturally appending any `Widget`s as children to `ListBox` and `FlowBox` in view macro.
 
 ### Added
 

--- a/relm4/src/extensions/container.rs
+++ b/relm4/src/extensions/container.rs
@@ -71,7 +71,7 @@ macro_rules! add_impl {
     };
 }
 
-append_impl!(gtk::Box, gtk::ListBox);
+append_impl!(gtk::Box, gtk::ListBox, gtk::FlowBox);
 add_child_impl!(gtk::InfoBar, gtk::Stack);
 
 #[cfg(feature = "libadwaita")]

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -162,11 +162,13 @@ container_child_impl! {
     gtk::InfoBar,
     gtk::Button,
     gtk::ComboBox,
+    gtk::FlowBox,
     gtk::FlowBoxChild,
     gtk::Frame,
     gtk::Popover,
     gtk::Window,
     gtk::ApplicationWindow,
+    gtk::ListBox,
     gtk::ListBoxRow,
     gtk::ScrolledWindow,
     gtk::Dialog,
@@ -177,11 +179,6 @@ container_child_impl! {
     gtk::WindowHandle,
     gtk::Expander,
     gtk::AspectFrame
-}
-
-container_child_impl! {
-    gtk::ListBox: gtk::ListBoxRow,
-    gtk::FlowBox: gtk::FlowBoxChild
 }
 
 #[cfg(feature = "libadwaita")]

--- a/relm4/src/extensions/remove.rs
+++ b/relm4/src/extensions/remove.rs
@@ -23,22 +23,6 @@ where
     }
 }
 
-impl RelmRemoveExt for gtk::ListBox {
-    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
-        let row = widget.as_ref();
-        row.set_child(None::<&gtk::Widget>);
-        self.remove(row);
-    }
-}
-
-impl RelmRemoveExt for gtk::FlowBox {
-    fn container_remove(&self, widget: &impl AsRef<Self::Child>) {
-        let child = widget.as_ref();
-        child.set_child(None::<&gtk::Widget>);
-        self.remove(widget.as_ref());
-    }
-}
-
 #[cfg(feature = "libadwaita")]
 #[cfg_attr(docsrs, doc(cfg(feature = "libadwaita")))]
 impl RelmRemoveExt for adw::PreferencesGroup {
@@ -90,7 +74,9 @@ remove_impl!(
     gtk::Grid,
     gtk::ActionBar,
     gtk::Stack,
-    gtk::HeaderBar
+    gtk::HeaderBar,
+    gtk::ListBox,
+    gtk::FlowBox
 );
 remove_child_impl!(gtk::InfoBar);
 


### PR DESCRIPTION
Previously, in the `view` macro, `ListBox` and `FlowBox` only supported managing `ListBoxRow` and `FlowBoxChild`, respectively. Now, they accept any `Widget`, and gtk will automatically manage the appropriate children wrappers.

Fixes #587

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
