### PR TITLE
Add bindings for Adwaita widgets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 + all: Update dependencies
 + core: Add gnome_49 feature flag for GNOME 49
 + core: Export `RelmSelectionExt` trait publicly from `relm4::typed_view` module to allow for user extensions of `TypedColumnView`
++ core: Implement `Binding` for various Adwaita widgets
 
 ## 0.10.0 - 2025-09-01
 

--- a/relm4/src/binding/widgets.rs
+++ b/relm4/src/binding/widgets.rs
@@ -42,11 +42,17 @@ impl_connect_binding!(gtk::Switch, bool, "active", switch);
 impl_connect_binding!(gtk::Spinner, bool, "spinning", spinner);
 impl_connect_binding!(gtk::Popover, bool, "visible", popover);
 impl_connect_binding!(gtk::Revealer, bool, "reveal-child", revealer);
+#[cfg(all(feature = "libadwaita", feature = "gnome_45"))]
+impl_connect_binding!(adw::SwitchRow, bool, "active", switch_row);
+#[cfg(feature = "libadwaita")]
+impl_connect_binding!(adw::ExpanderRow, bool, "expanded", expander_row);
 
 // f64 bindings
 impl_connect_binding!(gtk::SpinButton, f64, "value", spin_button);
 impl_connect_binding!(gtk::Adjustment, f64, "value", adjustment);
 impl_connect_binding!(gtk::ScaleButton, f64, "value", scale_button);
+#[cfg(all(feature = "libadwaita", feature = "gnome_45"))]
+impl_connect_binding!(adw::SpinRow, f64, "value", spin_row);
 
 // String bindings
 impl_connect_binding!(gtk::Label, String, "label", label);
@@ -58,3 +64,17 @@ impl_connect_binding!(gtk::StackPage, String, "name", stack_page, {
     let stack = gtk::Stack::default();
     stack.add_child(&gtk::Label::default())
 });
+#[cfg(feature = "libadwaita")]
+impl_connect_binding!(adw::SplitButton, String, "label", split_button);
+#[cfg(feature = "libadwaita")]
+impl_connect_binding!(adw::ButtonContent, String, "label", button_content);
+#[cfg(feature = "libadwaita")]
+impl_connect_binding!(adw::PreferencesRow, String, "title", preferences_row);
+#[cfg(feature = "libadwaita")]
+impl_connect_binding!(adw::ActionRow, String, "title", action_row);
+#[cfg(all(feature = "libadwaita", feature = "gnome_47"))]
+impl_connect_binding!(adw::ButtonRow, String, "title", button_row);
+#[cfg(feature = "libadwaita")]
+impl_connect_binding!(adw::WindowTitle, String, "title", window_title);
+#[cfg(all(feature = "libadwaita", feature = "gnome_44"))]
+impl_connect_binding!(adw::Banner, String, "title", banner);


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Adds bindings for the following Adwaita widgets:

- `bool`: `adw::SwitchRow`, `adw::ExpanderRow`
- `f64`: `adw::SpinRow`
- `String`: `adw::SplitButton`, `adw::ButtonContent`, `adw::PreferencesRow`, `adw::ActionRow`, `adw::ButtonRow`, `adw::WindowTitle`, `adw::Banner`

I decided against adding bindings for `adw::Avatar` or `adw::StatusPage` because they didn't really seem useful to me, but I can add those if wanted.

I also didn't add a `String` binding for `adw::EntryRow` or `adw::PasswordEntryRow`: It would be bound to the `title` property, but users may expect it to have been bound to the `text` property (from `gtk::Editable`). Relm4 doesn't include a binding implementation for `gtk::Entry` for what I assume are similar reasons.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
