### PR TITLE
add a iter method for iterating items in TypedGridView, TypedColumnView and TypedListView

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 + core: Add convenience methods for setting the active `StackPage` in `FactoryVecDeque` and `FactoryHashMap`
 + core: Impl `Binding` for `gtk::CheckButton`
 + core: Added a method to change column headers in `RelmColumn`. Useful for translations
++ core: Add a `iter` methods for iterating items in `TypedColumnView`, `TypedGridView` and `TypedListView`
 
 ### Added
 

--- a/examples/typed_column_view.rs
+++ b/examples/typed_column_view.rs
@@ -176,6 +176,10 @@ impl SimpleComponent for App {
                     self.view_wrapper.append(MyListItem::new(self.counter));
                 }
 
+                self.view_wrapper
+                    .iter()
+                    .for_each(|row| println!("item {}", row.borrow().value));
+
                 // Count up the first item
                 let first_item = self.view_wrapper.get(0).unwrap();
                 let first_binding = &mut first_item.borrow_mut().binding;

--- a/examples/typed_grid_view.rs
+++ b/examples/typed_grid_view.rs
@@ -169,6 +169,10 @@ impl SimpleComponent for App {
                     self.grid_view_wrapper.append(MyGridItem::new(self.counter));
                 }
 
+                self.grid_view_wrapper
+                    .iter()
+                    .for_each(|row| println!("item {}", row.borrow().value));
+
                 // Count up the first item
                 let first_item = self.grid_view_wrapper.get(0).unwrap();
                 let first_binding = &mut first_item.borrow_mut().binding;

--- a/examples/typed_list_view.rs
+++ b/examples/typed_list_view.rs
@@ -162,6 +162,10 @@ impl SimpleComponent for App {
                     self.list_view_wrapper.append(MyListItem::new(self.counter));
                 }
 
+                self.list_view_wrapper
+                    .iter()
+                    .for_each(|row| println!("item {}", row.borrow().value));
+
                 // Count up the first item
                 let first_item = self.list_view_wrapper.get(0).unwrap();
                 let first_binding = &mut first_item.borrow_mut().binding;

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -435,7 +435,7 @@ where
         self.store.remove_all();
     }
 
-    /// Returns an iterator that allows modifying each [`TypedColumnItem`].
+    /// Returns an iterator that allows modifying each [`TypedListItem`].
     pub fn iter(&self) -> TypedIterator<'_, TypedColumnView<T, S>> {
         TypedIterator {
             list: self,

--- a/relm4/src/typed_view/column.rs
+++ b/relm4/src/typed_view/column.rs
@@ -1,6 +1,9 @@
 //! Idiomatic and high-level abstraction over [`gtk::ColumnView`].
 
-use super::{get_mut_value, get_value, Filter, OrdFn, RelmSelectionExt, TypedListItem};
+use super::{
+    get_mut_value, get_value, iterator::TypedIterator, Filter, OrdFn, RelmSelectionExt,
+    TypedListItem,
+};
 use gtk::{
     gio, glib,
     prelude::{Cast, CastNone, FilterExt, IsA, ListItemExt, ListModelExt, ObjectExt},
@@ -430,5 +433,13 @@ where
     /// Remove all items.
     pub fn clear(&mut self) {
         self.store.remove_all();
+    }
+
+    /// Returns an iterator that allows modifying each [`TypedColumnItem`].
+    pub fn iter(&self) -> TypedIterator<'_, TypedColumnView<T, S>> {
+        TypedIterator {
+            list: self,
+            index: 0,
+        }
     }
 }

--- a/relm4/src/typed_view/grid.rs
+++ b/relm4/src/typed_view/grid.rs
@@ -1,6 +1,9 @@
 //! Idiomatic and high-level abstraction over [`gtk::GridView`].
 
-use super::{get_mut_value, get_value, Filter, OrdFn, RelmSelectionExt, TypedListItem};
+use super::{
+    get_mut_value, get_value, iterator::TypedIterator, Filter, OrdFn, RelmSelectionExt,
+    TypedListItem,
+};
 use gtk::{
     gio, glib,
     prelude::{Cast, CastNone, FilterExt, IsA, ListItemExt, ListModelExt, ObjectExt},
@@ -343,5 +346,13 @@ where
     /// Remove all items.
     pub fn clear(&mut self) {
         self.store.remove_all();
+    }
+
+    /// Returns an iterator that allows modifying each [`TypedListItem`].
+    pub fn iter(&self) -> TypedIterator<'_, TypedGridView<T, S>> {
+        TypedIterator {
+            list: self,
+            index: 0,
+        }
     }
 }

