### PR TITLE
Deactivate Gtk.ListItem in message_from_grid_view example.

### DIFF
--- a/examples/message_from_grid_view.rs
+++ b/examples/message_from_grid_view.rs
@@ -46,7 +46,8 @@ impl RelmGridItem for MyGridItem {
     type Root = gtk::Box;
     type Widgets = Widgets;
 
-    fn setup(_item: &gtk::ListItem) -> (gtk::Box, Widgets) {
+    fn setup(item: &gtk::ListItem) -> (gtk::Box, Widgets) {
+        item.set_activatable(false);
         relm4::view! {
             my_box = gtk::Box {
                 set_orientation: gtk::Orientation::Horizontal,


### PR DESCRIPTION
# Summary

This is because with activated feature `libadwaita` it adds clutter around buttons in the grid. Fixes #816.

*__NOTE:__ I made no addition to CHANGES.md as we have not made any releases since `message_from_grid_view` example was added.*

# Changes
- Deactivate `Gtk.ListItem`s widgets in the grid of `message_from_grid_view` example.

# Issues
- #816

# Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [ ] updated CHANGES.md

# Testing

To reproduce the issue and see the fix use the following command:

```sh
cargo run --example message_from_grid_view --features=libadwaita
```

# Screenshots

## Before

<img width="1544" height="844" alt="Screenshot before the change" src="https://github.com/user-attachments/assets/92abea53-f3b0-4aec-929f-42eac028fc2e" />

## After

<img width="1544" height="844" alt="Screenshot after the change" src="https://github.com/user-attachments/assets/fe9d6cdd-daa3-44a8-8ec2-9d79c387a9fe" />