### PR TITLE
Conditional root widgets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 + core: Implement container traits for `gtk::TreeExpander`, `gtk::MenuButton`, `gtk::SearchBar`, `gtk::Viewport`, and
   `adw::Dialog`
 + macros: Allow setting conditional widget `gtk::Stack` properties
++ macros: Conditional root widgets
 
 ### Changed
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,11 @@ Set properties on a
 [conditional widget](https://relm4.org/book/stable/component_macro/reference.html#conditional-widgets)'s
 [`Stack`](https://docs.rs/gtk4/latest/gtk4/struct.Stack.html).
 
+### `conditional_root.rs`
+
+Use a [conditional widget](https://relm4.org/book/stable/component_macro/reference.html#conditional-widgets) as a
+[component][components]'s root widget.
+
 ### `data_binding.rs`
 
 Automatically update the UI using [data binding](https://docs.rs/relm4/latest/relm4/binding/index.html).

--- a/examples/conditional_root.rs
+++ b/examples/conditional_root.rs
@@ -1,0 +1,102 @@
+use relm4::gtk::prelude::*;
+use relm4::prelude::*;
+pub struct App(Controller<Inner>);
+
+#[relm4::component(pub)]
+impl SimpleComponent for App {
+    type Init = ();
+    type Input = ();
+    type Output = ();
+
+    view! {
+        #[root]
+        window = gtk::Window {
+            set_title: Some("Conditional Root Example"),
+            set_default_size: (200, 150),
+
+            gtk::Box {
+                set_orientation: gtk::Orientation::Vertical,
+                set_spacing: 5,
+                set_margin_all: 5,
+                set_align: gtk::Align::Center,
+
+                #[local_ref]
+                inner -> gtk::Stack {},
+
+                gtk::Button {
+                    set_label: "Toggle",
+                    connect_clicked => (),
+                }
+            }
+
+        }
+    }
+
+    fn init(
+        _init: Self::Init,
+        root: Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = Self(Inner::builder().launch(()).detach());
+        let inner = model.0.widget();
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, _message: Self::Input, _sender: ComponentSender<Self>) {
+        self.0
+            .sender()
+            .send(())
+            .expect("Failed to send message to Inner component!");
+    }
+}
+
+pub struct Inner {
+    state: bool,
+    counter: usize,
+}
+
+#[relm4::component(pub)]
+impl SimpleComponent for Inner {
+    type Init = ();
+    type Input = ();
+    type Output = ();
+
+    view! {
+        if model.state {
+            gtk::Label {
+                #[watch]
+                set_label: &format!("Toggled {} times", model.counter),
+            }
+        } else {
+            gtk::Label {
+                set_label: "False",
+            }
+        }
+    }
+
+    fn init(
+        _init: Self::Init,
+        root: Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = Self {
+            state: true,
+            counter: 0,
+        };
+        let widgets = view_output!();
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, _msg: Self::Input, _sender: ComponentSender<Self>) {
+        self.state = !self.state;
+        self.counter += 1;
+    }
+}
+
+fn main() {
+    let app = RelmApp::new("relm4.example.conditional_root");
+    app.run::<App>(());
+}

--- a/relm4-macros/src/token_streams.rs
+++ b/relm4-macros/src/token_streams.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
 use syn::{Error, Ident, Visibility};
 
-use crate::widgets::{TopLevelWidget, ViewWidgets, Widget};
+use crate::widgets::{TopLevelInner, TopLevelWidget, ViewWidgets};
 
 #[derive(Default)]
 pub(super) struct TokenStreams {
@@ -53,7 +53,7 @@ impl ViewWidgets {
     }
 
     /// Get the root widget
-    pub(super) fn get_root_widget(&self) -> syn::Result<&Widget> {
+    pub(super) fn get_root_widget(&self) -> syn::Result<&TopLevelInner> {
         self.top_level_widgets
             .iter()
             .find(|w| w.root_attr.is_some())
@@ -69,7 +69,11 @@ impl ViewWidgets {
     /// Generate root type for `Root` parameter in `Component` impl
     pub(super) fn root_type(&self) -> TokenStream2 {
         match self.get_root_widget() {
-            Ok(root_widget) => root_widget.func_type_token_stream(),
+            Ok(TopLevelInner::Widget(root_widget)) => root_widget.func_type_token_stream(),
+            Ok(TopLevelInner::ConditionalWidget(_)) => {
+                let gtk_import = crate::gtk_import();
+                quote! { #gtk_import::Stack }.to_token_stream()
+            }
             Err(err) => err.to_compile_error(),
         }
     }
@@ -77,7 +81,7 @@ impl ViewWidgets {
     /// Get the name of the root widget
     pub(super) fn root_name(&self) -> TokenStream2 {
         match self.get_root_widget() {
-            Ok(root_widget) => root_widget.name.to_token_stream(),
+            Ok(inner) => inner.name().to_token_stream(),
             Err(err) => err.to_compile_error(),
         }
     }
@@ -96,7 +100,7 @@ impl TopLevelWidget {
     }
 }
 
-impl Widget {
+impl TopLevelInner {
     pub(super) fn init_token_generation(
         &self,
         streams: &mut TokenStreams,
@@ -110,15 +114,24 @@ impl Widget {
             sender_name,
         } = trait_impl_details;
 
-        let name = &self.name;
+        let name = &self.name();
 
         // Initialize the root
-        if generate_root_init_stream {
+        match (self, generate_root_init_stream) {
             // For the `component` macro
-            self.init_root_init_streams(&mut streams.init_root, &mut streams.init);
-        } else {
+            (Self::Widget(widget), true) => {
+                widget.init_root_init_streams(&mut streams.init_root, &mut streams.init)
+            }
             // For the `view!` macro
-            self.init_stream(&mut streams.init);
+            (Self::Widget(widget), false) => widget.init_stream(&mut streams.init),
+            // `component`
+            (Self::ConditionalWidget(conditional), true) => {
+                conditional.init_root_init_streams(&mut streams.init_root, &mut streams.init)
+            }
+            // `view!`
+            (Self::ConditionalWidget(conditional), false) => {
+                conditional.init_stream(&mut streams.init)
+            }
         }
 
         #[cfg(feature = "relm4")]
@@ -126,17 +139,35 @@ impl Widget {
             use relm4::RelmContainerExt as _;
         });
 
-        self.error_stream(&mut streams.error);
-        self.start_assign_stream(&mut streams.assign, sender_name);
-        self.init_conditional_init_stream(&mut streams.assign, model_name);
-        self.struct_fields_stream(&mut streams.struct_fields, vis);
-        self.return_stream(&mut streams.return_fields);
-        self.destructure_stream(&mut streams.destructure_fields);
-        self.init_update_view_stream(&mut streams.update_view, model_name);
+        match self {
+            TopLevelInner::Widget(widget) => {
+                widget.error_stream(&mut streams.error);
+                widget.start_assign_stream(&mut streams.assign, sender_name);
+                widget.init_conditional_init_stream(&mut streams.assign, model_name);
+                widget.struct_fields_stream(&mut streams.struct_fields, vis);
+                widget.return_stream(&mut streams.return_fields);
+                widget.destructure_stream(&mut streams.destructure_fields);
+                widget.init_update_view_stream(&mut streams.update_view, model_name);
+            }
+            TopLevelInner::ConditionalWidget(conditional) => {
+                conditional.error_stream(&mut streams.error);
+                conditional.start_assign_stream(&mut streams.assign, sender_name);
+                conditional.init_conditional_init_stream(&mut streams.assign, model_name);
+                conditional.struct_fields_stream(&mut streams.struct_fields, vis);
+                conditional.return_stream(&mut streams.return_fields);
+                conditional.destructure_stream(&mut streams.destructure_fields);
+                conditional.update_view_stream(&mut streams.update_view, model_name);
+            }
+        }
 
         // Rename the `root` to the actual widget name
         if generate_root_init_stream {
-            let mut_token = self.mutable.as_ref();
+            let mut_token = if let TopLevelInner::Widget(widget) = self {
+                widget.mutable.as_ref()
+            } else {
+                None
+            };
+
             if let Some(root_name) = root_name {
                 streams.rename_root.extend(quote! {
                     let #mut_token #name = #root_name.clone();

--- a/relm4-macros/src/widgets/codegen/assign/conditional_widget.rs
+++ b/relm4-macros/src/widgets/codegen/assign/conditional_widget.rs
@@ -1,12 +1,35 @@
-use quote::{quote, quote_spanned};
-use syn::Ident;
-
 use crate::widgets::{ConditionalBranches, ConditionalWidget, PropertyName};
+use proc_macro2::Span;
+use quote::{quote, quote_spanned};
+use syn::__private::TokenStream2;
+use syn::Ident;
+use syn::spanned::Spanned;
 
 use super::AssignInfo;
 
 impl ConditionalWidget {
-    pub(super) fn assign_stream<'a>(
+    pub(crate) fn start_assign_stream<'a>(
+        &'a self,
+        stream: &'a mut TokenStream2,
+        sender_name: &'a Ident,
+    ) {
+        let w_name = &self.name;
+        let mut info = AssignInfo {
+            stream,
+            widget_name: w_name,
+            template_path: None,
+            is_conditional: true,
+        };
+        let span = info.stream.span();
+
+        self.assign_branches(&mut info, sender_name, span);
+
+        if let Some(properties) = &self.properties {
+            properties.assign_stream(&mut info, sender_name);
+        }
+    }
+
+    pub(crate) fn assign_stream<'a>(
         &'a self,
         info: &mut AssignInfo<'a>,
         p_name: &PropertyName,
@@ -39,23 +62,33 @@ impl ConditionalWidget {
             template_path: None,
             is_conditional: true,
         };
+
+        self.assign_branches(&mut info, sender_name, span);
+
+        if let Some(properties) = &self.properties {
+            properties.assign_stream(&mut info, sender_name);
+        }
+    }
+
+    pub(crate) fn assign_branches<'a>(
+        &'a self,
+        info: &mut AssignInfo<'a>,
+        sender_name: &'a Ident,
+        span: Span,
+    ) {
         match &self.branches {
             ConditionalBranches::If(if_branches) => {
                 for branch in if_branches {
-                    let p_name = PropertyName::Ident(Ident::new("add_named", p_name.span()));
-                    branch.widget.assign_stream(&mut info, &p_name, sender_name);
+                    let p_name = PropertyName::Ident(Ident::new("add_named", span));
+                    branch.widget.assign_stream(info, &p_name, sender_name);
                 }
             }
             ConditionalBranches::Match((_, _, match_arms)) => {
                 for arm in match_arms {
-                    let p_name = PropertyName::Ident(Ident::new("add_named", p_name.span()));
-                    arm.widget.assign_stream(&mut info, &p_name, sender_name);
+                    let p_name = PropertyName::Ident(Ident::new("add_named", span));
+                    arm.widget.assign_stream(info, &p_name, sender_name);
                 }
             }
-        }
-
-        if let Some(properties) = &self.properties {
-            properties.assign_stream(&mut info, sender_name);
         }
     }
 }

--- a/relm4-macros/src/widgets/codegen/conditional_init.rs
+++ b/relm4-macros/src/widgets/codegen/conditional_init.rs
@@ -76,6 +76,18 @@ impl Widget {
 }
 
 impl ConditionalWidget {
+    pub(crate) fn init_conditional_init_stream(
+        &self,
+        stream: &mut TokenStream2,
+        model_name: &Ident,
+    ) {
+        if let Some(properties) = &self.properties {
+            let w_name = &self.name;
+            properties.conditional_init_stream(stream, w_name, model_name, true);
+        }
+        self.conditional_init_stream(stream, model_name);
+    }
+
     fn conditional_init_stream(&self, stream: &mut TokenStream2, model_name: &Ident) {
         let brach_stream = match &self.branches {
             ConditionalBranches::If(if_branches) => {

--- a/relm4-macros/src/widgets/codegen/destructure_fields.rs
+++ b/relm4-macros/src/widgets/codegen/destructure_fields.rs
@@ -46,7 +46,7 @@ impl Widget {
 }
 
 impl ConditionalWidget {
-    fn destructure_stream(&self, stream: &mut TokenStream2) {
+    pub(crate) fn destructure_stream(&self, stream: &mut TokenStream2) {
         let name = &self.name;
 
         stream.extend(quote! { #name, });

--- a/relm4-macros/src/widgets/codegen/error.rs
+++ b/relm4-macros/src/widgets/codegen/error.rs
@@ -53,7 +53,7 @@ impl Widget {
 }
 
 impl ConditionalWidget {
-    fn error_stream(&self, stream: &mut TokenStream2) {
+    pub(crate) fn error_stream(&self, stream: &mut TokenStream2) {
         match &self.branches {
             ConditionalBranches::If(if_branches) => {
                 for branch in if_branches {

--- a/relm4-macros/src/widgets/codegen/init.rs
+++ b/relm4-macros/src/widgets/codegen/init.rs
@@ -81,7 +81,21 @@ impl Widget {
 }
 
 impl ConditionalWidget {
-    fn init_stream(&self, stream: &mut TokenStream2) {
+    pub(crate) fn init_root_init_streams(
+        &self,
+        init_root_stream: &mut TokenStream2,
+        init_stream: &mut TokenStream2,
+    ) {
+        let gtk_import = crate::gtk_import();
+
+        init_root_stream.extend(quote! {
+            #gtk_import::Stack::default()
+        });
+
+        self.other_init_stream(init_stream)
+    }
+
+    pub(crate) fn init_stream(&self, stream: &mut TokenStream2) {
         let name = &self.name;
         let gtk_import = crate::gtk_import();
 
@@ -89,6 +103,13 @@ impl ConditionalWidget {
             name.span() =>
                 let #name = #gtk_import::Stack::default();
         });
+
+        self.other_init_stream(stream);
+    }
+
+    fn other_init_stream(&self, stream: &mut TokenStream2) {
+        let name = &self.name;
+        let gtk_import = crate::gtk_import();
 
         if let Some(transition) = &self.transition {
             stream.extend(quote_spanned! {

--- a/relm4-macros/src/widgets/codegen/return_fields.rs
+++ b/relm4-macros/src/widgets/codegen/return_fields.rs
@@ -46,7 +46,7 @@ impl Widget {
 }
 
 impl ConditionalWidget {
-    fn return_stream(&self, stream: &mut TokenStream2) {
+    pub(crate) fn return_stream(&self, stream: &mut TokenStream2) {
         let name = &self.name;
 
         stream.extend(quote! { #name, });

--- a/relm4-macros/src/widgets/codegen/struct_fields.rs
+++ b/relm4-macros/src/widgets/codegen/struct_fields.rs
@@ -57,7 +57,7 @@ impl Widget {
 }
 
 impl ConditionalWidget {
-    fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
+    pub(crate) fn struct_fields_stream(&self, stream: &mut TokenStream2, vis: &Option<Visibility>) {
         let name = &self.name;
         let gtk_import = crate::gtk_import();
 

--- a/relm4-macros/src/widgets/codegen/update_view.rs
+++ b/relm4-macros/src/widgets/codegen/update_view.rs
@@ -100,7 +100,7 @@ impl Widget {
 }
 
 impl ConditionalWidget {
-    fn update_view_stream(&self, stream: &mut TokenStream2, model_name: &Ident) {
+    pub(crate) fn update_view_stream(&self, stream: &mut TokenStream2, model_name: &Ident) {
         let brach_stream = match &self.branches {
             ConditionalBranches::If(if_branches) => {
                 let mut stream = TokenStream2::new();

--- a/relm4-macros/src/widgets/codegen/util/widget.rs
+++ b/relm4-macros/src/widgets/codegen/util/widget.rs
@@ -1,4 +1,4 @@
-use crate::widgets::ViewWidgets;
+use crate::widgets::{TopLevelInner, ViewWidgets};
 
 impl ViewWidgets {
     /// Get a mutable reference to the root widget
@@ -7,8 +7,9 @@ impl ViewWidgets {
             .top_level_widgets
             .iter_mut()
             .find(|w| w.root_attr.is_some())
+            && let TopLevelInner::Widget(widget) = &mut root_widget.inner
         {
-            root_widget.inner.name_assigned_by_user = true;
+            widget.name_assigned_by_user = true;
         }
     }
 }

--- a/relm4-macros/src/widgets/mod.rs
+++ b/relm4-macros/src/widgets/mod.rs
@@ -19,7 +19,22 @@ pub(super) struct ViewWidgets {
 #[derive(Debug)]
 pub(super) struct TopLevelWidget {
     pub(super) root_attr: Option<Ident>,
-    pub(super) inner: Widget,
+    pub(super) inner: TopLevelInner,
+}
+
+#[derive(Debug)]
+pub(super) enum TopLevelInner {
+    Widget(Widget),
+    ConditionalWidget(ConditionalWidget),
+}
+
+impl TopLevelInner {
+    pub(super) fn name(&self) -> &Ident {
+        match self {
+            TopLevelInner::Widget(widget) => &widget.name,
+            TopLevelInner::ConditionalWidget(widget) => &widget.name,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -84,7 +99,7 @@ struct ClosureSignalHandler {
 }
 
 #[derive(Debug)]
-enum PropertyName {
+pub(super) enum PropertyName {
     Ident(Ident),
     Path(Path),
     RelmContainerExtAssign(Span2),
@@ -160,7 +175,7 @@ struct ReturnedWidget {
 }
 
 #[derive(Debug)]
-struct ConditionalWidget {
+pub(super) struct ConditionalWidget {
     doc_attr: Option<TokenStream2>,
     transition: Option<Ident>,
     assign_wrapper: Option<Path>,

--- a/relm4-macros/src/widgets/parse/top_level_widget.rs
+++ b/relm4-macros/src/widgets/parse/top_level_widget.rs
@@ -1,10 +1,10 @@
-use syn::parse::ParseStream;
-
 use crate::util;
 use crate::widgets::{
-    Attr, Attrs, Properties, Property, PropertyName, PropertyType, TopLevelWidget, Widget,
-    WidgetAttr, WidgetFunc, WidgetTemplateAttr, parse_util,
+    Attr, Attrs, ConditionalWidget, ParseError, Properties, Property, PropertyName, PropertyType,
+    TopLevelInner, TopLevelWidget, Widget, WidgetAttr, WidgetFunc, WidgetTemplateAttr, parse_util,
 };
+use syn::Token;
+use syn::parse::ParseStream;
 
 impl TopLevelWidget {
     pub(super) fn parse(input: ParseStream<'_>) -> Self {
@@ -30,9 +30,8 @@ impl TopLevelWidget {
             (None, None)
         };
 
-        let inner = match Widget::parse(input, attributes, None) {
-            Ok(inner) => inner,
-            Err(err) => Widget {
+        let inner = TopLevelInner::parse(input, attributes).unwrap_or_else(|err| {
+            TopLevelInner::Widget(Widget {
                 doc_attr: None,
                 attr: WidgetAttr::None,
                 template_attr: WidgetTemplateAttr::None,
@@ -58,9 +57,27 @@ impl TopLevelWidget {
                 ref_token: None,
                 deref_token: None,
                 returned_widget: None,
-            },
-        };
+            })
+        });
 
         Self { root_attr, inner }
+    }
+}
+
+impl TopLevelInner {
+    fn parse(input: ParseStream<'_>, attributes: Option<Attrs>) -> Result<Self, ParseError> {
+        let conditional = if input.peek2(Token![=]) {
+            // `name = if ...`
+            input.peek3(Token![if]) || input.peek3(Token![match])
+        } else {
+            // `if ...`
+            input.peek(Token![if]) || input.peek(Token![match])
+        };
+
+        Ok(if conditional {
+            Self::ConditionalWidget(ConditionalWidget::parse(input, attributes, None)?)
+        } else {
+            Self::Widget(Widget::parse(input, attributes, None)?)
+        })
     }
 }

--- a/relm4-macros/tests/conditional_root.rs
+++ b/relm4-macros/tests/conditional_root.rs
@@ -1,0 +1,73 @@
+use relm4::ComponentController;
+use relm4::gtk::prelude::*;
+use relm4::{Component, ComponentParts, ComponentSender, Controller, SimpleComponent, gtk};
+pub struct App(Controller<Inner>);
+
+#[relm4_macros::component(pub)]
+impl SimpleComponent for App {
+    type Init = ();
+    type Input = ();
+    type Output = ();
+
+    view! {
+        gtk::Window {
+            #[local_ref]
+            inner -> gtk::Stack {},
+        }
+    }
+
+    fn init(
+        _init: Self::Init,
+        root: Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = Self(Inner::builder().launch(()).detach());
+        let inner = model.0.widget();
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+}
+
+pub struct Inner(bool);
+
+#[relm4_macros::component(pub)]
+impl SimpleComponent for Inner {
+    type Init = ();
+    type Input = ();
+    type Output = ();
+
+    view! {
+        #[root]
+        stack = if model.0 {
+            gtk::Box {
+                append: &label,
+            }
+        } else {
+            gtk::Label {
+                set_label: "False",
+            }
+        } -> {
+            set_transition_type: gtk::StackTransitionType::Crossfade,
+        },
+
+        label = gtk::Label {
+            set_label: "True",
+        }
+    }
+
+    fn init(
+        _init: Self::Init,
+        root: Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let model = Self(true);
+        let widgets = view_output!();
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, _msg: Self::Input, _sender: ComponentSender<Self>) {
+        self.0 = !self.0;
+    }
+}


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Allows [conditional widgets](https://relm4.org/book/stable/component_macro/reference.html#conditional-widgets) to be used as root widgets. Fixes #690, fixes #592.

I'm happy with the syntax and it seems to be functioning well, but I'd appreciate if someone with experience in how the macros work took a closer look at things to make sure I've got it right. I've tested it with both `if` and `match`, names (`name = if ...`), the `#[root]` annotation, and the conditional property syntax from #915.

#### Example
```rust
view! {
    if model.state {
        gtk::Label {
            #[watch]
            set_label: &format!("Toggled {} times", model.counter),
        }
    } else {
        gtk::Label {
            set_label: "False",
        }
    }
}
```

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