--- a/relm4/src/typed_view/iterator.rs
+++ b/relm4/src/typed_view/iterator.rs
@@ -1,0 +1,70 @@
+use std::any::Any;
+
+use super::{
+    column::TypedColumnView,
+    grid::{RelmGridItem, TypedGridView},
+    list::{RelmListItem, TypedListView},
+    selection_ext::RelmSelectionExt,
+    TypedListItem,
+};
+
+#[derive(Debug)]
+/// Holds the state for iterating [`TypedListItem`]s of [`TypedColumnView`], [`TypedGridView`] or [`TypedColumnView`].
+pub struct TypedIterator<'a, T> {
+    pub(crate) list: &'a T,
+    pub(crate) index: u32,
+}
+
+impl<T, S> Iterator for TypedIterator<'_, TypedColumnView<T, S>>
+where
+    T: Any,
+    S: RelmSelectionExt,
+{
+    type Item = TypedListItem<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.list.len() {
+            let result = self.list.get(self.index);
+            self.index += 1;
+            result
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, S> Iterator for TypedIterator<'_, TypedGridView<T, S>>
+where
+    T: RelmGridItem + Ord,
+    S: RelmSelectionExt,
+{
+    type Item = TypedListItem<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.list.len() {
+            let result = self.list.get(self.index);
+            self.index += 1;
+            result
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, S> Iterator for TypedIterator<'_, TypedListView<T, S>>
+where
+    T: RelmListItem,
+    S: RelmSelectionExt,
+{
+    type Item = TypedListItem<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.list.len() {
+            let result = self.list.get(self.index);
+            self.index += 1;
+            result
+        } else {
+            None
+        }
+    }
+}

--- a/relm4/src/typed_view/iterator.rs
+++ b/relm4/src/typed_view/iterator.rs
@@ -11,8 +11,8 @@ use super::{
 #[derive(Debug)]
 /// Holds the state for iterating [`TypedListItem`]s of [`TypedColumnView`], [`TypedGridView`] or [`TypedColumnView`].
 pub struct TypedIterator<'a, T> {
-    pub(crate) list: &'a T,
-    pub(crate) index: u32,
+    pub(super) list: &'a T,
+    pub(super) index: u32,
 }
 
 impl<T, S> Iterator for TypedIterator<'_, TypedColumnView<T, S>>

--- a/relm4/src/typed_view/list.rs
+++ b/relm4/src/typed_view/list.rs
@@ -1,6 +1,9 @@
 //! Idiomatic and high-level abstraction over [`gtk::ListView`].
 
-use super::{get_mut_value, get_value, Filter, OrdFn, RelmSelectionExt, TypedListItem};
+use super::{
+    get_mut_value, get_value, iterator::TypedIterator, Filter, OrdFn, RelmSelectionExt,
+    TypedListItem,
+};
 use gtk::{
     gio, glib,
     prelude::{Cast, CastNone, FilterExt, IsA, ListItemExt, ListModelExt, ObjectExt},
@@ -343,5 +346,13 @@ where
     /// Remove all items.
     pub fn clear(&mut self) {
         self.store.remove_all();
+    }
+
+    /// Returns an iterator that allows modifying each [`TypedListItem`].
+    pub fn iter(&self) -> TypedIterator<'_, TypedListView<T, S>> {
+        TypedIterator {
+            list: self,
+            index: 0,
+        }
     }
 }

--- a/relm4/src/typed_view/mod.rs
+++ b/relm4/src/typed_view/mod.rs
@@ -14,6 +14,8 @@ use std::{
     marker::PhantomData,
 };
 
+pub use self::iterator::TypedIterator;
+
 /// Sorting function used for views.
 pub type OrdFn<T> = Option<Box<dyn Fn(&T, &T) -> Ordering>>;
 

--- a/relm4/src/typed_view/mod.rs
+++ b/relm4/src/typed_view/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod column;
 pub mod grid;
+mod iterator;
 pub mod list;
 mod selection_ext;
 


### PR DESCRIPTION
#### Summary

In my project I used a lot of iterating over `TypedListItem`s in the TypedViews. This makes them easier to traverse and makes the whole `Iterator` ecosystem usable for them.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
