### PR TITLE
Allow setting conditional widget stack properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 + docs: Document `update_view` requirement on factory methods
 + core: Implement container traits for `gtk::TreeExpander`, `gtk::MenuButton`, `gtk::SearchBar`, `gtk::Viewport`, and
   `adw::Dialog`
++ macros: Allow setting conditional widget `gtk::Stack` properties
 
 ### Changed
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,12 @@ keyboard shortcuts and [menus](https://docs.rs/gio/latest/gio/struct.Menu.html).
 
 A [`MessageDialog`](https://docs.rs/gtk4/latest/gtk4/struct.MessageDialog.html) made of multiple [components].
 
+### `conditional_properties.rs`
+
+Set properties on a
+[conditional widget](https://relm4.org/book/stable/component_macro/reference.html#conditional-widgets)'s
+[`Stack`](https://docs.rs/gtk4/latest/gtk4/struct.Stack.html).
+
 ### `data_binding.rs`
 
 Automatically update the UI using [data binding](https://docs.rs/relm4/latest/relm4/binding/index.html).

--- a/examples/conditional_properties.rs
+++ b/examples/conditional_properties.rs
@@ -1,0 +1,94 @@
+use gtk::prelude::*;
+use relm4::prelude::*;
+
+struct AppModel {
+    left: bool,
+    homogeneous: bool,
+}
+
+#[derive(Debug)]
+enum AppMsg {
+    SetLeft(bool),
+    SetHomogeneous(bool),
+}
+
+#[relm4::component]
+impl SimpleComponent for AppModel {
+    type Init = ();
+    type Input = AppMsg;
+    type Output = ();
+
+    view! {
+        gtk::Window {
+            set_title: Some("Conditional Properties Example"),
+            set_default_size: (250, 125),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_spacing: 5,
+                set_margin_all: 5,
+
+                // Create a conditional widget stack.
+                #[transition(SlideLeftRight)]
+                if model.left {
+                    gtk::Label {
+                        set_halign: gtk::Align::Start,
+                        set_label: "This is\nthe left\npage!"
+                    }
+                } else {
+                    gtk::Label {
+                        set_halign: gtk::Align::Start,
+                        set_label: "This is the right page!"
+                   }
+                } -> {
+                    // You can set the `gtk::Stack`'s properties here.
+                    set_halign: gtk::Align::Center,
+                    #[watch]
+                    set_hhomogeneous: model.homogeneous,
+                    #[watch]
+                    set_vhomogeneous: model.homogeneous,
+                },
+
+                gtk::CheckButton {
+                    set_label: Some("Show left stack page"),
+                    set_active: model.left,
+                    connect_toggled[sender] => move |checkbox| sender.input(AppMsg::SetLeft(checkbox.is_active())),
+                },
+
+                gtk::CheckButton {
+                    set_label: Some("Homogeneous stack"),
+                    set_active: model.homogeneous,
+                    connect_toggled[sender] => move |checkbox| sender.input(AppMsg::SetHomogeneous(checkbox.is_active())),
+                },
+            }
+        }
+    }
+
+    fn init(
+        _init: Self::Init,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = AppModel {
+            left: true,
+            homogeneous: true,
+        };
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>) {
+        match msg {
+            AppMsg::SetLeft(left) => self.left = left,
+            AppMsg::SetHomogeneous(homogeneous) => self.homogeneous = homogeneous,
+        }
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.conditional_properties");
+    relm4::set_global_css("stack { border: 1px black solid; }");
+    app.run::<AppModel>(());
+}

--- a/relm4-macros/src/widgets/codegen/assign/conditional_widget.rs
+++ b/relm4-macros/src/widgets/codegen/assign/conditional_widget.rs
@@ -53,5 +53,9 @@ impl ConditionalWidget {
                 }
             }
         }
+
+        if let Some(properties) = &self.properties {
+            properties.assign_stream(&mut info, sender_name);
+        }
     }
 }

--- a/relm4-macros/src/widgets/codegen/destructure_fields.rs
+++ b/relm4-macros/src/widgets/codegen/destructure_fields.rs
@@ -63,6 +63,10 @@ impl ConditionalWidget {
                 }
             }
         }
+
+        if let Some(properties) = &self.properties {
+            properties.destructure_stream(stream);
+        }
     }
 }
 

--- a/relm4-macros/src/widgets/codegen/error.rs
+++ b/relm4-macros/src/widgets/codegen/error.rs
@@ -66,6 +66,10 @@ impl ConditionalWidget {
                 }
             }
         }
+
+        if let Some(properties) = &self.properties {
+            properties.error_stream(stream, &self.name);
+        }
     }
 }
 

--- a/relm4-macros/src/widgets/codegen/init.rs
+++ b/relm4-macros/src/widgets/codegen/init.rs
@@ -109,5 +109,9 @@ impl ConditionalWidget {
                 }
             }
         }
+
+        if let Some(properties) = &self.properties {
+            properties.init_stream(stream);
+        }
     }
 }

