### PR TITLE
remove codlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ fn main() {
 - [Words!](https://codeberg.org/petsoi/words) - [on Flathub](https://flathub.org/apps/page.codeberg.petsoi.words) - A word game similar to Wordle
 - [LACT](https://github.com/ilya-zlobintsev/lact) - A GPU configuration and info utility
 - [xdg-mimer](https://github.com/ketetefid/xdg-mimer) - A GUI tool for managing MIME associations using XDG standards
-- [CoDLinux](https://gitlab.com/kazam0180/codlinux) - A [CoD](https://en.wikipedia.org/wiki/Call_of_Duty) & [CoD:UO](https://en.wikipedia.org/wiki/Call_of_Duty:_United_Offensive) client helper for GNU/Linux
 - [waypomo](https://tangled.sh/@wrl.sh/waypomo) - endless pomodoro timer for wlroots compositors (uses gtk4-layer-shell)
 - [Vinyl](https://codeberg.org/M23Snezhok/Vinyl) - A simple adwaita audio player  
 - [ratic](https://gitlab.gnome.org/ratcornu/ratic) - A fully-featured music player.


### PR DESCRIPTION
CoDLinux no longer uses Relm4