### PR TITLE
Disable ability to focus on gkt4::ListItem in message_from_grid_view example.

### DIFF
--- a/examples/message_from_grid_view.rs
+++ b/examples/message_from_grid_view.rs
@@ -48,6 +48,7 @@ impl RelmGridItem for MyGridItem {
 
     fn setup(item: &gtk::ListItem) -> (gtk::Box, Widgets) {
         item.set_activatable(false);
+        item.set_focusable(false);
         relm4::view! {
             my_box = gtk::Box {
                 set_orientation: gtk::Orientation::Horizontal,

--- a/relm4/Cargo.toml
+++ b/relm4/Cargo.toml
@@ -125,3 +125,8 @@ required-features = ["libadwaita", "gnome_45"]
 name = "navigation_splitview_with_stack"
 path = "examples/navigation_splitview_with_stack.rs"
 required-features = ["libadwaita", "gnome_45"]
+
+[[example]]
+name = "message_from_grid_view"
+path = "examples/message_from_grid_view.rs"
+required-features = ["gtk/v4_12"]


### PR DESCRIPTION
# Summary

Further refine `message_from_grid_view` example. Disable ability to focus on `gkt4::ListItem`.
Address issue reported [here](https://github.com/Relm4/Relm4/issues/816#issuecomment-3690459872).

# Changes
- Disable ability to focus on `gkt4::ListItem` in `message_from_grid_view` example.
- Add declaration of `message_from_grid_view` example to `relm4/Cargo.toml` to be able to declare `gtk/v4_12` as `required-features` for the example. [`gtk4::ListItem#set_focusable`](https://docs.gtk.org/gtk4/method.ListItem.set_focusable.html) is was added only in GTK 4.12 and hidden behind feature flag in `gtk4` crate.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [ ] updated CHANGES.md
