### PR TITLE
Document `update_view` requirement on factory methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 + chore: adw::ToggleGroup factory over adw::Toggle & refactor nix
 + core: Implement container and factory traits for `adw::WrapBox`
++ docs: Document `update_view` requirement on factory methods
 
 ### Changed
 

--- a/relm4/src/factory/async/traits.rs
+++ b/relm4/src/factory/async/traits.rs
@@ -88,6 +88,15 @@ pub trait AsyncFactoryComponent:
     }
 
     /// Handles updates from a command.
+    ///
+    /// The default implementation of this method calls [`update_cmd`] followed by [`update_view`].
+    /// If you override this method while using the [`factory`] macro, you must remember to call
+    /// [`update_view`] in your implementation. Otherwise, the view will not reflect the updated
+    /// model.
+    ///
+    /// [`update_cmd`]: Self::update_cmd
+    /// [`update_view`]: Self::update_view
+    /// [`factory`]: relm4_macros::factory
     fn update_cmd_with_view(
         &mut self,
         widgets: &mut Self::Widgets,
@@ -105,6 +114,15 @@ pub trait AsyncFactoryComponent:
     fn update_view(&self, widgets: &mut Self::Widgets, sender: AsyncFactorySender<Self>) {}
 
     /// Updates the model and view. Optionally returns a command to run.
+    ///
+    /// The default implementation of this method calls [`update`] followed by [`update_view`].
+    /// If you override this method while using the [`factory`] macro, you must remember to call
+    /// [`update_view`] in your implementation. Otherwise, the view will not reflect the updated
+    /// model.
+    ///
+    /// [`update`]: Self::update
+    /// [`update_view`]: Self::update_view
+    /// [`factory`]: relm4_macros::factory
     fn update_with_view(
         &mut self,
         widgets: &mut Self::Widgets,

--- a/relm4/src/factory/sync/traits.rs
+++ b/relm4/src/factory/sync/traits.rs
@@ -64,6 +64,15 @@ pub trait FactoryComponent:
     fn update_cmd(&mut self, message: Self::CommandOutput, sender: FactorySender<Self>) {}
 
     /// Handles updates from a command.
+    ///
+    /// The default implementation of this method calls [`update_cmd`] followed by [`update_view`].
+    /// If you override this method while using the [`factory`] macro, you must remember to call
+    /// [`update_view`] in your implementation. Otherwise, the view will not reflect the updated
+    /// model.
+    ///
+    /// [`update_cmd`]: Self::update_cmd
+    /// [`update_view`]: Self::update_view
+    /// [`factory`]: relm4_macros::factory
     fn update_cmd_with_view(
         &mut self,
         widgets: &mut Self::Widgets,
@@ -79,6 +88,15 @@ pub trait FactoryComponent:
     fn update_view(&self, widgets: &mut Self::Widgets, sender: FactorySender<Self>) {}
 
     /// Updates the model and view. Optionally returns a command to run.
+    ///
+    /// The default implementation of this method calls [`update`] followed by [`update_view`].
+    /// If you override this method while using the [`factory`] macro, you must remember to call
+    /// [`update_view`] in your implementation. Otherwise, the view will not reflect the updated
+    /// model.
+    ///
+    /// [`update`]: Self::update
+    /// [`update_view`]: Self::update_view
+    /// [`factory`]: relm4_macros::factory
     fn update_with_view(
         &mut self,
         widgets: &mut Self::Widgets,


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Documents the need to call `update_view` in `update_with_view` and `update_cmd_with_view` on sync and async factories, bringing them in line with [the equivalent `Component` docs](https://docs.rs/relm4/0.10.0/relm4/component/trait.Component.html#method.update_with_view).

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
