### PR TITLE
feat: add bindings for various Entry widgets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 + macros: Allow setting conditional widget `gtk::Stack` properties
 + core: Implement factory view for `gtk::Fixed`
 + macros: Conditional root widgets
++ binding: Added more String bindings for various Entry widgets
 
 ### Changed
 

--- a/relm4/src/binding/widgets.rs
+++ b/relm4/src/binding/widgets.rs
@@ -64,6 +64,11 @@ impl_connect_binding!(gtk::StackPage, String, "name", stack_page, {
     let stack = gtk::Stack::default();
     stack.add_child(&gtk::Label::default())
 });
+impl_connect_binding!(gtk::Entry, String, "text", entry);
+impl_connect_binding!(gtk::PasswordEntry, String, "text", password_entry);
+impl_connect_binding!(gtk::SearchEntry, String, "text", search_entry);
+impl_connect_binding!(gtk::EditableLabel, String, "text", editable_label);
+
 #[cfg(feature = "libadwaita")]
 impl_connect_binding!(adw::SplitButton, String, "label", split_button);
 #[cfg(feature = "libadwaita")]
@@ -74,6 +79,10 @@ impl_connect_binding!(adw::PreferencesRow, String, "title", preferences_row);
 impl_connect_binding!(adw::ActionRow, String, "title", action_row);
 #[cfg(all(feature = "libadwaita", feature = "gnome_47"))]
 impl_connect_binding!(adw::ButtonRow, String, "title", button_row);
+#[cfg(all(feature = "libadwaita", feature = "gnome_47"))]
+impl_connect_binding!(adw::EntryRow, String, "text", entry_row);
+#[cfg(all(feature = "libadwaita", feature = "gnome_47"))]
+impl_connect_binding!(adw::PasswordEntryRow, String, "text", entry_row);
 #[cfg(feature = "libadwaita")]
 impl_connect_binding!(adw::WindowTitle, String, "title", window_title);
 #[cfg(all(feature = "libadwaita", feature = "gnome_44"))]


### PR DESCRIPTION
<!-- 
  Thank you for contributing to Relm4! 🎉

  If you need help or want to discuss this PR, please join our development chat: https://matrix.to/#/#relm4-dev:matrix.org
-->

#### Summary
Adds String bindings (using the `text` property from the `GtkEditable` API) for the following widgets: 
- gtk::Entry
- gtk::PasswordEntry
- gtk::SearchEntry
- gtk::EditableLabel
- adw::EntryRow
- adw::PasswordEntryRow

#### Checklist

- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test
- [x] updated CHANGES.md
