### PR TITLE
Additional `SetChildExt` implementations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 + chore: adw::ToggleGroup factory over adw::Toggle & refactor nix
 + core: Implement container and factory traits for `adw::WrapBox`
 + docs: Document `update_view` requirement on factory methods
++ core: Implement container traits for `gtk::TreeExpander`, `gtk::MenuButton`, `gtk::SearchBar`, `gtk::Viewport`, and
+  `adw::Dialog`
 
 ### Changed
 

--- a/relm4/src/extensions/mod.rs
+++ b/relm4/src/extensions/mod.rs
@@ -175,7 +175,18 @@ container_child_impl! {
     gtk::Revealer,
     gtk::WindowHandle,
     gtk::Expander,
-    gtk::AspectFrame
+    gtk::AspectFrame,
+    gtk::TreeExpander,
+    gtk::SearchBar,
+    gtk::Viewport
+}
+
+#[cfg(feature = "gnome_42")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gnome_42")))]
+mod gnome_42 {
+    use super::ContainerChild;
+
+    container_child_impl!(gtk::MenuButton);
 }
 
 #[cfg(feature = "libadwaita")]
@@ -217,6 +228,13 @@ mod libadwaita {
             adw::OverlaySplitView,
             adw::ToolbarView
         }
+    }
+
+    #[cfg(all(feature = "libadwaita", feature = "gnome_46"))]
+    mod gnome_46 {
+        use super::ContainerChild;
+
+        container_child_impl!(adw::Dialog);
     }
 
     #[cfg(all(feature = "libadwaita", feature = "gnome_48"))]

--- a/relm4/src/extensions/set_child.rs
+++ b/relm4/src/extensions/set_child.rs
@@ -42,8 +42,19 @@ set_child_impl!(
     gtk::Revealer,
     gtk::WindowHandle,
     gtk::Expander,
-    gtk::AspectFrame
+    gtk::AspectFrame,
+    gtk::TreeExpander,
+    gtk::SearchBar,
+    gtk::Viewport
 );
+
+#[cfg(feature = "gnome_42")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gnome_42")))]
+mod gnome_42 {
+    use super::RelmSetChildExt;
+
+    set_child_impl!(gtk::MenuButton);
+}
 
 #[cfg(feature = "libadwaita")]
 #[cfg_attr(docsrs, doc(cfg(feature = "libadwaita")))]
@@ -88,6 +99,15 @@ mod libadwaita {
         set_child_content_impl!(adw::NavigationSplitView);
         set_child_content_impl!(adw::OverlaySplitView);
         set_child_content_impl!(adw::ToolbarView);
+    }
+
+    #[cfg(all(feature = "libadwaita", feature = "gnome_46"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "libadwaita", feature = "gnome_46"))))]
+    mod gnome_46 {
+        use super::RelmSetChildExt;
+        use adw::prelude::AdwDialogExt;
+
+        set_child_impl!(adw::Dialog);
     }
 }
 


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Implements `SetChildExt` and `ContainerChild` for the following objects:

- `gtk::TreeExpander`
- `gtk::MenuButton` ([gated behind GTK 4.6](https://docs.gtk.org/gtk4/method.MenuButton.set_child.html))
- `gtk::SearchBar`
- `gtk::Viewport`
- `adw::Dialog` ([gated behind Adwaita 1.5](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Dialog.html))

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