--- a/relm4-macros/src/widgets/codegen/return_fields.rs
+++ b/relm4-macros/src/widgets/codegen/return_fields.rs
@@ -63,6 +63,10 @@ impl ConditionalWidget {
                 }
             }
         }
+
+        if let Some(properties) = &self.properties {
+            properties.return_stream(stream);
+        }
     }
 }
 

--- a/relm4-macros/src/widgets/codegen/struct_fields.rs
+++ b/relm4-macros/src/widgets/codegen/struct_fields.rs
@@ -87,6 +87,10 @@ impl ConditionalWidget {
                 }
             }
         }
+
+        if let Some(properties) = &self.properties {
+            properties.struct_fields_stream(stream, vis);
+        }
     }
 }
 

--- a/relm4-macros/src/widgets/codegen/update_view.rs
+++ b/relm4-macros/src/widgets/codegen/update_view.rs
@@ -161,6 +161,10 @@ impl ConditionalWidget {
             let current_page = #w_name.visible_child_name().map_or("".to_string(), |s| s.as_str().to_string());
             #w_name.set_visible_child_name(#brach_stream);
         });
+
+        if let Some(properties) = &self.properties {
+            properties.update_view_stream(stream, w_name, None, model_name, false);
+        }
     }
 }
 

--- a/relm4-macros/src/widgets/mod.rs
+++ b/relm4-macros/src/widgets/mod.rs
@@ -167,6 +167,7 @@ struct ConditionalWidget {
     name: Ident,
     args: Option<Args<Expr>>,
     branches: ConditionalBranches,
+    properties: Option<Properties>,
 }
 
 #[derive(Debug)]

--- a/relm4-macros/src/widgets/parse/conditional_widget.rs
+++ b/relm4-macros/src/widgets/parse/conditional_widget.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream as TokenStream2;
 use syn::parse::ParseStream;
-use syn::{Error, Expr, Ident, Path, Token};
+use syn::{Error, Expr, Ident, Path, Token, braced};
 
 use crate::args::Args;
 use crate::widgets::parse_util::{self, attr_twice_error};
-use crate::widgets::{Attr, Attrs, ConditionalBranches, ConditionalWidget, ParseError};
+use crate::widgets::{Attr, Attrs, ConditionalBranches, ConditionalWidget, ParseError, Properties};
 
 type ConditionalAttrs = (
     Option<Ident>,
@@ -53,29 +53,36 @@ impl ConditionalWidget {
             parse_util::unique_ident_from_parts(["conditional_widget"])
         };
 
-        if input.peek(Token![if]) {
-            let branches = ConditionalBranches::parse_if(input)?;
-            Ok(Self {
-                doc_attr,
-                transition,
-                assign_wrapper,
-                name,
-                args,
-                branches,
-            })
+        let branches = if input.peek(Token![if]) {
+            ConditionalBranches::parse_if(input)?
         } else if input.peek(Token![match]) {
-            let branches = ConditionalBranches::parse_match(input)?;
-            Ok(Self {
-                doc_attr,
-                transition,
-                assign_wrapper,
-                name,
-                args,
-                branches,
-            })
+            ConditionalBranches::parse_match(input)?
         } else {
-            Err(input.error("Expected `if` or `match`").into())
-        }
+            Err::<_, ParseError>(input.error("Expected `if` or `match`").into())?
+        };
+
+        let properties = if input.peek(Token![->]) {
+            let _arrow: Token![->] = input.parse()?;
+            Some(Self::parse_properties(input)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            doc_attr,
+            transition,
+            assign_wrapper,
+            name,
+            args,
+            branches,
+            properties,
+        })
+    }
+
+    fn parse_properties(input: ParseStream<'_>) -> syn::Result<Properties> {
+        let inner;
+        let _token = braced!(inner in input);
+        Ok(Properties::parse(&inner))
     }
 
     fn process_attrs(attrs: Option<Attrs>) -> Result<ConditionalAttrs, ParseError> {


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Allows setting conditional widget stack properties:

```rust
view! {
	if model.foo {
		gtk::Label { set_label: "foo" }
	} else {
		gtk::Label { set_label: "bar" }
	} -> {
		#[watch]
		set_halign: model.stack_align;

		set_hhomogeneous: false,
	}
}
```

Fixes #624.

This is my first contribution to the `view` macro, so I might not have done things optimally.

There's a lot to discuss before this is merged:

- Is this the right syntax? It's similar to the returned widget syntax, but doesn't allow specifying a name or type.
- Do we want to expose *all* of the `gtk::Stack`'s properties? Things like [`add_child`](https://docs.gtk.org/gtk4/method.Stack.add_child.html) and [`remove`](https://docs.gtk.org/gtk4/method.Stack.remove.html) could cause issues, *especially* the latter.
- Should we keep `#[transition]`, given that this PR makes it possible to set the `Stack`'s transition property directly?

If this is merged, the book will need to be updated.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
