### PR TITLE
Deprecate `#[transition]` on conditional widgets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 ### Changed
 
++ macros: Deprecate `#[transition]` conditional widget attribute
+
 ### Fixed
 
 ## 0.11.0 - 2026-05-10

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 ### Changed
 
 + macros: Deprecate `#[transition]` conditional widget attribute
++ examples: Replace deprecated `#[transition]` attribute
 
 ### Fixed
 

--- a/examples/conditional_properties.rs
+++ b/examples/conditional_properties.rs
@@ -29,7 +29,6 @@ impl SimpleComponent for AppModel {
                 set_margin_all: 5,
 
                 // Create a conditional widget stack.
-                #[transition(SlideLeftRight)]
                 if model.left {
                     gtk::Label {
                         set_halign: gtk::Align::Start,
@@ -42,6 +41,7 @@ impl SimpleComponent for AppModel {
                    }
                 } -> {
                     // You can set the `gtk::Stack`'s properties here.
+                    set_transition_type: gtk::StackTransitionType::SlideLeftRight,
                     set_halign: gtk::Align::Center,
                     #[watch]
                     set_hhomogeneous: model.homogeneous,

--- a/examples/macro_reference.rs
+++ b/examples/macro_reference.rs
@@ -74,8 +74,6 @@ impl SimpleComponent for App {
                 },
 
                 // A conditional widget
-                // Alternative: #[transition = "SlideLeft"]
-                #[transition(SlideLeft)]
                 append = if counter.value.is_multiple_of(2) {
                     gtk::Label {
                         set_label: "Value is even",
@@ -88,9 +86,10 @@ impl SimpleComponent for App {
                     gtk::Label {
                         set_label: "Value is odd",
                     }
+                } -> {
+                    set_transition_type: gtk::StackTransitionType::SlideLeft,
                 },
 
-                #[transition = "SlideRight"]
                 append: match_stack = match counter.value {
                     (0..=2) => {
                         gtk::Label {
@@ -102,6 +101,8 @@ impl SimpleComponent for App {
                             set_label: "Value is higher than 2",
                         }
                     },
+                } -> {
+                    set_transition_type: gtk::StackTransitionType::SlideRight,
                 },
 
                 append = &gtk::Label,

--- a/relm4-macros/src/widgets/codegen/init.rs
+++ b/relm4-macros/src/widgets/codegen/init.rs
@@ -92,7 +92,9 @@ impl ConditionalWidget {
 
         if let Some(transition) = &self.transition {
             stream.extend(quote_spanned! {
+                // emit deprecation warning
                 transition.span() =>
+                    const _: () = ::relm4::transition();
                     #name.set_transition_type(#gtk_import::StackTransitionType:: #transition);
             });
         }

--- a/relm4-macros/src/widgets/parse/conditional_widget.rs
+++ b/relm4-macros/src/widgets/parse/conditional_widget.rs
@@ -125,8 +125,9 @@ impl ConditionalWidget {
                     _ => {
                         return Err(Error::new(
                             attr.span(),
-                            "Conditional widgets can only have docs and `name` or `transition` as attribute.",
-                        ).into());
+                            "Conditional widgets can only have docs and `name` as attribute.",
+                        )
+                        .into());
                     }
                 }
             }

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -43,6 +43,8 @@ pub mod binding;
 pub mod component;
 pub mod factory;
 pub mod loading_widgets;
+#[doc(hidden)]
+pub mod macro_helper;
 pub mod shared_state;
 pub mod typed_view;
 
@@ -252,9 +254,3 @@ pub fn set_global_css_from_file_with_priority<P: AsRef<std::path::Path>>(
 pub fn set_global_css_from_file<P: AsRef<std::path::Path>>(path: P) -> Result<(), std::io::Error> {
     set_global_css_from_file_with_priority(path, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION)
 }
-
-/// Dummy function for marking the `#[transition]` macro attribute as deprecated.
-/// See https://stackoverflow.com/a/77267752.
-#[deprecated = "The `#[transition]` macro attribute is deprecated. Call `set_transition_type` on the returned widget instead."]
-#[doc(hidden)]
-pub const fn transition() {}

--- a/relm4/src/lib.rs
+++ b/relm4/src/lib.rs
@@ -252,3 +252,9 @@ pub fn set_global_css_from_file_with_priority<P: AsRef<std::path::Path>>(
 pub fn set_global_css_from_file<P: AsRef<std::path::Path>>(path: P) -> Result<(), std::io::Error> {
     set_global_css_from_file_with_priority(path, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION)
 }
+
+/// Dummy function for marking the `#[transition]` macro attribute as deprecated.
+/// See https://stackoverflow.com/a/77267752.
+#[deprecated = "The `#[transition]` macro attribute is deprecated. Call `set_transition_type` on the returned widget instead."]
+#[doc(hidden)]
+pub const fn transition() {}

--- a/relm4/src/macro_helper.rs
+++ b/relm4/src/macro_helper.rs
@@ -1,0 +1,4 @@
+/// Dummy function for marking the `#[transition]` macro attribute as deprecated.
+/// See <https://stackoverflow.com/a/77267752>.
+#[deprecated = "The `#[transition]` macro attribute is deprecated. Call `set_transition_type` on the returned widget instead."]
+pub const fn transition() {}


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Deprecates the `#[transition]` conditional widget attribute as suggested in [this comment on #915](https://github.com/Relm4/Relm4/pull/915#issuecomment-4444190004).

If this gets merged, I'll update the book to show the new method.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
