### PR TITLE
Fix deprecated transition attribute

### DIFF
--- a/relm4-macros/src/widgets/codegen/init.rs
+++ b/relm4-macros/src/widgets/codegen/init.rs
@@ -94,7 +94,7 @@ impl ConditionalWidget {
             stream.extend(quote_spanned! {
                 // emit deprecation warning
                 transition.span() =>
-                    const _: () = ::relm4::transition();
+                    const _: () = ::relm4::macro_helper::transition();
                     #name.set_transition_type(#gtk_import::StackTransitionType:: #transition);
             });
         }


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary

Fixes a bug introduced by my previous pull request #916. :upside_down_face: 

Commit ad8d1727 creates a deprecated dummy function at `relm4::transition` and emits a call to it in macro codegen to raise a deprecation warning.

Commit 3fd4588b moves the dummy function to `relm4::macro_helper::transition`, but does not update the codegen. This causes any code using the `#[transition]` attribute to fail to compile with an error mentioning the missing function.

This pull request fixes that oversight.

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [ ] updated CHANGES.md (given that this is fixing a bug that hasn't been released yet, I didn't mention it in the changelog)
